### PR TITLE
Polarised dust emission

### DIFF
--- a/SKIRT/core/MonteCarloSimulation.cpp
+++ b/SKIRT/core/MonteCarloSimulation.cpp
@@ -359,7 +359,16 @@ void MonteCarloSimulation::peelOffEmission(const PhotonPacket* pp, PhotonPacket*
     for (Instrument* instrument : _instrumentSystem->instruments())
     {
         if (!instrument->isSameObserverAsPreceding())
-            ppp->launchEmissionPeelOff(pp, instrument->bfkobs(pp->position()));
+        {
+            const Direction bfkobs = instrument->bfkobs(pp->position());
+            ppp->launchEmissionPeelOff(pp, bfkobs);
+
+            // if the photon packet is polarised, we have to rotate the Stokes vector into the frame of the instrument
+            if (ppp->isPolarized())
+            {
+                ppp->rotateIntoPlane(bfkobs, instrument->bfky(pp->position()));
+            }
+        }
         instrument->detect(ppp);
     }
 }

--- a/SKIRT/utils/StokesVector.hpp
+++ b/SKIRT/utils/StokesVector.hpp
@@ -82,6 +82,9 @@ public:
         unpolarized state, the zero vector is returned. */
     Direction normal() const { return _normal; }
 
+    /** This function can be used to check if the Stokes vector contains polarised radiation. */
+    bool isPolarized() const { return _polarized; }
+
     // -------- calculated properties -------
 
     /** This function returns the total polarization degree for the Stokes vector. */


### PR DESCRIPTION
**Description**
Two changes:
 - polarisation effects are now properly taken into account when launching emission peel off photon packets
 - emission now emits polarised photon packets if spheroidal dust particles are present

**Motivation**
This pull request adds the functionality required to model polarised dust emission by spheroidal dust grains.

**Tests**
[spheroid_test.zip](https://github.com/SKIRT/SKIRT9/files/4160103/spheroid_test.zip)
The above file contains a `.ski` file and a `.stab` emission coefficient data file for a single cell SKIRT simulation that uses the proposed polarised dust emission mechanism (launching and peel off; interaction of the emitted photons with the medium is not tested yet). The results can be tested against the expected emission and agree quite well:
![result](https://user-images.githubusercontent.com/7336967/73851794-65b0c300-482e-11ea-8c9d-c3a69ec1b9c8.png)
There is a noticeable offset between the actual and expected emission for a 45 degree observer angle, which is caused by an inconsistency between the tabulated emission coefficients used for the polarised emission and the ones used for the normal emission. Not much I can do about that for the moment. The polarisation signature agrees very well with the expectation.

**Guidelines**
Code was formatted using the format script and `clang-format-9`.

**Context**
Not applicable.