### PR TITLE
minRadius feature for Sphere1DSpatialGrid

### DIFF
--- a/SKIRT/core/Sphere1DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.cpp
@@ -16,7 +16,7 @@ void Sphere1DSpatialGrid::setupSelfAfter()
 {
     // Set up the grid properties
     _Nr = _meshRadial->numBins();
-    _rv = _meshRadial->mesh() * maxRadius();
+    _rv = minRadius() + _meshRadial->mesh() * (maxRadius() - minRadius());
 
     // base class setupSelfAfter() depends on initialization performed above
     SphereSpatialGrid::setupSelfAfter();
@@ -90,6 +90,7 @@ void Sphere1DSpatialGrid::path(SpatialGridPath* path) const
     double kx, ky, kz;
     path->direction().cartesian(kx, ky, kz);
     double rmax = maxRadius();
+    double rmin = minRadius();
 
     // Move the photon packet to the first grid cell that it will pass.
     // If it does not pass any grid cell, return an empty path.
@@ -109,6 +110,15 @@ void Sphere1DSpatialGrid::path(SpatialGridPath* path) const
             path->addSegment(-1, ds);
             q = qmax;
         }
+    }
+    else if (r < rmin)
+    {
+        // Same math, but ray inside shell will always intersect
+        r = rmin + 1e-8 * (_rv[1] - _rv[0]);
+        double qmin = sqrt((rmin - p) * (rmin + p));
+        double ds = (qmin - q);
+        path->addSegment(-1, ds);
+        q = qmin;
     }
 
     // Determination of the initial grid cell

--- a/SKIRT/core/Sphere1DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.cpp
@@ -133,39 +133,33 @@ void Sphere1DSpatialGrid::path(SpatialGridPath* path) const
 
     if (q < 0.0)
     {
-        int imin = NR::locateClip(_rv, p);
-        rN = _rv[i];
-        qN = -sqrt((rN - p) * (rN + p));
+        int imin = NR::locate(_rv, p);  // returns -1 when p < rmin
         while (i > imin)
         {
+            rN = _rv[i];  // i >= 0 here
+            qN = -sqrt((rN - p) * (rN + p));
             int m = i;
             double ds = qN - q;
             path->addSegment(m, ds);
-            i--;
+            i--;  // i can become -1 here
             q = qN;
-            rN = _rv[i];
-            qN = -sqrt((rN - p) * (rN + p));
         }
     }
 
-    // Outward movement
+    // Outward movement (starting with i potentially -1)
 
-    rN = _rv[i + 1];
-    qN = sqrt((rN - p) * (rN + p));
     while (true)
     {
+        rN = _rv[i + 1];
+        qN = sqrt((rN - p) * (rN + p));
         int m = i;
         double ds = qN - q;
-        path->addSegment(m, ds);
+        path->addSegment(m, ds);  // m can be -1 here, as intended
         i++;
         if (i >= _Nr)
             return;
         else
-        {
             q = qN;
-            rN = _rv[i + 1];
-            qN = sqrt((rN - p) * (rN + p));
-        }
     }
 }
 

--- a/SKIRT/core/Sphere1DSpatialGrid.hpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.hpp
@@ -22,12 +22,13 @@ class Sphere1DSpatialGrid : public SphereSpatialGrid
     ITEM_CONCRETE(Sphere1DSpatialGrid, SphereSpatialGrid, "a spherically symmetric spatial grid")
         ATTRIBUTE_TYPE_ALLOWED_IF(Sphere1DSpatialGrid, "!Dimension2&!Dimension3")
 
-        PROPERTY_ITEM(meshRadial, Mesh, "the bin distribution in the radial direction")
-        ATTRIBUTE_DEFAULT_VALUE(meshRadial, "LinMesh")
-
         PROPERTY_DOUBLE(minRadius, "the inner radius of the grid")
         ATTRIBUTE_QUANTITY(minRadius, "length")
         ATTRIBUTE_MIN_VALUE(minRadius, "[0")
+        ATTRIBUTE_DEFAULT_VALUE(minRadius, "0")
+
+        PROPERTY_ITEM(meshRadial, Mesh, "the bin distribution in the radial direction")
+        ATTRIBUTE_DEFAULT_VALUE(meshRadial, "LinMesh")
 
     ITEM_END()
 

--- a/SKIRT/core/Sphere1DSpatialGrid.hpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.hpp
@@ -25,6 +25,10 @@ class Sphere1DSpatialGrid : public SphereSpatialGrid
         PROPERTY_ITEM(meshRadial, Mesh, "the bin distribution in the radial direction")
         ATTRIBUTE_DEFAULT_VALUE(meshRadial, "LinMesh")
 
+        PROPERTY_DOUBLE(minRadius, "the inner radius of the grid")
+        ATTRIBUTE_QUANTITY(minRadius, "length")
+        ATTRIBUTE_MIN_VALUE(minRadius, "[0")
+
     ITEM_END()
 
     //============= Construction - Setup - Destruction =============


### PR DESCRIPTION
**Description**
Sphere1DSpatialGrid gets an extra property 'minRadius', analogous to 'maxRadius' of the parent class SphereSpatialGrid.

**Motivation**
This is useful for running thin spherical shell models, for which the inner cavity is relatively large. It avoid having to introduce a large number of empty shells, and makes it more intuitive to match the grid boundary with the medium boundary.

**Tests**
I have attached two .ski files which should be equivalent. Unfortunately, the results are not exactly the same, since the photons are moved to the first cell when they are in the central cavity. But they should be statistically the same, if this was implemented correctly.
[shell_test.zip](https://github.com/SKIRT/SKIRT9/files/4225439/shell_test.zip)

**Context**
This has been implemented in Sphere1DSpatialGrid, and not the parent class 
SphereSpatialGrid, because the other subclass, Sphere2DSpatialGrid, is much more complicated and less frequently used.
