### PR TITLE
add probes for RF and emission WLG

### DIFF
--- a/SKIRT/core/DustEmissionWavelengthGridProbe.cpp
+++ b/SKIRT/core/DustEmissionWavelengthGridProbe.cpp
@@ -1,0 +1,23 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "DustEmissionWavelengthGridProbe.hpp"
+#include "Configuration.hpp"
+#include "DisjointWavelengthGrid.hpp"
+#include "InstrumentWavelengthGridProbe.hpp"
+#include "MediumSystem.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void DustEmissionWavelengthGridProbe::probeSetup()
+{
+    if (find<Configuration>()->hasDustEmission() && find<MediumSystem>()->hasDust())
+    {
+        InstrumentWavelengthGridProbe::writeWavelengthGrid(this, find<Configuration>()->dustEmissionWLG(),
+                                                itemName() + "_wavelengths", "emission spectrum wavelengths");
+    }
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/DustEmissionWavelengthGridProbe.hpp
+++ b/SKIRT/core/DustEmissionWavelengthGridProbe.hpp
@@ -1,0 +1,33 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef DUSTEMISSIONWAVELENGTHGRIDPROBE_HPP
+#define DUSTEMISSIONWAVELENGTHGRIDPROBE_HPP
+
+#include "Probe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** DustEmissionWavelengthGridProbe outputs a column text file (named
+    <tt>prefix_probe_wavelengths.dat</tt>) with details on the dust emission wavelength grid, i.e.
+    the wavelength grid returned by the Configuration::dustEmissionWLG() function. For each
+    wavelength bin, the file lists the characteristic wavelength, the wavelength bin width, and the
+    left and right borders of the bin. */
+class DustEmissionWavelengthGridProbe : public Probe
+{
+    ITEM_CONCRETE(DustEmissionWavelengthGridProbe, Probe, "the dust emission wavelength grid")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(DustEmissionWavelengthGridProbe, "Level2&Dust&DustEmission")
+    ITEM_END()
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function performs probing after setup. */
+    void probeSetup() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/DustEmissivityProbe.cpp
+++ b/SKIRT/core/DustEmissivityProbe.cpp
@@ -5,14 +5,14 @@
 
 #include "DustEmissivityProbe.hpp"
 #include "ArrayTable.hpp"
-#include "DisjointWavelengthGrid.hpp"
 #include "Configuration.hpp"
+#include "DisjointWavelengthGrid.hpp"
+#include "InstrumentWavelengthGridProbe.hpp"
 #include "MediumSystem.hpp"
 #include "PlanckFunction.hpp"
 #include "StringUtils.hpp"
 #include "TextOutFile.hpp"
 #include "Units.hpp"
-#include "InstrumentWavelengthGridProbe.hpp"
 
 ////////////////////////////////////////////////////////////////////
 

--- a/SKIRT/core/DustEmissivityProbe.hpp
+++ b/SKIRT/core/DustEmissivityProbe.hpp
@@ -16,7 +16,7 @@
     assuming the dust would be embedded in a range of predefined input fields.
 
     The output emissivity spectra are discretized on the emission spectrum wavelength grid as
-    returned by the Configuration::emissionSpectrumWLG() function. The input radiation fields used
+    returned by the Configuration::dustEmissionWLG() function. The input radiation fields used
     for the calculations are discretized on the radiation field wavelength grid as returned by the
     Configuration::radiationFieldWLG() function. As a result, this probe requires the configuration
     of the simulation to include dust emission, so that a dust emissivity calculator, a radiation

--- a/SKIRT/core/RadiationFieldWavelengthGridProbe.cpp
+++ b/SKIRT/core/RadiationFieldWavelengthGridProbe.cpp
@@ -1,0 +1,27 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "RadiationFieldWavelengthGridProbe.hpp"
+#include "Configuration.hpp"
+#include "DisjointWavelengthGrid.hpp"
+#include "MediumSystem.hpp"
+#include "SpatialGrid.hpp"
+#include "StringUtils.hpp"
+#include "TextOutFile.hpp"
+#include "Units.hpp"
+#include "InstrumentWavelengthGridProbe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void RadiationFieldWavelengthGridProbe::probeSetup()
+{
+    if (find<Configuration>()->hasRadiationField())
+    {
+        InstrumentWavelengthGridProbe::writeWavelengthGrid(this, find<Configuration>()->radiationFieldWLG(),
+                                                 itemName() + "_wavelengths", "wavelengths for mean intensity");
+    }
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/RadiationFieldWavelengthGridProbe.hpp
+++ b/SKIRT/core/RadiationFieldWavelengthGridProbe.hpp
@@ -1,0 +1,33 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef RADIATIONFIELDWAVELENGTHGRIDPROBE_HPP
+#define RADIATIONFIELDWAVELENGTHGRIDPROBE_HPP
+
+#include "Probe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** RadiationFieldWavelengthGridProbe outputs a column text file (named
+    <tt>prefix_probe_wavelengths.dat</tt>) with details on the radiation field wavelength grid,
+    i.e. the wavelength grid returned by the Configuration::radiationFieldWLG() function. For each
+    wavelength bin, the file lists the characteristic wavelength, the wavelength bin width, and the
+    left and right borders of the bin. */
+class RadiationFieldWavelengthGridProbe : public Probe
+{
+    ITEM_CONCRETE(RadiationFieldWavelengthGridProbe, Probe, "the radiation field wavelength grid")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(RadiationFieldWavelengthGridProbe, "Level2&Medium&SpatialGrid&RadiationField")
+    ITEM_END()
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function performs probing after setup. */
+    void probeSetup() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -52,6 +52,7 @@
 #include "DustEmGrainComposition.hpp"
 #include "DustEmissionOptions.hpp"
 #include "DustEmissivityProbe.hpp"
+#include "DustEmissionWavelengthGridProbe.hpp"
 #include "DustGrainPopulationsProbe.hpp"
 #include "DustGrainSizeDistributionProbe.hpp"
 #include "DustSelfAbsorptionOptions.hpp"
@@ -145,6 +146,7 @@
 #include "ProbeSystem.hpp"
 #include "PseudoSersicGeometry.hpp"
 #include "QuasarSED.hpp"
+#include "RadiationFieldWavelengthGridProbe.hpp"
 #include "RadiationFieldPerCellProbe.hpp"
 #include "Random.hpp"
 #include "ReadFitsGeometry.hpp"
@@ -526,12 +528,14 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
 
     ItemRegistry::add<DefaultRadiationFieldCutsProbe>();
     ItemRegistry::add<RadiationFieldPerCellProbe>();
+    ItemRegistry::add<RadiationFieldWavelengthGridProbe>();
     ItemRegistry::add<DefaultDustTemperatureCutsProbe>();
     ItemRegistry::add<DustTemperaturePerCellProbe>();
     ItemRegistry::add<LinearDustTemperatureCutProbe>();
     ItemRegistry::add<MeridionalDustTemperatureCutProbe>();
     ItemRegistry::add<DustAbsorptionPerCellProbe>();
     ItemRegistry::add<DustEmissivityProbe>();
+    ItemRegistry::add<DustEmissionWavelengthGridProbe>();
 
     // Monte Carlo simulations
     ItemRegistry::add<MonteCarloSimulation>();


### PR DESCRIPTION
**Description**
Add probes that output the radiation field wavelength grid or the dust emission wavelength grid.

**Motivation**
The detailed of these wavelength grids are often useful when studying convergence (i.e. minimizing the number of wavelength bins) for a given input model. Even if these wavelength grids can be obtained as part of other probes, the extra info is in this case not needed (and it takes time to generate).
