### PR TITLE
Add probes for planar cuts at arbitrary positions in the model

### DIFF
--- a/SKIRT/core/AbstractPlanarCutsProbe.hpp
+++ b/SKIRT/core/AbstractPlanarCutsProbe.hpp
@@ -1,0 +1,52 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef ABSTRACTPLANARCUTSPROBE_HPP
+#define ABSTRACTPLANARCUTSPROBE_HPP
+
+#include "Probe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** AbstractWavelengthGridProbe is a base class for probes that need configuration options for
+    planar cuts parallel to the coordinate planes. The provided options include the position of the
+    planar cuts and the number of pixels in each spatial direction. */
+class AbstractPlanarCutsProbe : public Probe
+{
+    ITEM_ABSTRACT(AbstractPlanarCutsProbe, Probe, "a probe using configurable planar cuts")
+
+    PROPERTY_DOUBLE(positionX, "the x position of the cut parallel to the yz plane")
+        ATTRIBUTE_QUANTITY(positionX, "length")
+        ATTRIBUTE_DEFAULT_VALUE(positionX, "0")
+
+    PROPERTY_DOUBLE(positionY, "the y position of the cut parallel to the xz plane")
+        ATTRIBUTE_QUANTITY(positionY, "length")
+        ATTRIBUTE_DEFAULT_VALUE(positionY, "0")
+
+    PROPERTY_DOUBLE(positionZ, "the z position of the cut parallel to the xy plane")
+        ATTRIBUTE_QUANTITY(positionZ, "length")
+        ATTRIBUTE_DEFAULT_VALUE(positionZ, "0")
+
+    PROPERTY_INT(numPixelsX, "the number of pixels in the x direction")
+        ATTRIBUTE_MIN_VALUE(numPixelsX, "1")
+        ATTRIBUTE_MAX_VALUE(numPixelsX, "10000")
+        ATTRIBUTE_DEFAULT_VALUE(numPixelsX, "1024")
+
+    PROPERTY_INT(numPixelsY, "the number of pixels in the y direction")
+        ATTRIBUTE_MIN_VALUE(numPixelsY, "1")
+        ATTRIBUTE_MAX_VALUE(numPixelsY, "10000")
+        ATTRIBUTE_DEFAULT_VALUE(numPixelsY, "1024")
+
+    PROPERTY_INT(numPixelsZ, "the number of pixels in the z direction")
+        ATTRIBUTE_MIN_VALUE(numPixelsZ, "1")
+        ATTRIBUTE_MAX_VALUE(numPixelsZ, "10000")
+        ATTRIBUTE_DEFAULT_VALUE(numPixelsZ, "1024")
+
+    ITEM_END()
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/DefaultDustTemperatureCutsProbe.cpp
+++ b/SKIRT/core/DefaultDustTemperatureCutsProbe.cpp
@@ -4,104 +4,9 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "DefaultDustTemperatureCutsProbe.hpp"
-#include "Array.hpp"
 #include "Configuration.hpp"
-#include "DisjointWavelengthGrid.hpp"
-#include "FITSInOut.hpp"
 #include "MediumSystem.hpp"
-#include "Parallel.hpp"
-#include "ParallelFactory.hpp"
-#include "SpatialGrid.hpp"
-#include "TextOutFile.hpp"
-#include "Units.hpp"
-
-////////////////////////////////////////////////////////////////////
-
-// Private class to output a FITS file with the mean dust temperatures
-// in one of the coordinate planes (xy, xz, or yz).
-namespace
-{
-    // The image size in each direction, in pixels
-    const int Np = 1024;
-
-    class WriteTemperatureCut
-    {
-    private:
-        // cached values initialized in constructor
-        Probe* item;
-        MediumSystem* ms;
-        WavelengthGrid* wavelengthGrid;
-        Units* units;
-        double xbase, ybase, zbase, xpsize, ypsize, zpsize, xcenter, ycenter, zcenter;
-
-        // data members initialized in setup()
-        bool xd, yd, zd;  // direction of coordinate plane (110, 101, 011)
-        string plane;    // name of the coordinate plane (xy, xz, yz)
-
-        // results vector, properly resized in constructor
-        Array Tv;
-
-    public:
-        // constructor
-        WriteTemperatureCut(Probe* item_, MediumSystem* ms_)
-            : item(item_), ms(ms_),
-              wavelengthGrid(ms_->find<Configuration>()->radiationFieldWLG()), units(ms_->find<Units>())
-        {
-            double xmin, ymin, zmin, xmax, ymax, zmax;
-            ms->grid()->boundingBox().extent(xmin,ymin,zmin,xmax,ymax,zmax);
-            xpsize = (xmax-xmin)/Np;
-            ypsize = (ymax-ymin)/Np;
-            zpsize = (zmax-zmin)/Np;
-            xbase = xmin + 0.5*xpsize;
-            ybase = ymin + 0.5*ypsize;
-            zbase = zmin + 0.5*zpsize;
-            xcenter = (xmin+xmax)/2.0;
-            ycenter = (ymin+ymax)/2.0;
-            zcenter = (zmin+zmax)/2.0;
-
-            Tv.resize(Np*Np);
-        }
-
-        // setup for calculating a specific coordinate plane
-        void setup(bool xdir, bool ydir, bool zdir)
-        {
-            xd = xdir;
-            yd = ydir;
-            zd = zdir;
-            plane = "";
-            if (xd) plane += "x";
-            if (yd) plane += "y";
-            if (zd) plane += "z";
-        }
-
-        // the parallelized loop body; calculates the results for a set of lines in the images
-        void body(size_t firstIndex, size_t numIndices)
-        {
-            for (size_t j = firstIndex; j != firstIndex+numIndices; ++j)
-            {
-                double z = zd ? (zbase + j*zpsize) : 0.;
-                for (int i=0; i<Np; i++)
-                {
-                    double x = xd ? (xbase + i*xpsize) : 0.;
-                    double y = yd ? (ybase + (zd ? i : j)*ypsize) : 0.;
-                    int l = i + Np*j;
-                    Tv[l] = units->otemperature(ms->indicativeDustTemperature(Position(x,y,z)));
-                }
-            }
-        }
-
-        // Write the results to a FITS file with an appropriate name
-        void write()
-        {
-            string description = "dust temperatures in the " + plane + " plane";
-            string filename = item->itemName() + "_dust_T_" + plane;
-            FITSInOut::write(item, description, filename, Tv, units->utemperature(), Np, Np,
-                             units->olength(xd?xpsize:ypsize), units->olength(zd?zpsize:ypsize),
-                             units->olength(xd?xcenter:ycenter), units->olength(zd?zcenter:ycenter),
-                             units->ulength());
-        }
-    };
-}
+#include "PlanarDustTemperatureCutsProbe.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
@@ -109,39 +14,16 @@ void DefaultDustTemperatureCutsProbe::probeRun()
 {
     if (find<Configuration>()->hasPanRadiationField() && find<MediumSystem>()->hasDust())
     {
-        // locate the medium system
-        auto ms = find<MediumSystem>();
+        // the size in pixels (in each spatial direction) for the default cuts
+        const int Np = 1024;
 
-        // configure parallelization; perform only at the root processs
-        Parallel* parallel = find<ParallelFactory>()->parallelRootOnly();
+        // the dimension of the medium system
+        int dimension = find<MediumSystem>()->dimension();
 
-        // construct a private class instance to do the work
-        WriteTemperatureCut wtc(this, ms);
-
-        // for the xy plane (always)
-        {
-            wtc.setup(1,1,0);
-            parallel->call(Np, [&wtc](size_t i ,size_t n) { wtc.body(i, n); });
-            wtc.write();
-        }
-
-        // for the xz plane (only if dimension is at least 2)
-        int dimension = ms->dimension();
-        if (dimension >= 2)
-        {
-            wtc.setup(1,0,1);
-            parallel->call(Np, [&wtc](size_t i ,size_t n) { wtc.body(i, n); });
-            wtc.write();
-        }
-
-        // for the yz plane (only if dimension is 3)
-        if (dimension == 3)
-        {
-            wtc.setup(0,1,1);
-            parallel->call(Np, [&wtc](size_t i ,size_t n) { wtc.body(i, n); });
-            wtc.write();
-        }
-
+        // output cuts depending on the dimension of the medium system
+        PlanarDustTemperatureCutsProbe::writeDustTemperatureCut(this, 1,1,0, 0.,0.,0., Np,Np,Np);
+        if (dimension >= 2) PlanarDustTemperatureCutsProbe::writeDustTemperatureCut(this, 1,0,1, 0.,0.,0., Np,Np,Np);
+        if (dimension == 3) PlanarDustTemperatureCutsProbe::writeDustTemperatureCut(this, 0,1,1, 0.,0.,0., Np,Np,Np);
     }
 }
 

--- a/SKIRT/core/DefaultDustTemperatureCutsProbe.hpp
+++ b/SKIRT/core/DefaultDustTemperatureCutsProbe.hpp
@@ -16,7 +16,7 @@
     spherical symmetry only the intersection with the xy plane is written, for axial symmetry the
     intersections with the xy and xz planes are written, and for general geometries all three
     intersections are written. Each of the output files contains a map with 1024 x 1024 pixels, and
-    covers a field of view equal to the total extension of the spatial grid in the simulation.
+    covers a field of view equal to the total extent of the spatial grid in the simulation.
 
     The indicative dust temperature assigned to each output pixel is obtained as follows. First the
     probe determines the cell in the simulation's spatial grid "containing" the pixel according to

--- a/SKIRT/core/DefaultMediaDensityCutsProbe.cpp
+++ b/SKIRT/core/DefaultMediaDensityCutsProbe.cpp
@@ -12,14 +12,15 @@
 
 void DefaultMediaDensityCutsProbe::probeSetup()
 {
-    // The size in pixels for default cuts (in each spatial direction)
-    const int Np = 1024;
-
     if (find<Configuration>()->hasMedium())
     {
+        // the size in pixels (in each spatial direction) for the default cuts
+        const int Np = 1024;
+
+        // the dimension of the medium system
         int dimension = find<MediumSystem>()->dimension();
 
-        // output planes depending on the dimension of the medium system
+        // output cuts depending on the dimension of the medium system
         PlanarMediaDensityCutsProbe::writeMediaDensityCuts(this, 1,1,0, 0.,0.,0., Np,Np,Np);                     // xy
         if (dimension >= 2) PlanarMediaDensityCutsProbe::writeMediaDensityCuts(this, 1,0,1, 0.,0.,0., Np,Np,Np); // xz
         if (dimension == 3) PlanarMediaDensityCutsProbe::writeMediaDensityCuts(this, 0,1,1, 0.,0.,0., Np,Np,Np); // yz

--- a/SKIRT/core/DefaultMediaDensityCutsProbe.cpp
+++ b/SKIRT/core/DefaultMediaDensityCutsProbe.cpp
@@ -16,172 +16,127 @@
 
 ////////////////////////////////////////////////////////////////////
 
-// Private class to output FITS files with the theoretical and grid density
-// for each material type in one of the coordinate planes (xy, xz, or yz).
-namespace
+void DefaultMediaDensityCutsProbe::writeMediaDensityCuts(bool xd, bool yd, bool zd, int Nx, int Ny, int Nz)
 {
-    // The image size in each direction, in pixels
-    const int Np = 1024;
+    // locate relevant simulation items
+    auto units = find<Units>();
+    auto ms = find<MediumSystem>();
+    auto grid = ms->grid();
 
-    class WriteDensity
+    // determine spatial configuration (regardless of cut direction)
+    Box box = grid->boundingBox();
+    double xpsize = box.xwidth()/Nx;
+    double ypsize = box.ywidth()/Ny;
+    double zpsize = box.zwidth()/Nz;
+    double xbase = box.xmin() + 0.5*xpsize;
+    double ybase = box.ymin() + 0.5*ypsize;
+    double zbase = box.zmin() + 0.5*zpsize;
+    double xcenter = box.center().x();
+    double ycenter = box.center().y();
+    double zcenter = box.center().z();
+
+    // determine index configuration: i->colums, j->rows
+    int Ni = xd ? Nx : Ny;
+    int Nj = zd ? Nz : Ny;
+
+    // allocate result arrays with the appropriate size and initialize contents to zero
+    Array dust_tv, dust_gv;
+    Array elec_tv, elec_gv;
+    Array gas_tv, gas_gv;
+    int size = (xd ? Nx : 1) * (yd ? Ny : 1) * (zd ? Nz : 1);
+    if (ms->hasDust()) { dust_tv.resize(size), dust_gv.resize(size); }
+    if (ms->hasElectrons()) { elec_tv.resize(size), elec_gv.resize(size); }
+    if (ms->hasGas()) { gas_tv.resize(size), gas_gv.resize(size); }
+
+    // calculate the results in parallel; perform only at the root processs
+    auto parallel = find<ParallelFactory>()->parallelRootOnly();
+    parallel->call(Nj, [&dust_tv,&dust_gv,&elec_tv,&elec_gv,&gas_tv,&gas_gv,
+                            ms,grid,xpsize,ypsize,zpsize,xbase,ybase,zbase,
+                            xd,yd,zd,Ni](size_t firstIndex ,size_t numIndices)
     {
-    private:
-        // data members initialized in constructor
-        Probe* item;
-        MediumSystem* ms;
-        SpatialGrid* grid;
-        Units* units;
-        double xbase, ybase, zbase, xpsize, ypsize, zpsize, xcenter, ycenter, zcenter;
-
-        // data members initialized in setup()
-        bool xd, yd, zd; // direction of coordinate plane (110, 101, 011)
-        string plane;    // name of the coordinate plane (xy, xz, yz)
-
-        // results -- resized and initialized to zero in setup()
-        Array dust_tv, dust_gv;
-        Array elec_tv, elec_gv;
-        Array gas_tv, gas_gv;
-
-    public:
-        // constructor
-        WriteDensity(Probe* item_, MediumSystem* ms_)
-            : item(item_), ms(ms_), grid(ms_->grid()), units(ms_->find<Units>())
+        int numMedia = ms->numMedia();
+        for (size_t j = firstIndex; j != firstIndex+numIndices; ++j)
         {
-            double xmin, ymin, zmin, xmax, ymax, zmax;
-            grid->boundingBox().extent(xmin,ymin,zmin,xmax,ymax,zmax);
-            xpsize = (xmax-xmin)/Np;
-            ypsize = (ymax-ymin)/Np;
-            zpsize = (zmax-zmin)/Np;
-            xbase = xmin + 0.5*xpsize;
-            ybase = ymin + 0.5*ypsize;
-            zbase = zmin + 0.5*zpsize;
-            xcenter = (xmin+xmax)/2.0;
-            ycenter = (ymin+ymax)/2.0;
-            zcenter = (zmin+zmax)/2.0;
-        }
-
-        // setup for calculating a specific coordinate plane
-        void setup(bool xdir, bool ydir, bool zdir)
-        {
-            xd = xdir;
-            yd = ydir;
-            zd = zdir;
-            plane = "";
-            if (xd) plane += "x";
-            if (yd) plane += "y";
-            if (zd) plane += "z";
-
-            if (ms->hasDust()) { dust_tv.resize(Np*Np), dust_gv.resize(Np*Np); }
-            if (ms->hasElectrons()) { elec_tv.resize(Np*Np), elec_gv.resize(Np*Np); }
-            if (ms->hasGas()) { gas_tv.resize(Np*Np), gas_gv.resize(Np*Np); }
-        }
-
-        // the parallized loop body; calculates the results for a series of lines in the images
-        void body(size_t firstIndex, size_t numIndices)
-        {
-            int numMedia = ms->numMedia();
-            for (size_t j = firstIndex; j != firstIndex+numIndices; ++j)
+            double z = zd ? (zbase + j*zpsize) : 0.;
+            for (int i=0; i<Ni; i++)
             {
-                double z = zd ? (zbase + j*zpsize) : 0.;
-                for (int i=0; i<Np; i++)
-                {
-                    int l = i + Np*j;
-                    double x = xd ? (xbase + i*xpsize) : 0.;
-                    double y = yd ? (ybase + (zd ? i : j)*ypsize) : 0.;
-                    Position bfr(x,y,z);
-                    int m = grid->cellIndex(bfr);
+                int l = i + Ni*j;
+                double x = xd ? (xbase + i*xpsize) : 0.;
+                double y = yd ? (ybase + (zd ? i : j)*ypsize) : 0.;
+                Position bfr(x,y,z);
+                int m = grid->cellIndex(bfr);
 
-                    for (int h=0; h!=numMedia; ++h)
+                for (int h=0; h!=numMedia; ++h)
+                {
+                    if (ms->isDust(h))
                     {
-                        if (ms->isDust(h))
-                        {
-                            dust_tv[l] += ms->media()[h]->massDensity(bfr);
-                            if (m>=0) dust_gv[l] += ms->massDensity(m,h);
-                        }
-                        else if (ms->isElectrons(h))
-                        {
-                            elec_tv[l] += ms->media()[h]->numberDensity(bfr);
-                            if (m>=0) elec_gv[l] += ms->numberDensity(m,h);
-                        }
-                        else if (ms->isGas(h))
-                        {
-                            gas_tv[l] += ms->media()[h]->numberDensity(bfr);
-                            if (m>=0) gas_gv[l] += ms->numberDensity(m,h);
-                        }
+                        dust_tv[l] += ms->media()[h]->massDensity(bfr);
+                        if (m>=0) dust_gv[l] += ms->massDensity(m,h);
+                    }
+                    else if (ms->isElectrons(h))
+                    {
+                        elec_tv[l] += ms->media()[h]->numberDensity(bfr);
+                        if (m>=0) elec_gv[l] += ms->numberDensity(m,h);
+                    }
+                    else if (ms->isGas(h))
+                    {
+                        gas_tv[l] += ms->media()[h]->numberDensity(bfr);
+                        if (m>=0) gas_gv[l] += ms->numberDensity(m,h);
                     }
                 }
             }
         }
+    });
 
-        // write the results to two FITS files with appropriate names
-        void write()
+    // define a function to write a result array to a FITS file
+    auto write = [this,units,xpsize,ypsize,zpsize,xcenter,ycenter,zcenter,
+                        xd,yd,zd,Ni,Nj](Array& v, string label, string prefix, bool massDensity)
+    {
+        if (v.size())
         {
-            write(dust_tv, "dust theoretical density", "dust_t", true);
-            write(dust_gv, "dust gridded density", "dust_g", true);
-            write(elec_tv, "electron theoretical density", "elec_t", false);
-            write(elec_gv, "electron gridded density", "elec_g", false);
-            write(gas_tv, "gas theoretical density", "gas_t", false);
-            write(gas_gv, "gas gridded density", "gas_g", false);
-        }
+            // get the name of the coordinate plane (xy, xz, or yz)
+            string plane;
+            if (xd) plane += "x";
+            if (yd) plane += "y";
+            if (zd) plane += "z";
 
-    private:
-        void write(Array& v, string label, string prefix, bool massDensity)
-        {
-            if (v.size())
-            {
-                // convert to output units
-                v *= (massDensity ? units->omassvolumedensity(1.) : units->onumbervolumedensity(1.));
-                string densityUnits = massDensity ? units->umassvolumedensity() : units->unumbervolumedensity();
+            // convert to output units
+            v *= (massDensity ? units->omassvolumedensity(1.) : units->onumbervolumedensity(1.));
+            string densityUnits = massDensity ? units->umassvolumedensity() : units->unumbervolumedensity();
 
-                // write file
-                string filename = item->itemName() + "_" + prefix + "_" + plane;
-                FITSInOut::write(item, label + " in the " + plane + " plane", filename, v, densityUnits, Np, Np,
-                                 units->olength(xd?xpsize:ypsize), units->olength(zd?zpsize:ypsize),
-                                 units->olength(xd?xcenter:ycenter), units->olength(zd?zcenter:ycenter),
-                                 units->ulength());
-            }
+            // write file
+            string filename = itemName() + "_" + prefix + "_" + plane;
+            FITSInOut::write(this, label + " in the " + plane + " plane", filename, v, densityUnits, Ni, Nj,
+                             units->olength(xd?xpsize:ypsize), units->olength(zd?zpsize:ypsize),
+                             units->olength(xd?xcenter:ycenter), units->olength(zd?zcenter:ycenter),
+                             units->ulength());
         }
     };
+
+    // write the results for each material type to two FITS files with appropriate names
+    write(dust_tv, "dust theoretical density", "dust_t", true);
+    write(dust_gv, "dust gridded density", "dust_g", true);
+    write(elec_tv, "electron theoretical density", "elec_t", false);
+    write(elec_gv, "electron gridded density", "elec_g", false);
+    write(gas_tv, "gas theoretical density", "gas_t", false);
+    write(gas_gv, "gas gridded density", "gas_g", false);
 }
 
 ////////////////////////////////////////////////////////////////////
 
 void DefaultMediaDensityCutsProbe::probeSetup()
 {
+    // The size in pixels for default cuts (in each spatial direction)
+    const int Np = 1024;
+
     if (find<Configuration>()->hasMedium())
     {
-        // locate the medium system
-        auto ms = find<MediumSystem>();
+        int dimension = find<MediumSystem>()->dimension();
 
-        // configure parallelization; perform only at the root processs
-        Parallel* parallel = find<ParallelFactory>()->parallelRootOnly();
-
-        // construct a private class instance to do the work
-        WriteDensity wd(this, ms);
-
-        // for the xy plane (always)
-        {
-            wd.setup(1,1,0);
-            parallel->call(Np, [&wd](size_t i ,size_t n) { wd.body(i, n); });
-            wd.write();
-        }
-
-        // for the xz plane (only if dimension is at least 2)
-        int dimension = ms->dimension();
-        if (dimension >= 2)
-        {
-            wd.setup(1,0,1);
-            parallel->call(Np, [&wd](size_t i ,size_t n) { wd.body(i, n); });
-            wd.write();
-        }
-
-        // for the yz plane (only if dimension is 3)
-        if (dimension == 3)
-        {
-            wd.setup(0,1,1);
-            parallel->call(Np, [&wd](size_t i ,size_t n) { wd.body(i, n); });
-            wd.write();
-        }
+        // output planes depending on the dimension of the medium system
+        writeMediaDensityCuts(1,1,0, Np,Np,Np);                       // xy plane
+        if (dimension >= 2) writeMediaDensityCuts(1,0,1, Np,Np,Np);   // xz plane
+        if (dimension == 3) writeMediaDensityCuts(0,1,1, Np,Np,Np);   // yz plane
     }
 }
 

--- a/SKIRT/core/DefaultMediaDensityCutsProbe.cpp
+++ b/SKIRT/core/DefaultMediaDensityCutsProbe.cpp
@@ -4,123 +4,9 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "DefaultMediaDensityCutsProbe.hpp"
-#include "Array.hpp"
 #include "Configuration.hpp"
-#include "FITSInOut.hpp"
-#include "Medium.hpp"
 #include "MediumSystem.hpp"
-#include "Parallel.hpp"
-#include "ParallelFactory.hpp"
-#include "SpatialGrid.hpp"
-#include "Units.hpp"
-
-////////////////////////////////////////////////////////////////////
-
-void DefaultMediaDensityCutsProbe::writeMediaDensityCuts(bool xd, bool yd, bool zd, int Nx, int Ny, int Nz)
-{
-    // locate relevant simulation items
-    auto units = find<Units>();
-    auto ms = find<MediumSystem>();
-    auto grid = ms->grid();
-
-    // determine spatial configuration (regardless of cut direction)
-    Box box = grid->boundingBox();
-    double xpsize = box.xwidth()/Nx;
-    double ypsize = box.ywidth()/Ny;
-    double zpsize = box.zwidth()/Nz;
-    double xbase = box.xmin() + 0.5*xpsize;
-    double ybase = box.ymin() + 0.5*ypsize;
-    double zbase = box.zmin() + 0.5*zpsize;
-    double xcenter = box.center().x();
-    double ycenter = box.center().y();
-    double zcenter = box.center().z();
-
-    // determine index configuration: i->colums, j->rows
-    int Ni = xd ? Nx : Ny;
-    int Nj = zd ? Nz : Ny;
-
-    // allocate result arrays with the appropriate size and initialize contents to zero
-    Array dust_tv, dust_gv;
-    Array elec_tv, elec_gv;
-    Array gas_tv, gas_gv;
-    int size = (xd ? Nx : 1) * (yd ? Ny : 1) * (zd ? Nz : 1);
-    if (ms->hasDust()) { dust_tv.resize(size), dust_gv.resize(size); }
-    if (ms->hasElectrons()) { elec_tv.resize(size), elec_gv.resize(size); }
-    if (ms->hasGas()) { gas_tv.resize(size), gas_gv.resize(size); }
-
-    // calculate the results in parallel; perform only at the root processs
-    auto parallel = find<ParallelFactory>()->parallelRootOnly();
-    parallel->call(Nj, [&dust_tv,&dust_gv,&elec_tv,&elec_gv,&gas_tv,&gas_gv,
-                            ms,grid,xpsize,ypsize,zpsize,xbase,ybase,zbase,
-                            xd,yd,zd,Ni](size_t firstIndex ,size_t numIndices)
-    {
-        int numMedia = ms->numMedia();
-        for (size_t j = firstIndex; j != firstIndex+numIndices; ++j)
-        {
-            double z = zd ? (zbase + j*zpsize) : 0.;
-            for (int i=0; i<Ni; i++)
-            {
-                int l = i + Ni*j;
-                double x = xd ? (xbase + i*xpsize) : 0.;
-                double y = yd ? (ybase + (zd ? i : j)*ypsize) : 0.;
-                Position bfr(x,y,z);
-                int m = grid->cellIndex(bfr);
-
-                for (int h=0; h!=numMedia; ++h)
-                {
-                    if (ms->isDust(h))
-                    {
-                        dust_tv[l] += ms->media()[h]->massDensity(bfr);
-                        if (m>=0) dust_gv[l] += ms->massDensity(m,h);
-                    }
-                    else if (ms->isElectrons(h))
-                    {
-                        elec_tv[l] += ms->media()[h]->numberDensity(bfr);
-                        if (m>=0) elec_gv[l] += ms->numberDensity(m,h);
-                    }
-                    else if (ms->isGas(h))
-                    {
-                        gas_tv[l] += ms->media()[h]->numberDensity(bfr);
-                        if (m>=0) gas_gv[l] += ms->numberDensity(m,h);
-                    }
-                }
-            }
-        }
-    });
-
-    // define a function to write a result array to a FITS file
-    auto write = [this,units,xpsize,ypsize,zpsize,xcenter,ycenter,zcenter,
-                        xd,yd,zd,Ni,Nj](Array& v, string label, string prefix, bool massDensity)
-    {
-        if (v.size())
-        {
-            // get the name of the coordinate plane (xy, xz, or yz)
-            string plane;
-            if (xd) plane += "x";
-            if (yd) plane += "y";
-            if (zd) plane += "z";
-
-            // convert to output units
-            v *= (massDensity ? units->omassvolumedensity(1.) : units->onumbervolumedensity(1.));
-            string densityUnits = massDensity ? units->umassvolumedensity() : units->unumbervolumedensity();
-
-            // write file
-            string filename = itemName() + "_" + prefix + "_" + plane;
-            FITSInOut::write(this, label + " in the " + plane + " plane", filename, v, densityUnits, Ni, Nj,
-                             units->olength(xd?xpsize:ypsize), units->olength(zd?zpsize:ypsize),
-                             units->olength(xd?xcenter:ycenter), units->olength(zd?zcenter:ycenter),
-                             units->ulength());
-        }
-    };
-
-    // write the results for each material type to two FITS files with appropriate names
-    write(dust_tv, "dust theoretical density", "dust_t", true);
-    write(dust_gv, "dust gridded density", "dust_g", true);
-    write(elec_tv, "electron theoretical density", "elec_t", false);
-    write(elec_gv, "electron gridded density", "elec_g", false);
-    write(gas_tv, "gas theoretical density", "gas_t", false);
-    write(gas_gv, "gas gridded density", "gas_g", false);
-}
+#include "PlanarMediaDensityCutsProbe.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
@@ -134,9 +20,9 @@ void DefaultMediaDensityCutsProbe::probeSetup()
         int dimension = find<MediumSystem>()->dimension();
 
         // output planes depending on the dimension of the medium system
-        writeMediaDensityCuts(1,1,0, Np,Np,Np);                       // xy plane
-        if (dimension >= 2) writeMediaDensityCuts(1,0,1, Np,Np,Np);   // xz plane
-        if (dimension == 3) writeMediaDensityCuts(0,1,1, Np,Np,Np);   // yz plane
+        PlanarMediaDensityCutsProbe::writeMediaDensityCuts(this, 1,1,0, 0.,0.,0., Np,Np,Np);                     // xy
+        if (dimension >= 2) PlanarMediaDensityCutsProbe::writeMediaDensityCuts(this, 1,0,1, 0.,0.,0., Np,Np,Np); // xz
+        if (dimension == 3) PlanarMediaDensityCutsProbe::writeMediaDensityCuts(this, 0,1,1, 0.,0.,0., Np,Np,Np); // yz
     }
 }
 

--- a/SKIRT/core/DefaultMediaDensityCutsProbe.hpp
+++ b/SKIRT/core/DefaultMediaDensityCutsProbe.hpp
@@ -11,9 +11,9 @@
 ////////////////////////////////////////////////////////////////////
 
 /** DefaultMediaDensityCutsProbe outputs FITS files with cuts through the true input media density
-    and the grid-discretized media density along the coordinate planes. Each of these maps contains
-    1024 x 1024 pixels, and covers as a field of view the total extension of the spatial grid in
-    the simulation.
+    and the grid-discretized media density along the coordinate planes. The field of view of each
+    cut covers the extent of the spatial grid in the simulation in the relevant directions. Each
+    cut has 1024 x 1024 pixels.
 
     The number of data files written depends on the geometry and material contents of the media
     system. For spherical symmetry only the intersection with the xy plane is written, for axial
@@ -42,13 +42,6 @@ class DefaultMediaDensityCutsProbe : public Probe
 public:
     /** This function performs probing after setup. */
     void probeSetup() override;
-
-protected:
-    /** This function outputs FITS files with the theoretical and grid density for each material
-        type in the coordinate planes (xy, xz, or yz) indicated by the boolean "direction"
-        arguments \em xd, \em yd, and \em zd, exactly two of which must be true. The arguments \em
-        Nx, \em Ny, and \em Nz specify the number of pixels in the respective cut directions. */
-    void writeMediaDensityCuts(bool xd, bool yd, bool zd, int Nx, int Ny, int Nz);
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/DefaultMediaDensityCutsProbe.hpp
+++ b/SKIRT/core/DefaultMediaDensityCutsProbe.hpp
@@ -42,6 +42,13 @@ class DefaultMediaDensityCutsProbe : public Probe
 public:
     /** This function performs probing after setup. */
     void probeSetup() override;
+
+protected:
+    /** This function outputs FITS files with the theoretical and grid density for each material
+        type in the coordinate planes (xy, xz, or yz) indicated by the boolean "direction"
+        arguments \em xd, \em yd, and \em zd, exactly two of which must be true. The arguments \em
+        Nx, \em Ny, and \em Nz specify the number of pixels in the respective cut directions. */
+    void writeMediaDensityCuts(bool xd, bool yd, bool zd, int Nx, int Ny, int Nz);
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/DefaultRadiationFieldCutsProbe.cpp
+++ b/SKIRT/core/DefaultRadiationFieldCutsProbe.cpp
@@ -4,120 +4,11 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "DefaultRadiationFieldCutsProbe.hpp"
-#include "Array.hpp"
 #include "Configuration.hpp"
 #include "DisjointWavelengthGrid.hpp"
-#include "FITSInOut.hpp"
-#include "MediumSystem.hpp"
-#include "Parallel.hpp"
-#include "ParallelFactory.hpp"
-#include "SpatialGrid.hpp"
-#include "TextOutFile.hpp"
-#include "Units.hpp"
 #include "InstrumentWavelengthGridProbe.hpp"
-
-////////////////////////////////////////////////////////////////////
-
-// Private class to output a FITS file with the mean intensity of the radiation field
-// in each of the coordinate planes (xy, xz, or yz).
-namespace
-{
-    // The image size in each direction, in pixels
-    const int Np = 1024;
-
-    class WriteMeanIntensityCut
-    {
-    private:
-        // data members initialized in constructor
-        Probe* item;
-        MediumSystem* ms;
-        SpatialGrid* grid;
-        WavelengthGrid* wavelengthGrid;
-        Units* units;
-        double xbase, ybase, zbase, xpsize, ypsize, zpsize, xcenter, ycenter, zcenter;
-
-        // data members initialized in setup()
-        bool xd, yd, zd;  // direction of coordinate plane (110, 101, 011)
-        string plane;     // name of the coordinate plane (xy, xz, yz)
-
-        // results vector, properly sized in constructor and initialized to zero in setup()
-        Array Jvv;
-
-    public:
-        // constructor
-        WriteMeanIntensityCut(Probe* item_, MediumSystem* ms_)
-            : item(item_), ms(ms_), grid(ms_->grid()),
-              wavelengthGrid(ms_->find<Configuration>()->radiationFieldWLG()), units(ms_->find<Units>())
-        {
-            double xmin, ymin, zmin, xmax, ymax, zmax;
-            grid->boundingBox().extent(xmin,ymin,zmin,xmax,ymax,zmax);
-            xpsize = (xmax-xmin)/Np;
-            ypsize = (ymax-ymin)/Np;
-            zpsize = (zmax-zmin)/Np;
-            xbase = xmin + 0.5*xpsize;
-            ybase = ymin + 0.5*ypsize;
-            zbase = zmin + 0.5*zpsize;
-            xcenter = (xmin+xmax)/2.0;
-            ycenter = (ymin+ymax)/2.0;
-            zcenter = (zmin+zmax)/2.0;
-
-            Jvv.resize(Np*Np*wavelengthGrid->numBins());
-        }
-
-        // setup for calculating a specific coordinate plane
-        void setup(bool xdir, bool ydir, bool zdir)
-        {
-            xd = xdir;
-            yd = ydir;
-            zd = zdir;
-            plane = "";
-            if (xd) plane += "x";
-            if (yd) plane += "y";
-            if (zd) plane += "z";
-
-            Jvv = 0.;  // initialize all values to zero to facilitate the code in body()
-        }
-
-        // the parallized loop body; calculates the results for a series of lines in the images
-        void body(size_t firstIndex, size_t numIndices)
-        {
-            for (size_t j = firstIndex; j != firstIndex+numIndices; ++j)
-            {
-                double z = zd ? (zbase + j*zpsize) : 0.;
-                for (int i=0; i<Np; i++)
-                {
-                    double x = xd ? (xbase + i*xpsize) : 0.;
-                    double y = yd ? (ybase + (zd ? i : j)*ypsize) : 0.;
-                    Position bfr(x,y,z);
-                    int m = grid->cellIndex(bfr);
-                    if (m>=0)
-                    {
-                        const Array& Jv = ms->meanIntensity(m);
-                        for (int ell=0; ell!=wavelengthGrid->numBins(); ++ell)
-                        {
-                            int l = i + Np*j + Np*Np*ell;
-                            Jvv[l] = units->omeanintensityWavelength(wavelengthGrid->wavelength(ell), Jv[ell]);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Write the results to a FITS file with an appropriate name
-        void write()
-        {
-            string description = "mean intensity in the " + plane + " plane";
-            string filename = item->itemName() + "_J_" + plane;
-            Array wavegrid(wavelengthGrid->numBins());
-            for (int ell=0; ell!=wavelengthGrid->numBins(); ++ell)
-                wavegrid[ell] = units->owavelength(wavelengthGrid->wavelength(ell));
-            FITSInOut::write(item, description, filename, Jvv, units->umeanintensity(), Np, Np,
-                             units->olength(xd?xpsize:ypsize), units->olength(zd?zpsize:ypsize),
-                             units->olength(xd?xcenter:ycenter), units->olength(zd?zcenter:ycenter),
-                             units->ulength(), wavegrid, units->uwavelength());
-        }
-    };
-}
+#include "MediumSystem.hpp"
+#include "PlanarRadiationFieldCutsProbe.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
@@ -125,38 +16,16 @@ void DefaultRadiationFieldCutsProbe::probeRun()
 {
     if (find<Configuration>()->hasRadiationField())
     {
-        // locate the medium system
-        auto ms = find<MediumSystem>();
+        // the size in pixels (in each spatial direction) for the default cuts
+        const int Np = 1024;
 
-        // configure parallelization; perform only at the root processs
-        Parallel* parallel = find<ParallelFactory>()->parallelRootOnly();
+        // the dimension of the medium system
+        int dimension = find<MediumSystem>()->dimension();
 
-        // construct a private class instance to do the work
-        WriteMeanIntensityCut wmi(this, ms);
-
-        // for the xy plane (always)
-        {
-            wmi.setup(1,1,0);
-            parallel->call(Np, [&wmi](size_t i ,size_t n) { wmi.body(i, n); });
-            wmi.write();
-        }
-
-        // for the xz plane (only if dimension is at least 2)
-        int dimension = ms->dimension();
-        if (dimension >= 2)
-        {
-            wmi.setup(1,0,1);
-            parallel->call(Np, [&wmi](size_t i ,size_t n) { wmi.body(i, n); });
-            wmi.write();
-        }
-
-        // for the yz plane (only if dimension is 3)
-        if (dimension == 3)
-        {
-            wmi.setup(0,1,1);
-            parallel->call(Np, [&wmi](size_t i ,size_t n) { wmi.body(i, n); });
-            wmi.write();
-        }
+        // output cuts depending on the dimension of the medium system
+        PlanarRadiationFieldCutsProbe::writeRadiationFieldCut(this, 1,1,0, 0.,0.,0., Np,Np,Np);
+        if (dimension >= 2) PlanarRadiationFieldCutsProbe::writeRadiationFieldCut(this, 1,0,1, 0.,0.,0., Np,Np,Np);
+        if (dimension == 3) PlanarRadiationFieldCutsProbe::writeRadiationFieldCut(this, 0,1,1, 0.,0.,0., Np,Np,Np);
 
         // if requested, also output the wavelength grid
         if (writeWavelengthGrid())

--- a/SKIRT/core/PlanarDustTemperatureCutsProbe.cpp
+++ b/SKIRT/core/PlanarDustTemperatureCutsProbe.cpp
@@ -1,0 +1,90 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "PlanarDustTemperatureCutsProbe.hpp"
+#include "Array.hpp"
+#include "Configuration.hpp"
+#include "FITSInOut.hpp"
+#include "MediumSystem.hpp"
+#include "Parallel.hpp"
+#include "ParallelFactory.hpp"
+#include "SpatialGrid.hpp"
+#include "Units.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void PlanarDustTemperatureCutsProbe::writeDustTemperatureCut(Probe* probe, bool xd, bool yd, bool zd,
+                                                             double xc, double yc, double zc, int Nx, int Ny, int Nz)
+{
+    // locate relevant simulation items
+    auto units = probe->find<Units>();
+    auto ms = probe->find<MediumSystem>();
+
+    // determine spatial configuration (regardless of cut direction)
+    Box box = ms->grid()->boundingBox();
+    double xpsize = box.xwidth()/Nx;
+    double ypsize = box.ywidth()/Ny;
+    double zpsize = box.zwidth()/Nz;
+    double xbase = box.xmin() + 0.5*xpsize;
+    double ybase = box.ymin() + 0.5*ypsize;
+    double zbase = box.zmin() + 0.5*zpsize;
+    double xcenter = box.center().x();
+    double ycenter = box.center().y();
+    double zcenter = box.center().z();
+
+    // determine index configuration: i->colums, j->rows
+    int Ni = xd ? Nx : Ny;
+    int Nj = zd ? Nz : Ny;
+
+    // allocate result array with the appropriate size
+    int size = (xd ? Nx : 1) * (yd ? Ny : 1) * (zd ? Nz : 1);
+    Array Tv(size);
+
+    // calculate the results in parallel; perform only at the root processs
+    auto parallel = probe->find<ParallelFactory>()->parallelRootOnly();
+    parallel->call(Nj, [&Tv,ms,units,xpsize,ypsize,zpsize,xbase,ybase,zbase,
+                            xd,yd,zd,xc,yc,zc,Ni](size_t firstIndex, size_t numIndices)
+    {
+        for (size_t j = firstIndex; j != firstIndex+numIndices; ++j)
+        {
+            double z = zd ? (zbase + j*zpsize) : zc;
+            for (int i=0; i<Ni; i++)
+            {
+                double x = xd ? (xbase + i*xpsize) : xc;
+                double y = yd ? (ybase + (zd ? i : j)*ypsize) : yc;
+                int l = i + Ni*j;
+                Tv[l] = units->otemperature(ms->indicativeDustTemperature(Position(x,y,z)));
+            }
+        }
+    });
+
+    // get the name of the coordinate plane (xy, xz, or yz)
+    string plane;
+    if (xd) plane += "x";
+    if (yd) plane += "y";
+    if (zd) plane += "z";
+
+    // write the results to a FITS file with an appropriate name
+    string description = "dust temperatures in the " + plane + " plane";
+    string filename = probe->itemName() + "_dust_T_" + plane;
+    FITSInOut::write(probe, description, filename, Tv, units->utemperature(), Ni, Nj,
+                     units->olength(xd?xpsize:ypsize), units->olength(zd?zpsize:ypsize),
+                     units->olength(xd?xcenter:ycenter), units->olength(zd?zcenter:ycenter),
+                     units->ulength());
+}
+
+////////////////////////////////////////////////////////////////////
+
+void PlanarDustTemperatureCutsProbe::probeRun()
+{
+    if (find<Configuration>()->hasPanRadiationField() && find<MediumSystem>()->hasDust())
+    {
+        writeDustTemperatureCut(this, 1,1,0, positionX(),positionY(),positionZ(), numPixelsX(),numPixelsY(),numPixelsZ());
+        writeDustTemperatureCut(this, 1,0,1, positionX(),positionY(),positionZ(), numPixelsX(),numPixelsY(),numPixelsZ());
+        writeDustTemperatureCut(this, 0,1,1, positionX(),positionY(),positionZ(), numPixelsX(),numPixelsY(),numPixelsZ());
+    }
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/PlanarDustTemperatureCutsProbe.cpp
+++ b/SKIRT/core/PlanarDustTemperatureCutsProbe.cpp
@@ -39,8 +39,7 @@ void PlanarDustTemperatureCutsProbe::writeDustTemperatureCut(Probe* probe, bool 
     int Nj = zd ? Nz : Ny;
 
     // allocate result array with the appropriate size
-    int size = (xd ? Nx : 1) * (yd ? Ny : 1) * (zd ? Nz : 1);
-    Array Tv(size);
+    Array Tv(Ni * Nj);
 
     // calculate the results in parallel; perform only at the root processs
     auto parallel = probe->find<ParallelFactory>()->parallelRootOnly();

--- a/SKIRT/core/PlanarDustTemperatureCutsProbe.hpp
+++ b/SKIRT/core/PlanarDustTemperatureCutsProbe.hpp
@@ -1,0 +1,53 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef PLANARDUSTTEMPERATURECUTSPROBE_HPP
+#define PLANARDUSTTEMPERATURECUTSPROBE_HPP
+
+#include "AbstractPlanarCutsProbe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** PlanarDustTemperatureCutsProbe outputs FITS files (named <tt>prefix_probe_dust_T_XX.fits</tt>)
+    with cuts through an indicative dust temperature along three planes parallel to the coordinate
+    planes. The offset of each cut plane from the corresponding coordinate plane can be configured
+    by the user (and is zero by default). The field of view of each cut covers the extent of the
+    spatial grid in the simulation in the relevant directions. The number of pixels in each
+    direction can be configured by the user as well.
+
+    The indicative dust temperature assigned to each output pixel is obtained as follows. First the
+    probe determines the cell in the simulation's spatial grid "containing" the pixel according to
+    its position in the cut being considered. The probe then calculates the indicative dust
+    temperature for that cell by averaging the LTE equilibrium temperatures for the various dust
+    mixes present in the cell. Note that the indicative dust temperature does not really correspond
+    to a physical temperature. For more information about the indicative dust temperature, refer to
+    the MediumSystem::indicativeDustTemperature() function. */
+class PlanarDustTemperatureCutsProbe : public AbstractPlanarCutsProbe
+{
+    ITEM_CONCRETE(PlanarDustTemperatureCutsProbe, AbstractPlanarCutsProbe,
+                  "cuts of the indicative dust temperature along planes parallel to the coordinate planes")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(PlanarDustTemperatureCutsProbe,
+                                    "Level2&Dust&SpatialGrid&RadiationField&Panchromatic")
+    ITEM_END()
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function performs probing after all photon packets have been emitted and detected. */
+    void probeRun() override;
+
+    /** This function outputs a FITS file with an indicative dust temperature cut in a plane
+        parallel to the coordinate plane indicated by the boolean "direction" arguments \em xd, \em
+        yd, and \em zd, exactly two of which must be true. The arguments \em xc, \em yc, and \em zc
+        specify the position of the cuts, and the arguments \em Nx, \em Ny, and \em Nz specify the
+        number of pixels in each direction. */
+    static void writeDustTemperatureCut(Probe* probe, bool xd, bool yd, bool zd,
+                                        double xc, double yc, double zc, int Nx, int Ny, int Nz);
+
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/PlanarDustTemperatureCutsProbe.hpp
+++ b/SKIRT/core/PlanarDustTemperatureCutsProbe.hpp
@@ -45,7 +45,6 @@ public:
         number of pixels in each direction. */
     static void writeDustTemperatureCut(Probe* probe, bool xd, bool yd, bool zd,
                                         double xc, double yc, double zc, int Nx, int Ny, int Nz);
-
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/PlanarMediaDensityCutsProbe.cpp
+++ b/SKIRT/core/PlanarMediaDensityCutsProbe.cpp
@@ -16,132 +16,111 @@
 
 ////////////////////////////////////////////////////////////////////
 
-// Private class to output FITS files with the theoretical and grid density
-// for each material type in one of the coordinate planes (xy, xz, or yz).
-namespace
+void PlanarMediaDensityCutsProbe::writeMediaDensityCuts(Probe* probe, bool xd, bool yd, bool zd,
+                                                        double xc, double yc, double zc, int Nx, int Ny, int Nz)
 {
-    // The image size in each direction, in pixels
-    const int Np = 1024;
+    // locate relevant simulation items
+    auto units = probe->find<Units>();
+    auto ms = probe->find<MediumSystem>();
+    auto grid = ms->grid();
 
-    class WriteDensity
+    // determine spatial configuration (regardless of cut direction)
+    Box box = grid->boundingBox();
+    double xpsize = box.xwidth()/Nx;
+    double ypsize = box.ywidth()/Ny;
+    double zpsize = box.zwidth()/Nz;
+    double xbase = box.xmin() + 0.5*xpsize;
+    double ybase = box.ymin() + 0.5*ypsize;
+    double zbase = box.zmin() + 0.5*zpsize;
+    double xcenter = box.center().x();
+    double ycenter = box.center().y();
+    double zcenter = box.center().z();
+
+    // determine index configuration: i->colums, j->rows
+    int Ni = xd ? Nx : Ny;
+    int Nj = zd ? Nz : Ny;
+
+    // allocate result arrays with the appropriate size and initialize contents to zero
+    Array dust_tv, dust_gv;
+    Array elec_tv, elec_gv;
+    Array gas_tv, gas_gv;
+    int size = (xd ? Nx : 1) * (yd ? Ny : 1) * (zd ? Nz : 1);
+    if (ms->hasDust()) { dust_tv.resize(size), dust_gv.resize(size); }
+    if (ms->hasElectrons()) { elec_tv.resize(size), elec_gv.resize(size); }
+    if (ms->hasGas()) { gas_tv.resize(size), gas_gv.resize(size); }
+
+    // calculate the results in parallel; perform only at the root processs
+    auto parallel = probe->find<ParallelFactory>()->parallelRootOnly();
+    parallel->call(Nj, [&dust_tv,&dust_gv,&elec_tv,&elec_gv,&gas_tv,&gas_gv,
+                            ms,grid,xpsize,ypsize,zpsize,xbase,ybase,zbase,
+                            xd,yd,zd,xc,yc,zc,Ni](size_t firstIndex ,size_t numIndices)
     {
-    private:
-        // data members initialized in constructor
-        Probe* item;
-        MediumSystem* ms;
-        SpatialGrid* grid;
-        Units* units;
-        double xbase, ybase, zbase, xpsize, ypsize, zpsize, xcenter, ycenter, zcenter;
-
-        // data members initialized in setup()
-        bool xd, yd, zd; // direction of coordinate plane (110, 101, 011)
-        string plane;    // name of the coordinate plane (xy, xz, yz)
-
-        // results -- resized and initialized to zero in setup()
-        Array dust_tv, dust_gv;
-        Array elec_tv, elec_gv;
-        Array gas_tv, gas_gv;
-
-    public:
-        // constructor
-        WriteDensity(Probe* item_, MediumSystem* ms_)
-            : item(item_), ms(ms_), grid(ms_->grid()), units(ms_->find<Units>())
+        int numMedia = ms->numMedia();
+        for (size_t j = firstIndex; j != firstIndex+numIndices; ++j)
         {
-            double xmin, ymin, zmin, xmax, ymax, zmax;
-            grid->boundingBox().extent(xmin,ymin,zmin,xmax,ymax,zmax);
-            xpsize = (xmax-xmin)/Np;
-            ypsize = (ymax-ymin)/Np;
-            zpsize = (zmax-zmin)/Np;
-            xbase = xmin + 0.5*xpsize;
-            ybase = ymin + 0.5*ypsize;
-            zbase = zmin + 0.5*zpsize;
-            xcenter = (xmin+xmax)/2.0;
-            ycenter = (ymin+ymax)/2.0;
-            zcenter = (zmin+zmax)/2.0;
-        }
-
-        // setup for calculating a specific coordinate plane
-        void setup(bool xdir, bool ydir, bool zdir)
-        {
-            xd = xdir;
-            yd = ydir;
-            zd = zdir;
-            plane = "";
-            if (xd) plane += "x";
-            if (yd) plane += "y";
-            if (zd) plane += "z";
-
-            if (ms->hasDust()) { dust_tv.resize(Np*Np), dust_gv.resize(Np*Np); }
-            if (ms->hasElectrons()) { elec_tv.resize(Np*Np), elec_gv.resize(Np*Np); }
-            if (ms->hasGas()) { gas_tv.resize(Np*Np), gas_gv.resize(Np*Np); }
-        }
-
-        // the parallized loop body; calculates the results for a series of lines in the images
-        void body(size_t firstIndex, size_t numIndices)
-        {
-            int numMedia = ms->numMedia();
-            for (size_t j = firstIndex; j != firstIndex+numIndices; ++j)
+            double z = zd ? (zbase + j*zpsize) : zc;
+            for (int i=0; i<Ni; i++)
             {
-                double z = zd ? (zbase + j*zpsize) : zcenter;
-                for (int i=0; i<Np; i++)
-                {
-                    int l = i + Np*j;
-                    double x = xd ? (xbase + i*xpsize) : xcenter;
-                    double y = yd ? (ybase + (zd ? i : j)*ypsize) : ycenter;
-                    Position bfr(x,y,z);
-                    int m = grid->cellIndex(bfr);
+                int l = i + Ni*j;
+                double x = xd ? (xbase + i*xpsize) : xc;
+                double y = yd ? (ybase + (zd ? i : j)*ypsize) : yc;
+                Position bfr(x,y,z);
+                int m = grid->cellIndex(bfr);
 
-                    for (int h=0; h!=numMedia; ++h)
+                for (int h=0; h!=numMedia; ++h)
+                {
+                    if (ms->isDust(h))
                     {
-                        if (ms->isDust(h))
-                        {
-                            dust_tv[l] += ms->media()[h]->massDensity(bfr);
-                            if (m>=0) dust_gv[l] += ms->massDensity(m,h);
-                        }
-                        else if (ms->isElectrons(h))
-                        {
-                            elec_tv[l] += ms->media()[h]->numberDensity(bfr);
-                            if (m>=0) elec_gv[l] += ms->numberDensity(m,h);
-                        }
-                        else if (ms->isGas(h))
-                        {
-                            gas_tv[l] += ms->media()[h]->numberDensity(bfr);
-                            if (m>=0) gas_gv[l] += ms->numberDensity(m,h);
-                        }
+                        dust_tv[l] += ms->media()[h]->massDensity(bfr);
+                        if (m>=0) dust_gv[l] += ms->massDensity(m,h);
+                    }
+                    else if (ms->isElectrons(h))
+                    {
+                        elec_tv[l] += ms->media()[h]->numberDensity(bfr);
+                        if (m>=0) elec_gv[l] += ms->numberDensity(m,h);
+                    }
+                    else if (ms->isGas(h))
+                    {
+                        gas_tv[l] += ms->media()[h]->numberDensity(bfr);
+                        if (m>=0) gas_gv[l] += ms->numberDensity(m,h);
                     }
                 }
             }
         }
+    });
 
-        // write the results to two FITS files with appropriate names
-        void write()
+    // define a function to write a result array to a FITS file
+    auto write = [probe,units,xpsize,ypsize,zpsize,xcenter,ycenter,zcenter,
+                        xd,yd,zd,Ni,Nj](Array& v, string label, string prefix, bool massDensity)
+    {
+        if (v.size())
         {
-            write(dust_tv, "dust theoretical density", "dust_t", true);
-            write(dust_gv, "dust gridded density", "dust_g", true);
-            write(elec_tv, "electron theoretical density", "elec_t", false);
-            write(elec_gv, "electron gridded density", "elec_g", false);
-            write(gas_tv, "gas theoretical density", "gas_t", false);
-            write(gas_gv, "gas gridded density", "gas_g", false);
-        }
+            // get the name of the coordinate plane (xy, xz, or yz)
+            string plane;
+            if (xd) plane += "x";
+            if (yd) plane += "y";
+            if (zd) plane += "z";
 
-    private:
-        void write(Array& v, string label, string prefix, bool massDensity)
-        {
-            if (v.size())
-            {
-                // convert to output units
-                v *= (massDensity ? units->omassvolumedensity(1.) : units->onumbervolumedensity(1.));
-                string densityUnits = massDensity ? units->umassvolumedensity() : units->unumbervolumedensity();
+            // convert to output units
+            v *= (massDensity ? units->omassvolumedensity(1.) : units->onumbervolumedensity(1.));
+            string densityUnits = massDensity ? units->umassvolumedensity() : units->unumbervolumedensity();
 
-                // write file
-                string filename = item->itemName() + "_" + prefix + "_" + plane;
-                FITSInOut::write(item, label + " in the " + plane + " plane", filename, v, densityUnits, Np, Np,
-                                 units->olength(xd?xpsize:ypsize), units->olength(zd?zpsize:ypsize),
-                                 units->olength(xd?xcenter:ycenter), units->olength(zd?zcenter:ycenter),
-                                 units->ulength());
-            }
+            // write file
+            string filename = probe->itemName() + "_" + prefix + "_" + plane;
+            FITSInOut::write(probe, label + " in the " + plane + " plane", filename, v, densityUnits, Ni, Nj,
+                             units->olength(xd?xpsize:ypsize), units->olength(zd?zpsize:ypsize),
+                             units->olength(xd?xcenter:ycenter), units->olength(zd?zcenter:ycenter),
+                             units->ulength());
         }
     };
+
+    // write the results for each material type to two FITS files with appropriate names
+    write(dust_tv, "dust theoretical density", "dust_t", true);
+    write(dust_gv, "dust gridded density", "dust_g", true);
+    write(elec_tv, "electron theoretical density", "elec_t", false);
+    write(elec_gv, "electron gridded density", "elec_g", false);
+    write(gas_tv, "gas theoretical density", "gas_t", false);
+    write(gas_gv, "gas gridded density", "gas_g", false);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -150,38 +129,10 @@ void PlanarMediaDensityCutsProbe::probeSetup()
 {
     if (find<Configuration>()->hasMedium())
     {
-        // locate the medium system
-        auto ms = find<MediumSystem>();
-
-        // configure parallelization; perform only at the root processs
-        Parallel* parallel = find<ParallelFactory>()->parallelRootOnly();
-
-        // construct a private class instance to do the work
-        WriteDensity wd(this, ms);
-
-        // for the xy plane (always)
-        {
-            wd.setup(1,1,0);
-            parallel->call(Np, [&wd](size_t i ,size_t n) { wd.body(i, n); });
-            wd.write();
-        }
-
-        // for the xz plane (only if dimension is at least 2)
-        int dimension = ms->dimension();
-        if (dimension >= 2)
-        {
-            wd.setup(1,0,1);
-            parallel->call(Np, [&wd](size_t i ,size_t n) { wd.body(i, n); });
-            wd.write();
-        }
-
-        // for the yz plane (only if dimension is 3)
-        if (dimension == 3)
-        {
-            wd.setup(0,1,1);
-            parallel->call(Np, [&wd](size_t i ,size_t n) { wd.body(i, n); });
-            wd.write();
-        }
+        // output planes depending on the dimension of the medium system
+        writeMediaDensityCuts(this, 1,1,0, positionX(),positionY(),positionZ(), numPixelsX(),numPixelsY(),numPixelsZ());
+        writeMediaDensityCuts(this, 1,0,1, positionX(),positionY(),positionZ(), numPixelsX(),numPixelsY(),numPixelsZ());
+        writeMediaDensityCuts(this, 0,1,1, positionX(),positionY(),positionZ(), numPixelsX(),numPixelsY(),numPixelsZ());
     }
 }
 

--- a/SKIRT/core/PlanarMediaDensityCutsProbe.cpp
+++ b/SKIRT/core/PlanarMediaDensityCutsProbe.cpp
@@ -44,7 +44,7 @@ void PlanarMediaDensityCutsProbe::writeMediaDensityCuts(Probe* probe, bool xd, b
     Array dust_tv, dust_gv;
     Array elec_tv, elec_gv;
     Array gas_tv, gas_gv;
-    int size = (xd ? Nx : 1) * (yd ? Ny : 1) * (zd ? Nz : 1);
+    int size = Ni * Nj;
     if (ms->hasDust()) { dust_tv.resize(size), dust_gv.resize(size); }
     if (ms->hasElectrons()) { elec_tv.resize(size), elec_gv.resize(size); }
     if (ms->hasGas()) { gas_tv.resize(size), gas_gv.resize(size); }

--- a/SKIRT/core/PlanarMediaDensityCutsProbe.cpp
+++ b/SKIRT/core/PlanarMediaDensityCutsProbe.cpp
@@ -53,7 +53,7 @@ void PlanarMediaDensityCutsProbe::writeMediaDensityCuts(Probe* probe, bool xd, b
     auto parallel = probe->find<ParallelFactory>()->parallelRootOnly();
     parallel->call(Nj, [&dust_tv,&dust_gv,&elec_tv,&elec_gv,&gas_tv,&gas_gv,
                             ms,grid,xpsize,ypsize,zpsize,xbase,ybase,zbase,
-                            xd,yd,zd,xc,yc,zc,Ni](size_t firstIndex ,size_t numIndices)
+                            xd,yd,zd,xc,yc,zc,Ni](size_t firstIndex, size_t numIndices)
     {
         int numMedia = ms->numMedia();
         for (size_t j = firstIndex; j != firstIndex+numIndices; ++j)
@@ -129,7 +129,6 @@ void PlanarMediaDensityCutsProbe::probeSetup()
 {
     if (find<Configuration>()->hasMedium())
     {
-        // output planes depending on the dimension of the medium system
         writeMediaDensityCuts(this, 1,1,0, positionX(),positionY(),positionZ(), numPixelsX(),numPixelsY(),numPixelsZ());
         writeMediaDensityCuts(this, 1,0,1, positionX(),positionY(),positionZ(), numPixelsX(),numPixelsY(),numPixelsZ());
         writeMediaDensityCuts(this, 0,1,1, positionX(),positionY(),positionZ(), numPixelsX(),numPixelsY(),numPixelsZ());

--- a/SKIRT/core/PlanarMediaDensityCutsProbe.hpp
+++ b/SKIRT/core/PlanarMediaDensityCutsProbe.hpp
@@ -6,22 +6,21 @@
 #ifndef PLANARMEDIADENSITYCUTSPROBE_HPP
 #define PLANARMEDIADENSITYCUTSPROBE_HPP
 
-#include "Probe.hpp"
+#include "AbstractPlanarCutsProbe.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
 /** PlanarMediaDensityCutsProbe outputs FITS files with cuts through the true input media density
-    and the grid-discretized media density along lines through the center of the grid coordinates, 
-    aligned parallel to the coordinate planes. Each of these maps contains 1024 x 1024 pixels, and 
-    covers as a field of view the total extension of the spatial grid in the simulation.
+    and the grid-discretized media density along three planes parallel to the coordinate planes.
+    The offset of each cut plane from the corresponding coordinate plane can be configured by the
+    user (and is zero by default). The field of view of each cut covers the extent of the spatial
+    grid in the simulation in the relevant directions. The number of pixels in each direction can
+    be configured by the user as well.
 
-    The number of data files written depends on the geometry and material contents of the media
-    system. For spherical symmetry only the intersection with the xy plane is written, for axial
-    symmetry the intersections with the xy and xz planes are written, and for general geometries
-    all three intersections are written. Also, a separate set of files is produced for each
-    material type (dust, electrons, or gas). The files for dust provide the dust mass density, and
-    those for electrons and gas provide the electron or hydrogen number density. Multiple media
-    components containing the same material type are combined, regardless of ordering.
+    A separate set of files is produced for each material type (dust, electrons, or gas). The files
+    for dust provide the dust mass density, and those for electrons and gas provide the electron or
+    hydrogen number density. Multiple media components containing the same material type are
+    combined, regardless of ordering.
 
     The difference between the true input density maps (named <tt>prefix_probe_MM_t_XX.fits</tt>)
     and the grid-discretized density maps (named <tt>prefix_probe_MM_g_XX.fits</tt>) is the
@@ -31,9 +30,10 @@
     from the finite-resolution spatial grid in the simulation. A comparison of both sets of maps
     can reveal whether the configured spatial grid is suitable (in the ideal case, there would be
     no difference between both sets of maps). */
-class PlanarMediaDensityCutsProbe : public Probe
+class PlanarMediaDensityCutsProbe : public AbstractPlanarCutsProbe
 {
-    ITEM_CONCRETE(PlanarMediaDensityCutsProbe, Probe, "cuts of the media densities through the center of the grid coordinate positions, parallel to the coordinate planes")
+    ITEM_CONCRETE(PlanarMediaDensityCutsProbe, AbstractPlanarCutsProbe,
+                  "cuts of the media densities along planes parallel to the coordinate planes")
         ATTRIBUTE_TYPE_DISPLAYED_IF(PlanarMediaDensityCutsProbe, "Medium&SpatialGrid")
     ITEM_END()
 
@@ -42,6 +42,14 @@ class PlanarMediaDensityCutsProbe : public Probe
 public:
     /** This function performs probing after setup. */
     void probeSetup() override;
+
+    /** This function outputs FITS files with the theoretical and grid density for each material
+        type in the coordinate planes (xy, xz, or yz) indicated by the boolean "direction"
+        arguments \em xd, \em yd, and \em zd, exactly two of which must be true. The arguments \em
+        xc, \em yc, and \em zc specify the position of the cuts, and the arguments \em Nx, \em Ny,
+        and \em Nz specify the number of pixels in each direction. */
+    static void writeMediaDensityCuts(Probe* probe, bool xd, bool yd, bool zd,
+                                      double xc, double yc, double zc, int Nx, int Ny, int Nz);
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/PlanarMediaDensityCutsProbe.hpp
+++ b/SKIRT/core/PlanarMediaDensityCutsProbe.hpp
@@ -34,7 +34,7 @@ class PlanarMediaDensityCutsProbe : public AbstractPlanarCutsProbe
 {
     ITEM_CONCRETE(PlanarMediaDensityCutsProbe, AbstractPlanarCutsProbe,
                   "cuts of the media densities along planes parallel to the coordinate planes")
-        ATTRIBUTE_TYPE_DISPLAYED_IF(PlanarMediaDensityCutsProbe, "Medium&SpatialGrid")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(PlanarMediaDensityCutsProbe, "Level2&Medium&SpatialGrid")
     ITEM_END()
 
     //======================== Other Functions =======================
@@ -44,7 +44,7 @@ public:
     void probeSetup() override;
 
     /** This function outputs FITS files with the theoretical and grid density for each material
-        type in the coordinate planes (xy, xz, or yz) indicated by the boolean "direction"
+        type in a plane parallel to the coordinate plane indicated by the boolean "direction"
         arguments \em xd, \em yd, and \em zd, exactly two of which must be true. The arguments \em
         xc, \em yc, and \em zc specify the position of the cuts, and the arguments \em Nx, \em Ny,
         and \em Nz specify the number of pixels in each direction. */

--- a/SKIRT/core/PlanarRadiationFieldCutsProbe.cpp
+++ b/SKIRT/core/PlanarRadiationFieldCutsProbe.cpp
@@ -1,0 +1,113 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "PlanarRadiationFieldCutsProbe.hpp"
+#include "Array.hpp"
+#include "Configuration.hpp"
+#include "DisjointWavelengthGrid.hpp"
+#include "FITSInOut.hpp"
+#include "InstrumentWavelengthGridProbe.hpp"
+#include "MediumSystem.hpp"
+#include "Parallel.hpp"
+#include "ParallelFactory.hpp"
+#include "SpatialGrid.hpp"
+#include "Units.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void PlanarRadiationFieldCutsProbe::writeRadiationFieldCut(Probe* probe, bool xd, bool yd, bool zd,
+                                                           double xc, double yc, double zc, int Nx, int Ny, int Nz)
+{
+    // locate relevant simulation items
+    auto units = probe->find<Units>();
+    auto ms = probe->find<MediumSystem>();
+    auto grid = ms->grid();
+    auto wavelengthGrid = probe->find<Configuration>()->radiationFieldWLG();
+
+    // determine spatial configuration (regardless of cut direction)
+    Box box = ms->grid()->boundingBox();
+    double xpsize = box.xwidth()/Nx;
+    double ypsize = box.ywidth()/Ny;
+    double zpsize = box.zwidth()/Nz;
+    double xbase = box.xmin() + 0.5*xpsize;
+    double ybase = box.ymin() + 0.5*ypsize;
+    double zbase = box.zmin() + 0.5*zpsize;
+    double xcenter = box.center().x();
+    double ycenter = box.center().y();
+    double zcenter = box.center().z();
+
+    // determine index configuration: i->colums, j->rows
+    int Ni = xd ? Nx : Ny;
+    int Nj = zd ? Nz : Ny;
+
+    // allocate result array with the appropriate size and initialize it to zero
+    size_t size = Ni * Nj;
+    Array Jvv(size * wavelengthGrid->numBins());
+
+    // calculate the results in parallel; perform only at the root processs
+    auto parallel = probe->find<ParallelFactory>()->parallelRootOnly();
+    parallel->call(Nj, [&Jvv,units,ms,grid,wavelengthGrid,xpsize,ypsize,zpsize,xbase,ybase,zbase,
+                            xd,yd,zd,xc,yc,zc,Ni,size](size_t firstIndex, size_t numIndices)
+    {
+        for (size_t j = firstIndex; j != firstIndex+numIndices; ++j)
+        {
+            double z = zd ? (zbase + j*zpsize) : zc;
+            for (int i=0; i<Ni; i++)
+            {
+                double x = xd ? (xbase + i*xpsize) : xc;
+                double y = yd ? (ybase + (zd ? i : j)*ypsize) : yc;
+                Position bfr(x,y,z);
+                int m = grid->cellIndex(bfr);
+                if (m>=0)
+                {
+                    const Array& Jv = ms->meanIntensity(m);
+                    for (int ell=0; ell!=wavelengthGrid->numBins(); ++ell)
+                    {
+                        size_t l = i + Ni*j + size*ell;
+                        Jvv[l] = units->omeanintensityWavelength(wavelengthGrid->wavelength(ell), Jv[ell]);
+                    }
+                }
+            }
+        }
+    });
+
+    // get the name of the coordinate plane (xy, xz, or yz)
+    string plane;
+    if (xd) plane += "x";
+    if (yd) plane += "y";
+    if (zd) plane += "z";
+
+    // write the results to a FITS file with an appropriate name
+    string description = "mean intensity in the " + plane + " plane";
+    string filename = probe->itemName() + "_J_" + plane;
+    Array wavegrid(wavelengthGrid->numBins());
+    for (int ell=0; ell!=wavelengthGrid->numBins(); ++ell)
+        wavegrid[ell] = units->owavelength(wavelengthGrid->wavelength(ell));
+    FITSInOut::write(probe, description, filename, Jvv, units->umeanintensity(), Ni, Nj,
+                     units->olength(xd?xpsize:ypsize), units->olength(zd?zpsize:ypsize),
+                     units->olength(xd?xcenter:ycenter), units->olength(zd?zcenter:ycenter),
+                     units->ulength(), wavegrid, units->uwavelength());
+}
+
+////////////////////////////////////////////////////////////////////
+
+void PlanarRadiationFieldCutsProbe::probeRun()
+{
+    if (find<Configuration>()->hasRadiationField())
+    {
+        writeRadiationFieldCut(this, 1,1,0, positionX(),positionY(),positionZ(), numPixelsX(),numPixelsY(),numPixelsZ());
+        writeRadiationFieldCut(this, 1,0,1, positionX(),positionY(),positionZ(), numPixelsX(),numPixelsY(),numPixelsZ());
+        writeRadiationFieldCut(this, 0,1,1, positionX(),positionY(),positionZ(), numPixelsX(),numPixelsY(),numPixelsZ());
+
+        // if requested, also output the wavelength grid
+        if (writeWavelengthGrid())
+        {
+            InstrumentWavelengthGridProbe::writeWavelengthGrid(this, find<Configuration>()->radiationFieldWLG(),
+                                                     itemName() + "_wavelengths", "wavelengths for mean intensity");
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/PlanarRadiationFieldCutsProbe.hpp
+++ b/SKIRT/core/PlanarRadiationFieldCutsProbe.hpp
@@ -1,0 +1,56 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef PLANARRADIATIONFIELDCUTSPROBE_HPP
+#define PLANARRADIATIONFIELDCUTSPROBE_HPP
+
+#include "AbstractPlanarCutsProbe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** PlanarRadiationFieldCutsProbe outputs FITS files (named <tt>prefix_probe_J_XX.fits</tt>) with
+    cuts through the mean radiation field intensity along three planes parallel to the coordinate
+    planes. The offset of each cut plane from the corresponding coordinate plane can be configured
+    by the user (and is zero by default). The field of view of each cut covers the extent of the
+    spatial grid in the simulation in the relevant directions. The number of pixels in each
+    direction can be configured by the user as well.
+
+    Each of the output files actually contains a datacube with a map for each bin in the wavelength
+    grid returned by the Configuration::radiationFieldWLG() function. The maps have 1024 x 1024
+    pixels, and cover a field of view equal to the total extension of the spatial grid in the
+    simulation.
+
+    The probe offers an option to output a separate text column file with details on the radiation
+    field wavelength grid. For each wavelength bin, the file lists the characteristic wavelength,
+    the wavelength bin width, and the left and right borders of the bin. */
+class PlanarRadiationFieldCutsProbe : public AbstractPlanarCutsProbe
+{
+    ITEM_CONCRETE(PlanarRadiationFieldCutsProbe, AbstractPlanarCutsProbe,
+                  "cuts of the mean radiation field intensity along planes parallel to the coordinate planes")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(PlanarRadiationFieldCutsProbe, "Level2&Medium&SpatialGrid&RadiationField")
+
+    PROPERTY_BOOL(writeWavelengthGrid, "output a text file with the radiation field wavelength grid")
+        ATTRIBUTE_DEFAULT_VALUE(writeWavelengthGrid, "false")
+
+    ITEM_END()
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function performs probing after all photon packets have been emitted and detected. */
+    void probeRun() override;
+
+    /** This function outputs a FITS file with a mean radiation field intensity cut in a plane
+        parallel to the coordinate plane indicated by the boolean "direction" arguments \em xd, \em
+        yd, and \em zd, exactly two of which must be true. The arguments \em xc, \em yc, and \em zc
+        specify the position of the cuts, and the arguments \em Nx, \em Ny, and \em Nz specify the
+        number of pixels in each direction. */
+    static void writeRadiationFieldCut(Probe* probe, bool xd, bool yd, bool zd,
+                                        double xc, double yc, double zc, int Nx, int Ny, int Nz);
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -519,6 +519,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<Probe>();
     ItemRegistry::add<AbstractWavelengthProbe>();
     ItemRegistry::add<AbstractWavelengthGridProbe>();
+    ItemRegistry::add<AbstractPlanarCutsProbe>();
     ItemRegistry::add<InstrumentWavelengthGridProbe>();
     ItemRegistry::add<LuminosityProbe>();
     ItemRegistry::add<LaunchedPacketsProbe>();

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -140,6 +140,7 @@
 #include "PhotonPacketOptions.hpp"
 #include "PlanarDustTemperatureCutsProbe.hpp"
 #include "PlanarMediaDensityCutsProbe.hpp"
+#include "PlanarRadiationFieldCutsProbe.hpp"
 #include "PlummerGeometry.hpp"
 #include "PointSource.hpp"
 #include "PolarizedGraphiteGrainComposition.hpp"
@@ -537,6 +538,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<DustGrainSizeDistributionProbe>();
 
     ItemRegistry::add<DefaultRadiationFieldCutsProbe>();
+    ItemRegistry::add<PlanarRadiationFieldCutsProbe>();
     ItemRegistry::add<RadiationFieldPerCellProbe>();
     ItemRegistry::add<RadiationFieldWavelengthGridProbe>();
     ItemRegistry::add<DefaultDustTemperatureCutsProbe>();

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -138,6 +138,7 @@
 #include "ParticleSource.hpp"
 #include "PerspectiveInstrument.hpp"
 #include "PhotonPacketOptions.hpp"
+#include "PlanarDustTemperatureCutsProbe.hpp"
 #include "PlanarMediaDensityCutsProbe.hpp"
 #include "PlummerGeometry.hpp"
 #include "PointSource.hpp"
@@ -539,6 +540,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<RadiationFieldPerCellProbe>();
     ItemRegistry::add<RadiationFieldWavelengthGridProbe>();
     ItemRegistry::add<DefaultDustTemperatureCutsProbe>();
+    ItemRegistry::add<PlanarDustTemperatureCutsProbe>();
     ItemRegistry::add<DustTemperaturePerCellProbe>();
     ItemRegistry::add<LinearDustTemperatureCutProbe>();
     ItemRegistry::add<MeridionalDustTemperatureCutProbe>();


### PR DESCRIPTION
**Description**
Add probes for planar medium density, dust temperature, and radiation field at an arbitrary position in the spatial domain (but still parallel to the coordinate planes). Refactored the corresponding default cut probes to use the same code (without changing their behaviour).

**Important note**
This is an extension of the earlier contribution by @christopherlovell discussed in issue #12 . However, note that the default value for the cut position now changed to (0,0,0) instead of the center of the spatial grid. To get the same behaviour, users must explicitly specify the coordinates of the grid center.

**Motivation**
Allow users to probe these quantities at other locations in the model than along the coordinate planes. 

**Tests**
New functional tests were added to the standard set.
