### PR TITLE
Support velocity dispersion for imported sources

### DIFF
--- a/SKIRT/core/AdaptiveMeshSnapshot.cpp
+++ b/SKIRT/core/AdaptiveMeshSnapshot.cpp
@@ -319,6 +319,14 @@ Vec AdaptiveMeshSnapshot::velocity(int m) const
 
 ////////////////////////////////////////////////////////////////////
 
+double AdaptiveMeshSnapshot::velocityDispersion(int m) const
+{
+    const Array& prop = _cells[m]->properties();
+    return prop[velocityDispersionIndex()];
+}
+
+////////////////////////////////////////////////////////////////////
+
 void AdaptiveMeshSnapshot::parameters(int m, Array& params) const
 {
     int n = numParameters();
@@ -362,6 +370,14 @@ Vec AdaptiveMeshSnapshot::velocity(Position bfr) const
 {
     int m = cellIndex(bfr);
     return m>=0 ? velocity(m) : Vec();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double AdaptiveMeshSnapshot::velocityDispersion(Position bfr) const
+{
+    int m = cellIndex(bfr);
+    return m>=0 ? velocityDispersion(m) : 0.;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/AdaptiveMeshSnapshot.hpp
+++ b/SKIRT/core/AdaptiveMeshSnapshot.hpp
@@ -191,6 +191,11 @@ public:
         not being imported, or the index is out of range, the behavior is undefined. */
     Vec velocity(int m) const override;
 
+    /** This function returns the velocity dispersion of the entity with index \f$0\le m \le
+        N_\mathrm{ent}-1\f$. If the velocity dispersion is not being imported, or the index is out
+        of range, the behavior is undefined. */
+    double velocityDispersion(int m) const override;
+
     /** This function stores the parameters of the leaf cell with index \em m into the given array.
         If parameters are not being imported, or the index is out of range, the behavior is
         undefined. */
@@ -220,6 +225,12 @@ public:
         point \f${\bf{r}}\f$. If the point is outside the domain, the function returns zero
         velocity. If the velocity is not being imported, the behavior is undefined. */
     Vec velocity(Position bfr) const override;
+
+    /** This function returns the velocity dispersion of the entity nearest to (or at) the
+        specified point \f${\bf{r}}\f$. If the point is outside the domain, the function returns
+        zero dispersion. If the velocity dispersion is not being imported, the behavior is
+        undefined. */
+    double velocityDispersion(Position bfr) const override;
 
     /** This function stores the parameters of the leaf cell containing the specified point
         \f${\bf{r}}\f$ into the given array. If the point is outside the domain, the function

--- a/SKIRT/core/AdaptiveMeshSource.hpp
+++ b/SKIRT/core/AdaptiveMeshSource.hpp
@@ -23,17 +23,20 @@
     columns expected in the input file depends on the options configured by the user for this
     AdaptiveMeshSource instance, including the selected %SEDFamily.
 
-    \f[ [ v_x\,(\mathrm{km/s}) \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) ] \quad \dots
-    \text{SED family parameters}\dots \f]
+    \f[ [ v_x\,(\mathrm{km/s}) \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) \quad [
+    \sigma_v\,(\mathrm{km/s}) ] ] \quad \dots \text{SED family parameters}\dots \f]
 
     If the \em importVelocity option is enabled, the first three columns specify the \f$v_x\f$,
-    \f$v_y\f$, \f$v_z\f$ bulk velocity components of the source population represented by the cell
-    corresponding to the site. The remaining columns specify the parameters required by the
-    configured %SED family to select and scale the appropriate %SED. For example for the
-    Bruzual-Charlot %SED family, the remaining columns provide the initial mass, the metallicity,
-    and the age of the stellar population represented by the cell corresponding to the site. Refer
-    to the documentation of the configured type of SEDFamily for information about the expected
-    parameters and their default units. */
+    \f$v_y\f$, \f$v_z\f$ bulk velocity components of the source population represented by the cell.
+    If additionally the \em importVelocityDispersion option is enabled, the next column specifies
+    the velocity dispersion \f$\sigma_v\f$, adjusting the velocity for each photon packet launch
+    with a random offset sampled from a spherically symmetric Gaussian distribution.
+
+    The remaining columns specify the parameters required by the configured %SED family to select
+    and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining
+    columns provide the initial mass, the metallicity, and the age of the stellar population
+    represented by the cell corresponding to the site. Refer to the documentation of the configured
+    type of SEDFamily for information about the expected parameters and their default units. */
 class AdaptiveMeshSource : public MeshSource
 {
     ITEM_CONCRETE(AdaptiveMeshSource, MeshSource,

--- a/SKIRT/core/CubicalBackgroundSource.cpp
+++ b/SKIRT/core/CubicalBackgroundSource.cpp
@@ -94,7 +94,7 @@ namespace
 ////////////////////////////////////////////////////////////////////
 
 void CubicalBackgroundSource::launchNormalized(PhotonPacket* pp, size_t historyIndex, double lambda, double Lw,
-                                               BulkVelocityInterface* bvi) const
+                                               VelocityInterface* bvi) const
 {
     // generate a random launch wall
     Direction bfu = generateLaunchWall(random());

--- a/SKIRT/core/CubicalBackgroundSource.hpp
+++ b/SKIRT/core/CubicalBackgroundSource.hpp
@@ -81,7 +81,7 @@ public:
         Finally, the function launches the photon packet, passing it all of the above information.
         */
     void launchNormalized(PhotonPacket* pp, size_t historyIndex, double lambda, double Lw,
-                          BulkVelocityInterface* bvi) const override;
+                          VelocityInterface* bvi) const override;
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/GeometricSource.cpp
+++ b/SKIRT/core/GeometricSource.cpp
@@ -17,7 +17,7 @@ int GeometricSource::geometryDimension() const
 //////////////////////////////////////////////////////////////////////
 
 void GeometricSource::launchNormalized(PhotonPacket* pp, size_t historyIndex, double lambda, double Lw,
-                                       BulkVelocityInterface* bvi) const
+                                       VelocityInterface* bvi) const
 {
     // generate a random position from the geometry
     Position bfr = _geometry->generatePosition();

--- a/SKIRT/core/GeometricSource.hpp
+++ b/SKIRT/core/GeometricSource.hpp
@@ -38,7 +38,7 @@ public:
         source. The emission is unpolarized and isotropic; the emission direction is simply sampled
         from a uniform distribution on the unit sphere. */
     void launchNormalized(PhotonPacket* pp, size_t historyIndex, double lambda, double Lw,
-                          BulkVelocityInterface* bvi) const override;
+                          VelocityInterface* bvi) const override;
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ImportedSource.cpp
+++ b/SKIRT/core/ImportedSource.cpp
@@ -5,7 +5,6 @@
 
 #include "ImportedSource.hpp"
 #include "Configuration.hpp"
-#include "BulkVelocityInterface.hpp"
 #include "Constants.hpp"
 #include "FatalError.hpp"
 #include "Log.hpp"
@@ -17,6 +16,7 @@
 #include "Random.hpp"
 #include "SEDFamily.hpp"
 #include "Snapshot.hpp"
+#include "VelocityInterface.hpp"
 #include "WavelengthGrid.hpp"
 
 ////////////////////////////////////////////////////////////////////
@@ -236,8 +236,8 @@ namespace
 
 namespace
 {
-    // an instance of this class offers the bulk velocity interface for an imported entity
-    class EntityVelocity : public BulkVelocityInterface
+    // an instance of this class offers the velocity interface for an imported entity
+    class EntityVelocity : public VelocityInterface
     {
     private:
         Vec _bfv;
@@ -248,7 +248,7 @@ namespace
         {
             _bfv += sigma * random->gauss() * random->direction();
         }
-        Vec bulkVelocity() const override { return _bfv; }
+        Vec velocity() const override { return _bfv; }
     };
 
     // setup a velocity instance (with the redshift interface) for each parallel execution thread; this works even if
@@ -312,7 +312,7 @@ void ImportedSource::launch(PhotonPacket* pp, size_t historyIndex, double L) con
     Position bfr = _snapshot->generatePosition(m);
 
     // provide a redshift interface for the appropriate velocity, if enabled
-    BulkVelocityInterface* bvi = nullptr;
+    VelocityInterface* bvi = nullptr;
     if (!_oligochromatic && _importVelocity)
     {
         t_velocity.setBulkVelocity(_snapshot->velocity(m));

--- a/SKIRT/core/ImportedSource.hpp
+++ b/SKIRT/core/ImportedSource.hpp
@@ -33,7 +33,7 @@ class Snapshot;
     spatial and spectral information for an entity yields its contribution to the imported
     radiation source.
 
-    The input file may also include a bulk velocity vector (with an optional velocity dispersion)
+    The input file may also include a bulk velocity vector with an optional velocity dispersion
     for each entity. When this option is enabled, the appropriate Doppler shift is taken into
     account when launching photon packets. Apart from the anisotropy resulting from this optional
     Doppler shift, the radiation emitted by this primary source is always isotropic. It is also

--- a/SKIRT/core/ImportedSource.hpp
+++ b/SKIRT/core/ImportedSource.hpp
@@ -33,10 +33,11 @@ class Snapshot;
     spatial and spectral information for an entity yields its contribution to the imported
     radiation source.
 
-    The input file may also include a seperate (bulk) velocity vector for each entity. When this
-    option is enabled, the appropriate Doppler shift is taken into account when launching photon
-    packets. Apart from the anisotropy resulting from this optional Doppler shift, the radiation
-    emitted by this primary source is always isotropic. It is also always unpolarized. */
+    The input file may also include a bulk velocity vector (with an optional velocity dispersion)
+    for each entity. When this option is enabled, the appropriate Doppler shift is taken into
+    account when launching photon packets. Apart from the anisotropy resulting from this optional
+    Doppler shift, the radiation emitted by this primary source is always isotropic. It is also
+    always unpolarized. */
 class ImportedSource : public Source
 {
     ITEM_ABSTRACT(ImportedSource, Source, "a primary source imported from snapshot data")
@@ -48,7 +49,13 @@ class ImportedSource : public Source
 
     PROPERTY_BOOL(importVelocity, "import velocity components (3 columns)")
         ATTRIBUTE_DEFAULT_VALUE(importVelocity, "false")
-        ATTRIBUTE_DISPLAYED_IF(importVelocity, "(Panchromatic&Level2)|Level3")
+        ATTRIBUTE_RELEVANT_IF(importVelocity, "Panchromatic")
+        ATTRIBUTE_DISPLAYED_IF(importVelocity, "Level2")
+
+    PROPERTY_BOOL(importVelocityDispersion, "import velocity dispersion (spherically symmetric)")
+        ATTRIBUTE_DEFAULT_VALUE(importVelocityDispersion, "false")
+        ATTRIBUTE_RELEVANT_IF(importVelocityDispersion, "Panchromatic&importVelocity")
+        ATTRIBUTE_DISPLAYED_IF(importVelocityDispersion, "Level2")
 
     PROPERTY_STRING(useColumns, "a list of names corresponding to columns in the file to be imported")
         ATTRIBUTE_DEFAULT_VALUE(useColumns, "")

--- a/SKIRT/core/MonteCarloSimulation.hpp
+++ b/SKIRT/core/MonteCarloSimulation.hpp
@@ -250,7 +250,7 @@ private:
         direction of the observer \f${\bf{k}}_{\text{obs}}\f$. For anisotropic emission, a weight
         factor is applied to the luminosity to compensate for the fact that the probability that a
         photon packet would have been emitted towards the observer is not the same as the
-        probability that it is emitted in any other direction. If the source has a bulk velocity,
+        probability that it is emitted in any other direction. If the source has a nonzero velocity,
         the wavelength of the peel-off photon packet is Doppler-shifted for the new direction.
 
         The first argument specifies the photon packet that was just emitted; the second argument
@@ -267,7 +267,7 @@ private:
         the Configuration::radiationFieldWLG() function for more information). Locating the
         appropriate spatial bin is trivial because each segment in the photon packet's path stores
         the index of the cell being crossed. The wavelength bin is derived from the photon packet's
-        perceived wavelength in the cell under consideration, taking into account the bulk velocity
+        perceived wavelength in the cell under consideration, taking into account the velocity
         of the medium in that cell.
 
         For each segment \f$n\f$ in the photon packet's path, this function first determines the

--- a/SKIRT/core/NormalizedSource.cpp
+++ b/SKIRT/core/NormalizedSource.cpp
@@ -78,7 +78,7 @@ double NormalizedSource::specificLuminosity(double wavelength) const
 
 //////////////////////////////////////////////////////////////////////
 
-Vec NormalizedSource::bulkVelocity() const
+Vec NormalizedSource::velocity() const
 {
     return Vec(velocityX(), velocityY(), velocityZ());
 }

--- a/SKIRT/core/NormalizedSource.hpp
+++ b/SKIRT/core/NormalizedSource.hpp
@@ -7,7 +7,7 @@
 #define NORMALIZEDSOURCE_HPP
 
 #include "Source.hpp"
-#include "BulkVelocityInterface.hpp"
+#include "VelocityInterface.hpp"
 #include "LuminosityNormalization.hpp"
 #include "SED.hpp"
 
@@ -21,7 +21,7 @@
 
     Subclasses must handle the spatial distribution of the source, and can optionally add
     anisotropy and/or polarization. */
-class NormalizedSource : public Source, public BulkVelocityInterface
+class NormalizedSource : public Source, public VelocityInterface
 {
     ITEM_ABSTRACT(NormalizedSource, Source, "a primary source with a single SED")
 
@@ -65,7 +65,7 @@ class NormalizedSource : public Source, public BulkVelocityInterface
     //============= Construction - Setup - Destruction =============
 
 protected:
-    /** This function creates a private object offering the redshift interface if the bulk velocity
+    /** This function creates a private object offering the velocity interface if the bulk velocity
         is nonzero. */
     void setupSelfBefore() override;
 
@@ -77,7 +77,7 @@ public:
         bulk velocity. */
     int dimension() const override;
 
-    /** This function returns true if the bulk velocity of the source is nonzero. */
+    /** This function returns true if the velocity of the source is nonzero. */
     bool hasVelocity() const override;
 
     /** This function returns the wavelength range for this source. Outside this range, all
@@ -99,9 +99,9 @@ public:
          whole) or if the source simply does not emit at the wavelength. */
      double specificLuminosity(double wavelength) const override;
 
-     /** This function implements the BulkVelocityInterface interface. It returns the bulk velocity
+     /** This function implements the VelocityInterface interface. It returns the bulk velocity
          of this source, as configured by the user. */
-     Vec bulkVelocity() const override;
+     Vec velocity() const override;
 
      /** This function causes the photon packet \em pp to be launched from the source using the
          given history index and luminosity contribution. In this abstract class, the function
@@ -122,7 +122,7 @@ public:
         handle the spatial distribution of the source, optionally adding anisotropy and/or
         polarization. */
     virtual void launchNormalized(PhotonPacket* pp, size_t historyIndex, double lambda, double Lw,
-                                  BulkVelocityInterface* bvi) const = 0;
+                                  VelocityInterface* bvi) const = 0;
 
     //======================== Data Members ========================
 
@@ -133,7 +133,7 @@ private:
     WavelengthDistribution* _biasDistribution{nullptr}; // the wavelength bias distribution
 
     // pointer to an object offering the redshift interface; either "this" or null pointer if the bulk velocity is zero
-    BulkVelocityInterface* _bvi{nullptr};
+    VelocityInterface* _bvi{nullptr};
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ParticleSnapshot.cpp
+++ b/SKIRT/core/ParticleSnapshot.cpp
@@ -175,6 +175,13 @@ Vec ParticleSnapshot::velocity(int m) const
 
 ////////////////////////////////////////////////////////////////////
 
+double ParticleSnapshot::velocityDispersion(int m) const
+{
+    return _propv[m][velocityDispersionIndex()];
+}
+
+////////////////////////////////////////////////////////////////////
+
 void ParticleSnapshot::parameters(int m, Array& params) const
 {
     int n = numParameters();
@@ -188,6 +195,14 @@ Vec ParticleSnapshot::velocity(Position bfr) const
 {
     const SmoothedParticle* nearestParticle = _grid ? _grid->nearestParticle(bfr) : nullptr;
     return nearestParticle ? velocity(nearestParticle->index()) : Vec();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double ParticleSnapshot::velocityDispersion(Position bfr) const
+{
+    const SmoothedParticle* nearestParticle = _grid ? _grid->nearestParticle(bfr) : nullptr;
+    return nearestParticle ? velocityDispersion(nearestParticle->index()) : 0.;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ParticleSnapshot.hpp
+++ b/SKIRT/core/ParticleSnapshot.hpp
@@ -71,6 +71,11 @@ public:
         being imported, or the index is out of range, the behavior is undefined. */
     Vec velocity(int m) const override;
 
+    /** This function returns the velocity dispersion of the entity with index \f$0\le m \le
+        N_\mathrm{ent}-1\f$. If the velocity dispersion is not being imported, or the index is out
+        of range, the behavior is undefined. */
+    double velocityDispersion(int m) const override;
+
     /** This function stores the parameters of the particle with index \em m into the given array.
         If parameters are not being imported, or the index is out of range, the behavior is
         undefined. */
@@ -80,6 +85,12 @@ public:
         \f${\bf{r}}\f$. If the point is outside the domain, the function returns zero velocity. If
         the velocity is not being imported, the behavior is undefined. */
     Vec velocity(Position bfr) const override;
+
+    /** This function returns the velocity dispersion of the entity nearest to (or at) the
+        specified point \f${\bf{r}}\f$. If the point is outside the domain, the function returns
+        zero dispersion. If the velocity dispersion is not being imported, the behavior is
+        undefined. */
+    double velocityDispersion(Position bfr) const override;
 
     /** This function stores the parameters of the particle centered nearest to the specified point
         \f${\bf{r}}\f$ into the given array. If the point is outside the domain, the function

--- a/SKIRT/core/ParticleSource.hpp
+++ b/SKIRT/core/ParticleSource.hpp
@@ -23,19 +23,22 @@
     this ParticleSource instance, including the selected %SEDFamily.
 
     \f[ x\,(\mathrm{pc}) \quad y\,(\mathrm{pc}) \quad z\,(\mathrm{pc}) \quad h\,(\mathrm{pc}) \quad
-    [ v_x\,(\mathrm{km/s}) \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) ]  \quad \dots
-    \text{SED family parameters}\dots \f]
+    [ v_x\,(\mathrm{km/s}) \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) \quad [
+    \sigma_v\,(\mathrm{km/s}) ] ] \quad \dots \text{SED family parameters}\dots \f]
 
     The first three columns are the \f$x\f$, \f$y\f$ and \f$z\f$ coordinates of the particle, and
     the fourth column is the particle smoothing length \f$h\f$. If the \em importVelocity option is
-    enabled, the next three columns specify the \f$v_x\f$, \f$v_y\f$, \f$v_z\f$ velocity
-    components of the particle (considered as the bulk velocity for the source population
-    represented by the particle). Finally, the remaining columns specify the parameters required by
-    the configured %SED family to select and scale the appropriate %SED. For example for the
-    Bruzual-Charlot %SED family, the remaining columns provide the initial mass, the metallicity,
-    and the age of the stellar population represented by the particle. Refer to the documentation
-    of the configured type of SEDFamily for information about the expected parameters and their
-    default units. */
+    enabled, the next three columns specify the \f$v_x\f$, \f$v_y\f$, \f$v_z\f$ bulk velocity
+    components of the source population represented by the particle. If additionally the \em
+    importVelocityDispersion option is enabled, the next column specifies the velocity dispersion
+    \f$\sigma_v\f$, adjusting the velocity for each photon packet launch with a random offset
+    sampled from a spherically symmetric Gaussian distribution.
+
+    The remaining columns specify the parameters required by the configured %SED family to select
+    and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining
+    columns provide the initial mass, the metallicity, and the age of the stellar population
+    represented by the particle. Refer to the documentation of the configured type of SEDFamily for
+    information about the expected parameters and their default units. */
 class ParticleSource : public ImportedSource
 {
     ITEM_CONCRETE(ParticleSource, ImportedSource, "a primary source imported from smoothed particle data")

--- a/SKIRT/core/PointSource.cpp
+++ b/SKIRT/core/PointSource.cpp
@@ -30,7 +30,7 @@ int PointSource::geometryDimension() const
 //////////////////////////////////////////////////////////////////////
 
 void PointSource::launchNormalized(PhotonPacket* pp, size_t historyIndex, double lambda, double Lw,
-                                   BulkVelocityInterface* bvi) const
+                                   VelocityInterface* bvi) const
 {
     // get the source position
     Position bfr(positionX(), positionY(), positionZ());

--- a/SKIRT/core/PointSource.hpp
+++ b/SKIRT/core/PointSource.hpp
@@ -16,7 +16,7 @@
     The spectral distribution is characterized by an SED object, and the bolometric output is
     characterized by a LuminosityNormalization object. The emitted radiation can be anisotropic
     (configured through an AngularDistribution object) and/or be polarized (configured through a
-    PolarizationState object). The point source can also have a bulk velocity. */
+    PolarizationState object). The point source can also have a velocity. */
 class PointSource : public NormalizedSource
 {
     ITEM_CONCRETE(PointSource, NormalizedSource, "a primary point source")
@@ -52,7 +52,7 @@ class PointSource : public NormalizedSource
 
 public:
     /** This function returns the dimension of the point source, taking into account anisotropic
-        emission or polarization, if present, but ignoring the bulk velocity (because this is
+        emission or polarization, if present, but ignoring the velocity (because this is
         handled in the base class). */
     int geometryDimension() const override;
 
@@ -62,7 +62,7 @@ public:
         source. The emission is unpolarized and isotropic; the emission direction is simply sampled
         from a uniform distribution on the unit sphere. */
     void launchNormalized(PhotonPacket* pp, size_t historyIndex, double lambda, double Lw,
-                          BulkVelocityInterface* bvi) const override;
+                          VelocityInterface* bvi) const override;
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SecondarySourceSystem.cpp
+++ b/SKIRT/core/SecondarySourceSystem.cpp
@@ -4,7 +4,6 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "SecondarySourceSystem.hpp"
-#include "BulkVelocityInterface.hpp"
 #include "Configuration.hpp"
 #include "DisjointWavelengthGrid.hpp"
 #include "FatalError.hpp"
@@ -18,6 +17,7 @@
 #include "ProcessManager.hpp"
 #include "Random.hpp"
 #include "StringUtils.hpp"
+#include "VelocityInterface.hpp"
 #include "WavelengthDistribution.hpp"
 
 ////////////////////////////////////////////////////////////////////
@@ -169,7 +169,7 @@ namespace
     // This information includes the normalized regular and cumulative dust emission spectra, calculated from
     // the stored radiation field and the dust properties using the configured emission calculator, and
     // the average bulk velocity of the material in the cell, obtained from the medium system.
-    class DustCellEmission : public BulkVelocityInterface
+    class DustCellEmission : public VelocityInterface
     {
     private:
         // information initialized once, during the first call to calculateIfNeeded()
@@ -328,7 +328,7 @@ namespace
             return NR::value<NR::interpolateLogLog>(lambda, _lambdav, _pv);
         }
 
-        Vec bulkVelocity() const override { return _bfv; }
+        Vec velocity() const override { return _bfv; }
     };
 
     // setup a DustCellEmission instance for each parallel execution thread to cache dust emission information
@@ -387,7 +387,7 @@ void SecondarySourceSystem::launch(PhotonPacket* pp, size_t historyIndex) const
     Position bfr = _ms->grid()->randomPositionInCell(m);
 
     // provide a redshift interface for the appropriate velocity, if it is nonzero
-    BulkVelocityInterface* bvi = t_dustcell.bulkVelocity().isNull() ? nullptr : &t_dustcell;
+    VelocityInterface* bvi = t_dustcell.velocity().isNull() ? nullptr : &t_dustcell;
 
     // launch the photon packet with isotropic direction
     pp->launch(historyIndex, lambda, L*w, bfr, _random->direction(), bvi);

--- a/SKIRT/core/Snapshot.cpp
+++ b/SKIRT/core/Snapshot.cpp
@@ -134,6 +134,12 @@ void Snapshot::importVelocity()
     _infile->addColumn("velocity z", "velocity", "km/s");
 }
 
+void Snapshot::importVelocityDispersion()
+{
+    _velocityDispersionIndex = _nextIndex++;
+    _infile->addColumn("velocity dispersion", "velocity", "km/s");
+}
+
 ////////////////////////////////////////////////////////////////////
 
 void Snapshot::importParameters(const vector<SnapshotParameter>& parameters)

--- a/SKIRT/core/Snapshot.hpp
+++ b/SKIRT/core/Snapshot.hpp
@@ -156,6 +156,11 @@ public:
         The default unit is km/s. */
     void importVelocity();
 
+    /** This function configures the snapshot to import a single velocity dispersion value,
+        specifying a random offset to the bulk velocity with a spherically symmetric Gaussian
+        distribution. The default unit is km/s. */
+    void importVelocityDispersion();
+
     /** This function configures the snapshot to import alignment characteristics including
         orientation and fraction of alignment. TO DO: provide details and implement. */
     void importAlignment();
@@ -214,6 +219,10 @@ protected:
         being imported, for use by subclasses. */
     int velocityIndex() const { return _velocityIndex; }
 
+    /** This function returns the column index of the velocity dispersion field, or -1 if this is
+        not being imported, for use by subclasses. */
+    int velocityDispersionIndex() const { return _velocityDispersionIndex; }
+
     /** This function returns the column index of the first field in the parameter list, or -1 if
         this is not being imported, for use by subclasses. */
     int parametersIndex() const { return _parametersIndex; }
@@ -265,6 +274,17 @@ public:
         \f${\bf{r}}\f$. If the point is outside the domain, the function returns zero velocity. If
         the velocity is not being imported, the behavior is undefined. */
     virtual Vec velocity(Position bfr) const = 0;
+
+    /** This function returns the velocity dispersion of the entity with index \f$0\le m \le
+        N_\mathrm{ent}-1\f$. If the velocity dispersion is not being imported, or the index is out
+        of range, the behavior is undefined. */
+    virtual double velocityDispersion(int m) const = 0;
+
+    /** This function returns the velocity dispersion of the entity nearest to (or at) the
+        specified point \f${\bf{r}}\f$. If the point is outside the domain, the function returns
+        zero dispersion. If the velocity dispersion is not being imported, the behavior is
+        undefined. */
+    virtual double velocityDispersion(Position bfr) const = 0;
 
     /** This function stores the parameters of the entity with index \f$0\le m \le
         N_\mathrm{ent}-1\f$ into the given array. If parameters are not being imported, or the
@@ -344,6 +364,7 @@ private:
     int _metallicityIndex{-1};
     int _temperatureIndex{-1};
     int _velocityIndex{-1};
+    int _velocityDispersionIndex{-1};
     int _parametersIndex{-1};
     int _numParameters{0};
 

--- a/SKIRT/core/Source.hpp
+++ b/SKIRT/core/Source.hpp
@@ -22,7 +22,7 @@ class Random;
       - Some normalization for the luminosity (e.g., bolometric, at a given wavelength, ...).
       - If the emission is anisotropic, the rest-frame angular distribution of the emission.
       - If the emission is polarized, the polarization state of the emission in each direction.
-      - The bulk velocity of the source relative to the model coordinate frame.
+      - The velocity of the source relative to the model coordinate frame.
 
     Furthermore, each source has a function for launching a photon packet that proceeds roughly
     as follows:
@@ -35,7 +35,7 @@ class Random;
       - Determine the polarization state of the emission at that location and at that wavelength,
         i.e. an object offering the PolarizationState interface (function to return a Stokes vector
         for a given direction)
-      - Determine the bulk velocity of the source at that location
+      - Determine the velocity of the source at that location
       - Pass the items listed above to the photon packet launch procedure
 
     Wavelengths for new photon packets can be sampled from the intrinsic spectral distribution of
@@ -94,8 +94,8 @@ public:
         none of these symmetries. */
     virtual int dimension() const = 0;
 
-    /** This function returns true if this source may have a nonzero bulk velocity for some
-        positions. */
+    /** This function returns true if this source may have a nonzero velocity for some positions.
+        */
     virtual bool hasVelocity() const = 0;
 
     /** This function returns the luminosity \f$L\f$ (i.e. radiative power) of the source

--- a/SKIRT/core/SphericalBackgroundSource.cpp
+++ b/SKIRT/core/SphericalBackgroundSource.cpp
@@ -76,7 +76,7 @@ namespace
 ////////////////////////////////////////////////////////////////////
 
 void SphericalBackgroundSource::launchNormalized(PhotonPacket* pp, size_t historyIndex, double lambda, double Lw,
-                                                 BulkVelocityInterface* bvi) const
+                                                 VelocityInterface* bvi) const
 {
     // generate a random intrinsic launch "position" on the unit sphere
     Direction bfu = random()->direction();

--- a/SKIRT/core/SphericalBackgroundSource.hpp
+++ b/SKIRT/core/SphericalBackgroundSource.hpp
@@ -91,7 +91,7 @@ public:
         Finally, the function launches the photon packet, passing it all of the above information.
         */
     void launchNormalized(PhotonPacket* pp, size_t historyIndex, double lambda, double Lw,
-                          BulkVelocityInterface* bvi) const override;
+                          VelocityInterface* bvi) const override;
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/StellarSurfaceSource.cpp
+++ b/SKIRT/core/StellarSurfaceSource.cpp
@@ -76,7 +76,7 @@ namespace
 ////////////////////////////////////////////////////////////////////
 
 void StellarSurfaceSource::launchNormalized(PhotonPacket* pp, size_t historyIndex, double lambda, double Lw,
-                                            BulkVelocityInterface* bvi) const
+                                            VelocityInterface* bvi) const
 {
     // generate a random intrinsic launch "position" on the unit sphere
     Direction bfu = random()->direction();

--- a/SKIRT/core/StellarSurfaceSource.hpp
+++ b/SKIRT/core/StellarSurfaceSource.hpp
@@ -91,7 +91,7 @@ public:
         Finally, the function launches the photon packet, passing it all of the above information.
         */
     void launchNormalized(PhotonPacket* pp, size_t historyIndex, double lambda, double Lw,
-                          BulkVelocityInterface* bvi) const override;
+                          VelocityInterface* bvi) const override;
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/VoronoiMeshSnapshot.cpp
+++ b/SKIRT/core/VoronoiMeshSnapshot.cpp
@@ -727,6 +727,14 @@ Vec VoronoiMeshSnapshot::velocity(int m) const
 
 ////////////////////////////////////////////////////////////////////
 
+double VoronoiMeshSnapshot::velocityDispersion(int m) const
+{
+    const Array& prop = _cells[m]->properties();
+    return prop[velocityDispersionIndex()];
+}
+
+////////////////////////////////////////////////////////////////////
+
 void VoronoiMeshSnapshot::parameters(int m, Array& params) const
 {
     int n = numParameters();
@@ -821,6 +829,14 @@ Vec VoronoiMeshSnapshot::velocity(Position bfr) const
 {
     int m = cellIndex(bfr);
     return m>=0 ? velocity(m) : Vec();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double VoronoiMeshSnapshot::velocityDispersion(Position bfr) const
+{
+    int m = cellIndex(bfr);
+    return m>=0 ? velocityDispersion(m) : 0.;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/VoronoiMeshSnapshot.hpp
+++ b/SKIRT/core/VoronoiMeshSnapshot.hpp
@@ -214,6 +214,11 @@ public:
         being imported, or the index is out of range, the behavior is undefined. */
     Vec velocity(int m) const override;
 
+    /** This function returns the velocity dispersion of the entity with index \f$0\le m \le
+        N_\mathrm{ent}-1\f$. If the velocity dispersion is not being imported, or the index is out
+        of range, the behavior is undefined. */
+    double velocityDispersion(int m) const override;
+
     /** This function stores the parameters of the cell with index \em m into the given array. If
         parameters are not being imported, or the index is out of range, the behavior is undefined.
         */
@@ -260,6 +265,12 @@ public:
         \f${\bf{r}}\f$. If the point is outside the domain, the function returns zero velocity. If
         the velocity is not being imported, the behavior is undefined. */
     Vec velocity(Position bfr) const override;
+
+    /** This function returns the velocity dispersion of the entity nearest to (or at) the
+        specified point \f${\bf{r}}\f$. If the point is outside the domain, the function returns
+        zero dispersion. If the velocity dispersion is not being imported, the behavior is
+        undefined. */
+    double velocityDispersion(Position bfr) const override;
 
     /** This function stores the parameters of the cell containing the specified point
         \f${\bf{r}}\f$ into the given array. If the point is outside the domain, the function

--- a/SKIRT/core/VoronoiMeshSource.hpp
+++ b/SKIRT/core/VoronoiMeshSource.hpp
@@ -22,14 +22,18 @@
     this VoronoiMeshSource instance, including the selected %SEDFamily.
 
     \f[ x\,(\mathrm{pc}) \quad y\,(\mathrm{pc}) \quad z\,(\mathrm{pc}) \quad [ v_x\,(\mathrm{km/s})
-    \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) ] \quad \dots \text{SED family
-    parameters}\dots \f]
+    \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) \quad [ \sigma_v\,(\mathrm{km/s}) ] ]
+    \quad \dots \text{SED family parameters}\dots \f]
 
     The first three columns are the \f$x\f$, \f$y\f$ and \f$z\f$ coordinates of the Voronoi site
     (i.e. the location defining a particular Voronoi cell). If the \em importVelocity option is
     enabled, the next three columns specify the \f$v_x\f$, \f$v_y\f$, \f$v_z\f$ bulk velocity
-    components of the source population represented by the cell corresponding to the site. Finally,
-    the remaining columns specify the parameters required by the configured %SED family to select
+    components of the source population represented by the cell corresponding to the site. If
+    additionally the \em importVelocityDispersion option is enabled, the next column specifies the
+    velocity dispersion \f$\sigma_v\f$, adjusting the velocity for each photon packet launch with a
+    random offset sampled from a spherically symmetric Gaussian distribution.
+
+    The remaining columns specify the parameters required by the configured %SED family to select
     and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining
     columns provide the initial mass, the metallicity, and the age of the stellar population
     represented by the cell corresponding to the site. Refer to the documentation of the configured

--- a/SKIRT/utils/PhotonPacket.cpp
+++ b/SKIRT/utils/PhotonPacket.cpp
@@ -4,10 +4,10 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "PhotonPacket.hpp"
-#include "Constants.hpp"
 #include "AngularDistributionInterface.hpp"
+#include "Constants.hpp"
 #include "PolarizationProfileInterface.hpp"
-#include "BulkVelocityInterface.hpp"
+#include "VelocityInterface.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
@@ -18,7 +18,7 @@ PhotonPacket::PhotonPacket()
 ////////////////////////////////////////////////////////////////////
 
 void PhotonPacket::launch(size_t historyIndex, double lambda, double L, Position bfr, Direction bfk,
-                          BulkVelocityInterface* bvi,
+                          VelocityInterface* bvi,
                           AngularDistributionInterface* adi,
                           PolarizationProfileInterface* ppi)
 {
@@ -33,7 +33,7 @@ void PhotonPacket::launch(size_t historyIndex, double lambda, double L, Position
     _nscatt = 0;
     setPosition(bfr);
     setDirection(bfk);
-    if (bvi) _lambda = shiftedEmissionWavelength(lambda, bfk, bvi->bulkVelocity());
+    if (bvi) _lambda = shiftedEmissionWavelength(lambda, bfk, bvi->velocity());
     if (ppi) setPolarized(ppi->polarizationForDirection(bfk));
     else setUnpolarized();
     _hasObservedOpticalDepth = false;
@@ -65,7 +65,7 @@ void PhotonPacket::launchEmissionPeelOff(const PhotonPacket* pp, Direction bfk)
     _nscatt = 0;
     setPosition(pp->position());
     setDirection(bfk);
-    if (pp->_bvi) _lambda = shiftedEmissionWavelength(_lambda0, bfk, pp->_bvi->bulkVelocity());
+    if (pp->_bvi) _lambda = shiftedEmissionWavelength(_lambda0, bfk, pp->_bvi->velocity());
     if (pp->_adi) applyBias(pp->_adi->probabilityForDirection(bfk));
     if (pp->_ppi) setPolarized(pp->_ppi->polarizationForDirection(bfk));
     else setUnpolarized();

--- a/SKIRT/utils/PhotonPacket.hpp
+++ b/SKIRT/utils/PhotonPacket.hpp
@@ -10,7 +10,7 @@
 #include "StokesVector.hpp"
 class AngularDistributionInterface;
 class PolarizationProfileInterface;
-class BulkVelocityInterface;
+class VelocityInterface;
 
 ////////////////////////////////////////////////////////////////////
 
@@ -70,7 +70,7 @@ public:
         arguments to the corresponding data members and initializes the other data members as
         described below.
 
-        If the BulkVelocityInterface is specified (i.e. it is not the null pointer), then the
+        If the VelocityInterface is specified (i.e. it is not the null pointer), then the
         packet's wavelength is Doppler shifted corresponding to its emission direction. If the
         PolarizationStateInterface is specified, the packet's polarization state is set according
         to its emission direction; otherwise the polarization state is set to unpolarized. The
@@ -82,7 +82,7 @@ public:
         set to zero. The current path is invalidated, and all information about the previous life
         cycle is lost. */
     void launch(size_t historyIndex, double lambda, double L, Position bfr, Direction bfk,
-                BulkVelocityInterface* bvi=nullptr,
+                VelocityInterface* bvi=nullptr,
                 AngularDistributionInterface* adi=nullptr,
                 PolarizationProfileInterface* ppi=nullptr);
 
@@ -104,7 +104,7 @@ public:
         from the base photon packet to the peel off photon packet, updates the peel off direction,
         and honors some extra source properties tracked by the base photon packet as follows.
 
-        If the base packet has a BulkVelocityInterface (i.e. if it is not the null pointer), then
+        If the base packet has a VelocityInterface (i.e. if it is not the null pointer), then
         the peel-off packet's wavelength is Doppler shifted corresponding to its propagation
         direction. If the base packet has an AngularDistributionInterface, a bias for the
         probability of the peel-off propagation direction is applied to the peel-off packet's
@@ -244,7 +244,7 @@ private:
 
     // physical information on radiation source; the interfaces are not used in peel-off photon packets
     double _lambda0{0};      // original wavelength in the rest-frame of the source
-    BulkVelocityInterface* _bvi{nullptr};
+    VelocityInterface* _bvi{nullptr};
     AngularDistributionInterface* _adi{nullptr};
     PolarizationProfileInterface* _ppi{nullptr};
 

--- a/SKIRT/utils/VelocityInterface.hpp
+++ b/SKIRT/utils/VelocityInterface.hpp
@@ -3,27 +3,26 @@
 ////       © Astronomical Observatory, Ghent University         ////
 ///////////////////////////////////////////////////////////////// */
 
-#ifndef BULKVELOCITYINTERFACE_HPP
-#define BULKVELOCITYINTERFACE_HPP
+#ifndef VELOCITYINTERFACE_HPP
+#define VELOCITYINTERFACE_HPP
 
 #include "Vec.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
-/** BulkVelocityInterface is a pure interface to obtain the bulk velocity of a radiation source or
-    receiver. */
-class BulkVelocityInterface
+/** VelocityInterface is a pure interface to obtain the velocity of a radiation source. */
+class VelocityInterface
 {
 protected:
     /** The empty constructor for the interface. */
-    BulkVelocityInterface() { }
+    VelocityInterface() { }
 
 public:
     /** The empty destructor for the interface. */
-    virtual ~BulkVelocityInterface() { }
+    virtual ~VelocityInterface() { }
 
-    /** This function returns the bulk velocity of the radiation source or receiver. */
-    virtual Vec bulkVelocity() const = 0;
+    /** This function returns the velocity of the radiation source. */
+    virtual Vec velocity() const = 0;
 };
 
 ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
The user can enable an extra optional column for imported sources that specifies a spherically symmetric velocity dispersion in addition to the bulk velocity of each particle or cell.

**Motivation**
The stellar velocities in the imported model may not be sufficiently randomised just by assigning a separate bulk velocity to each particle/cell, except perhaps for snapshots with very high mass resolution. Adding a dispersion to each particle/cell can then improve the modelling. See also issue #7 .

**Tests**
Added test case to the standard set of functional tests
