### PR TITLE
Fix bug in optimization of instruments with the same line of sight

### DIFF
--- a/SKIRT/core/InstrumentSystem.cpp
+++ b/SKIRT/core/InstrumentSystem.cpp
@@ -14,10 +14,8 @@ void InstrumentSystem::setupSelfAfter()
     Instrument* preceding = nullptr;
     for (Instrument* instrument : _instruments)
     {
-        if (!preceding)
-            preceding = instrument;
-        else
-            instrument->determineSameObserverAsPreceding(preceding);
+        if (preceding) instrument->determineSameObserverAsPreceding(preceding);
+        preceding = instrument;
     }
 }
 


### PR DESCRIPTION
**Description**
This change fixes a bug in the optimization of consecutive instruments with the same line of sight. In some cases, an instrument would incorrectly use the line of sight of the previous instrument instead of its own line of sight.

**Motivation**
The previous behavior was incorrect.

**Tests**
All functional tests still run and a new test has been added for this particular problem.

**Context**
Thank you to @anatrcka for reporting this problem.
