### PR TITLE
Fix metadata causing CylindricalVectorField to appear twice

### DIFF
--- a/SKIRT/core/RadialVectorField.hpp
+++ b/SKIRT/core/RadialVectorField.hpp
@@ -21,7 +21,7 @@
 class RadialVectorField : public VectorField
 {
     ITEM_CONCRETE(RadialVectorField, VectorField, "a vector field pointing away from the origin")
-        ATTRIBUTE_TYPE_INSERT(CylindricalVectorField, "Dimension3")
+        ATTRIBUTE_TYPE_INSERT(RadialVectorField, "Dimension3")
 
         PROPERTY_DOUBLE(unityRadius, "the radius where the magnitude of the vectors is unity")
         ATTRIBUTE_QUANTITY(unityRadius, "length")


### PR DESCRIPTION
**Description**
Fix metadata causing CylindricalVectorField to appear twice in the list of classes on the Web site.

**Context**
Issue reported by @mstalevski.
