### PR TITLE
Fix default number surface density for stellar units

### DIFF
--- a/SKIRT/core/SkirtUnitDef.cpp
+++ b/SKIRT/core/SkirtUnitDef.cpp
@@ -360,7 +360,7 @@ SkirtUnitDef::SkirtUnitDef()
     addDefaultUnit("StellarUnits", "masssurfacedensity", "Msun/AU2");
     addDefaultUnit("StellarUnits", "massvolumedensity", "Msun/AU3");
     addDefaultUnit("StellarUnits", "massrate", "Msun/yr");
-    addDefaultUnit("StellarUnits", "numbersurfacedensity", "1/cm3");
+    addDefaultUnit("StellarUnits", "numbersurfacedensity", "1/cm2");
     addDefaultUnit("StellarUnits", "numbervolumedensity", "1/cm3");
     addDefaultUnit("StellarUnits", "masscoefficient", "m2/kg");
     addDefaultUnit("StellarUnits", "time", "Gyr");


### PR DESCRIPTION
**Description**
Fixed the default value of the number surface density unit in the StellarUnit system.

**Motivation**
Q&A crashed when entering normalization on number surface density when using stellar units.

**Tests**
Added new test case. Other tests cases still run.

**Context**
Error report by Bert Vander Meulen.
