### PR TITLE
Parallel instruments output the extent of the spatial axes in angular units 

### DIFF
--- a/SKIRT/core/AllSkyInstrument.cpp
+++ b/SKIRT/core/AllSkyInstrument.cpp
@@ -71,7 +71,7 @@ void AllSkyInstrument::setupSelfBefore()
     // configure flux recorder with a large distance relative to the pixel size so that atan(s/2d) = s/2d
     // and the default calibration can be easily corrected when detecting each individual photon packet
     instrumentFluxRecorder()->setRestFrameDistance(_s * 1e8);
-    instrumentFluxRecorder()->includeSurfaceBrightness(_Nx, _Ny, _s, _s, 0, 0);
+    instrumentFluxRecorder()->includeSurfaceBrightness(_Nx, _Ny, _s, _s, 0, 0, false);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/FluxRecorder.hpp
+++ b/SKIRT/core/FluxRecorder.hpp
@@ -159,9 +159,12 @@ public:
         for each wavelength. The recorder assumes parallel projection at the specified distance
         from the model and using the specified frame properties. The number of pixels, and the
         pixel sizes are used to calibrate the surface brightness; the center coordinates are used
-        only for the metadata in the output file. */
+        only for the metadata in the output file. If the \em convertToAngularSize flag is true, the
+        coordinates and pixel sizes are converted to angular sizes before being written to the
+        metadata of the output file. If the flag is false, these values are left in distance units.
+        */
     void includeSurfaceBrightness(int numPixelsX, int numPixelsY, double pixelSizeX, double pixelSizeY, double centerX,
-                                  double centerY);
+                                  double centerY, bool convertToAngularSize);
 
     /** This function completes the configuration of the recorder. It must be called after any of
         the configuration functions, and before the first invocation of the detect() function. */
@@ -280,6 +283,7 @@ private:
     double _pixelSizeAverage{0};
     double _centerX{0};
     double _centerY{0};
+    bool _convertToAngularSize{false};
 
     // cached info, initialized when configuration is finalized
     MediumSystem* _ms{nullptr};   // pointer to medium system, if present (used only if hasMedium is true)

--- a/SKIRT/core/FrameInstrument.cpp
+++ b/SKIRT/core/FrameInstrument.cpp
@@ -15,7 +15,7 @@ void FrameInstrument::setupSelfBefore()
 
     // configure flux recorder
     instrumentFluxRecorder()->includeSurfaceBrightness(numPixelsX(), numPixelsY(), fieldOfViewX() / numPixelsX(),
-                                                       fieldOfViewY() / numPixelsY(), centerX(), centerY());
+                                                       fieldOfViewY() / numPixelsY(), centerX(), centerY(), true);
 
     // precalculate information needed by pixelOnDetector() function
     _costheta = cos(inclination());

--- a/SKIRT/core/PerspectiveInstrument.cpp
+++ b/SKIRT/core/PerspectiveInstrument.cpp
@@ -83,7 +83,7 @@ void PerspectiveInstrument::setupSelfBefore()
     // configure flux recorder with a large distance relative to the pixel size so that atan(s/2d) = s/2d
     // and the default calibration can be easily corrected when detecting each individual photon packet
     instrumentFluxRecorder()->setRestFrameDistance(_s * 1e8);
-    instrumentFluxRecorder()->includeSurfaceBrightness(_Nx, _Ny, _s, _s, 0, 0);
+    instrumentFluxRecorder()->includeSurfaceBrightness(_Nx, _Ny, _s, _s, 0, 0, false);
 }
 
 ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
The parallel instruments (FrameInstrument, FullInstrument) now output the extent of the spatial axes in FITS data cubes in angular units corresponding to the distance or redshift from the instrument to the simulated model, as opposed to using rest-frame model distances. The values of the surface brightness pixels in the data cubes do NOT change.

**Motivation**
These new units make a lot more sense observationally, especially when considering models at nonzero redshift.

**Tests**
All functional tests still produced the same results, modulo the intended change.

**Context**
The other instruments (e.g. AllSkyInstrument and PerspectiveInstrument) and all probes are considered to operate in the model rest frame and therefore still output rest-frame model distances for the spatial axes.
