### PR TITLE
clamp values in tabulated dust mix

### DIFF
--- a/SKIRT/core/TabulatedDustMix.cpp
+++ b/SKIRT/core/TabulatedDustMix.cpp
@@ -26,9 +26,9 @@ double TabulatedDustMix::getOpticalProperties(const Array& lambdav, const Array&
     Array insigmascav = mu * inkappaextv * inalbedov;
 
     // resample to wavelength grid required by caller
-    sigmaabsv = NR::resample<NR::interpolateLogLog>(lambdav, inlambdav, insigmaabsv);
-    sigmascav = NR::resample<NR::interpolateLogLog>(lambdav, inlambdav, insigmascav);
-    asymmparv = NR::resample<NR::interpolateLogLin>(lambdav, inlambdav, inasymmparv);
+    sigmaabsv = NR::clampedResample<NR::interpolateLogLog>(lambdav, inlambdav, insigmaabsv);
+    sigmascav = NR::clampedResample<NR::interpolateLogLog>(lambdav, inlambdav, insigmascav);
+    asymmparv = NR::clampedResample<NR::interpolateLogLin>(lambdav, inlambdav, inasymmparv);
 
     return mu;
 }

--- a/SKIRT/core/TabulatedDustMix.hpp
+++ b/SKIRT/core/TabulatedDustMix.hpp
@@ -23,7 +23,9 @@
     set the absolute scale of the property, so that the cross sections listed by some of the probes
     have an appropriately scaled value.
 
-    Property values outside of the tabulated wavelength range are considered to be zero.
+    Property values outside of the tabulated wavelength range are clamped to the nearest border
+    value. As a special-case consequence, if only a single wavelength is tabulated, the properties
+    are considered to be constant for all wavelengths.
 
     The subclass must load the tabulated data, and this abstract class handles everything else. */
 class TabulatedDustMix : public DustMix

--- a/SKIRT/utils/NR.hpp
+++ b/SKIRT/utils/NR.hpp
@@ -410,6 +410,23 @@ public:
         return yresv;
     }
 
+    /** This template function resamples the function values \f$y_k\f$ defined on a grid \f$x_k\f$
+        (both specified as arrays of the same length) onto an new grid \f$x_l^*\f$. The result is
+        returned as an array of function values \f$y_l^*\f$ with the same length as the target
+        grid. For new grid points that fall beyond the original grid, the function value is set to
+        the value at the corresponding outer grid point, i.e. \f$y_0\f$ or \f$y_{n-1}\f$. For new
+        grid points inside the original grid, the function value is interpolated using the function
+        specified as template argument. The interpolation functions provided by this namespace can
+        be passed as a template argument for this purpose. */
+    template<double interpolateFunction(double, double, double, double, double)>
+    static inline Array clampedResample(const Array& xresv, const Array& xoriv, const Array& yoriv)
+    {
+        int n = xresv.size();
+        Array yresv(n);
+        for (int l = 0; l < n; l++) yresv[l] = clampedValue<interpolateFunction>(xresv[l], xoriv, yoriv);
+        return yresv;
+    }
+
     //=============== Constructing cumulative distribution functions ==================
 
 public:


### PR DESCRIPTION
**Description**
The tabulated dust mixes (List and File) now properly clamp values outside of the tabulated wavelength range to the values at the outer borders.

**Motivation**
There was an inconsistency between the documented and actual behavior.

**Tests**
All function tests run after the intended changes are accounted for.
