### PR TITLE
Avoid NaNs in (unused) precalculated data

### DIFF
--- a/SKIRT/core/MultiGrainDustMix.cpp
+++ b/SKIRT/core/MultiGrainDustMix.cpp
@@ -399,7 +399,7 @@ size_t MultiGrainDustMix::initializeExtraProperties(const Array& lambdav)
                         sum2 += weightv[i] * dndav[i] * dav[i];
                     }
                     double bulkDensity = population->composition()->bulkDensity();
-                    double meanMass = bulkDensity * sum1 / sum2;
+                    double meanMass = sum2 ? bulkDensity * sum1 / sum2 : 0.;
 
                     // get the grain type for this population
                     string grainType = population->composition()->name();


### PR DESCRIPTION
**Description**
Fix a bug that caused NaN values for the mean mass of a dust population's size bin if the size bin does not contain any dust. The code depending on the mean mass happened to behave as if the NaN value was actually zero, so that the end result was correct anyway.

**Motivation**
Intermediate NaN values are evil. A future update to the code using the mean mass might have unsurfaced a very hard to find bug.

**Context**
Thanks to @drvdputt for reporting this (internal) bug.
