### PR TITLE
Warning message for incorrect installed resource pack version

### DIFF
--- a/SKIRT/core/FilePaths.cpp
+++ b/SKIRT/core/FilePaths.cpp
@@ -20,8 +20,14 @@ namespace
     // the resource paths:  <filename, complete_path>
     std::unordered_map<string, string> _resourcePaths;
 
-    // the resource pack version numbers:  <packname, version>
-    std::unordered_map<string, int> _packVersions;
+    // the expected resource pack names
+    vector<string> _expectedPacks;
+
+    // the expected resource pack version numbers:  <packname, version>
+    std::unordered_map<string, int> _expectedPackVersions;
+
+    // the installed resource pack version numbers:  <packname, version>
+    std::unordered_map<string, int> _installedPackVersions;
 
     // relative paths to check for presence of built-in resources
     const char* _intpaths[] = {"../../../git/SKIRT/resources", "../../../../git/SKIRT/resources"};
@@ -31,9 +37,10 @@ namespace
     const char* _extpaths[] = {"../../../resources", "../../../../resources"};
     const int _Nextpaths = sizeof(_extpaths) / sizeof(const char*);
 
-    // recursively searches the given directory and its subdirectories for any files
-    // and adds the corresponding canonical paths to the resource dictionary
-    void findResourcePathsIn(string directory)
+    // recursively searches the given directory and its subdirectories for any files,
+    // adds the corresponding canonical paths to the resource dictionary,
+    // and processes any "version.txt" files encountered
+    void findResourcesIn(string directory)
     {
         // search the current level
         for (const string& filename : System::filesInDirectory(directory))
@@ -41,23 +48,24 @@ namespace
             if (!_resourcePaths.count(filename))
                 _resourcePaths.emplace(filename, System::canonicalPath(StringUtils::joinPaths(directory, filename)));
 
-            // remember the version numbers for each resource pack
+            // remember the name and version number for each installed resource pack
             if (filename == "version.txt")
             {
                 auto segments = StringUtils::split(directory, "_");
                 if (segments.size() > 1)
                 {
-                    string packname = segments[segments.size()-1];
-                    int version = 0;
+                    string packname = segments[segments.size() - 1];
+                    int packversion = 0;
                     try
                     {
                         std::ifstream versionfile(StringUtils::joinPaths(directory, filename));
-                        versionfile >> version;
+                        versionfile >> packversion;
                     }
-                    catch (...) {};
+                    catch (...)
+                    {};
 
-                    if (!_packVersions.count(packname) && version > 0)
-                        _packVersions.emplace(packname, version);
+                    if (packversion > 0 && !_installedPackVersions.count(packname))
+                        _installedPackVersions.emplace(packname, packversion);
                 }
             }
         }
@@ -65,12 +73,39 @@ namespace
         // search the subdirectories
         for (const string& subdirname : System::dirsInDirectory(directory))
         {
-            findResourcePathsIn(StringUtils::joinPaths(directory, subdirname));
+            findResourcesIn(StringUtils::joinPaths(directory, subdirname));
         }
     }
 
-    // populates the dictionary with resource paths, or throws an error if there is a problem
-    void findResourcePaths()
+    // parses the list of expected resource packs, if present, and stores the results
+    // !! assumes that the dictionary with resource paths has already been populated !!
+    void readExpectedPacks()
+    {
+        if (_resourcePaths.count("ExpectedResources.txt"))
+        {
+            try
+            {
+                std::ifstream expectedfile(_resourcePaths.at("ExpectedResources.txt"));
+                while (expectedfile.good())
+                {
+                    string packname;
+                    int packversion = 0;
+                    expectedfile >> packname >> packversion;
+                    if (!packname.empty() && packversion > 0 && !_expectedPackVersions.count(packname))
+                    {
+                        _expectedPacks.emplace_back(packname);
+                        _expectedPackVersions.emplace(packname, packversion);
+                    }
+                }
+            }
+            catch (...)
+            {};
+        }
+    }
+
+    // populates the dictionary with resource paths and gathers resource pack information,
+    // or throws a fatal error if there is a problem
+    void findResources()
     {
         // get the executable path (or the empty string in case of failure)
         string executableFilePath = System::executablePath();
@@ -83,7 +118,7 @@ namespace
         for (int i = 0; i < _Nintpaths; i++)
         {
             string test = StringUtils::joinPaths(executableDirPath, _intpaths[i]);
-            if (System::isDir(test)) findResourcePathsIn(test);
+            if (System::isDir(test)) findResourcesIn(test);
         }
 
         // at this point we should have found at least some internal resources
@@ -94,8 +129,37 @@ namespace
         for (int i = 0; i < _Nextpaths; i++)
         {
             string test = StringUtils::joinPaths(executableDirPath, _extpaths[i]);
-            if (System::isDir(test)) findResourcePathsIn(test);
+            if (System::isDir(test)) findResourcesIn(test);
         }
+
+        // parse the list of expected resource packs, if present
+        readExpectedPacks();
+    }
+
+    // returns true if the resource filename matches the requirements, false otherwise;
+    // see documentation of the resourceName() function for more details
+    bool matches(string resource, string type, const vector<string>& segments)
+    {
+        if (!StringUtils::endsWith(resource, type)) return false;
+        for (string segment : segments)
+        {
+            if (!StringUtils::contains(resource, segment)) return false;
+        }
+        return true;
+    }
+
+    // returns a human-readable message describing the specified requirements;
+    // see documentation of the resourceName() function for more details
+    string message(string type, const vector<string>& segments)
+    {
+        string msg = "type '" + type + "'";
+        if (!segments.empty())
+        {
+            msg += " with filename containing";
+            for (string segment : segments) msg += " '" + segment + "',";
+            msg.erase(msg.size() - 1, 1);
+        }
+        return msg;
     }
 }
 
@@ -111,7 +175,7 @@ FilePaths::FilePaths(SimulationItem* parent)
 void FilePaths::setupSelfBefore()
 {
     SimulationItem::setupSelfBefore();
-    std::call_once(_initialized, findResourcePaths);
+    std::call_once(_initialized, findResources);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -127,6 +191,14 @@ void FilePaths::setInputPath(string value)
 string FilePaths::inputPath() const
 {
     return _inputPath;
+}
+
+////////////////////////////////////////////////////////////////////
+
+string FilePaths::input(string name) const
+{
+    if (StringUtils::isAbsolutePath(name)) return name;
+    return _inputPath + name;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -160,14 +232,6 @@ string FilePaths::outputPrefix() const
 
 ////////////////////////////////////////////////////////////////////
 
-string FilePaths::input(string name) const
-{
-    if (StringUtils::isAbsolutePath(name)) return name;
-    return _inputPath + name;
-}
-
-////////////////////////////////////////////////////////////////////
-
 string FilePaths::output(string name) const
 {
     return _outputPath + _outputPrefix + "_" + name;
@@ -177,8 +241,7 @@ string FilePaths::output(string name) const
 
 string FilePaths::resource(string name)
 {
-    // initialize the resource paths if needed
-    std::call_once(_initialized, findResourcePaths);
+    std::call_once(_initialized, findResources);
 
     if (!_resourcePaths.count(name))
     {
@@ -191,51 +254,9 @@ string FilePaths::resource(string name)
 
 ////////////////////////////////////////////////////////////////////
 
-bool FilePaths::hasResource(std::string name)
-{
-    // initialize the resource paths if needed
-    std::call_once(_initialized, findResourcePaths);
-
-    return _resourcePaths.count(name) > 0;
-}
-
-////////////////////////////////////////////////////////////////////
-
-namespace
-{
-    // returns true if the resource filename matches the requirements, false otherwise;
-    // see documentation of the resourceName() function for more details
-    bool matches(string resource, string type, const vector<string>& segments)
-    {
-        if (!StringUtils::endsWith(resource, type)) return false;
-        for (string segment : segments)
-        {
-            if (!StringUtils::contains(resource, segment)) return false;
-        }
-        return true;
-    }
-
-    // returns a human-readable message describing the specified requirements;
-    // see documentation of the resourceName() function for more details
-    string message(string type, const vector<string>& segments)
-    {
-        string msg = "type '" + type + "'";
-        if (!segments.empty())
-        {
-            msg += " with filename containing";
-            for (string segment : segments) msg += " '" + segment + "',";
-            msg.erase(msg.size() - 1, 1);
-        }
-        return msg;
-    }
-}
-
-////////////////////////////////////////////////////////////////////
-
 string FilePaths::resourceName(string type, const vector<string>& segments)
 {
-    // initialize the resource paths if needed
-    std::call_once(_initialized, findResourcePaths);
+    std::call_once(_initialized, findResources);
 
     // look for matching resource filename
     string result;
@@ -252,6 +273,33 @@ string FilePaths::resourceName(string type, const vector<string>& segments)
     // fail if not found
     if (result.empty()) throw FATALERROR("No resources matching " + message(type, segments));
     return result;
+}
+
+////////////////////////////////////////////////////////////////////
+
+vector<string> FilePaths::expectedPacks()
+{
+    std::call_once(_initialized, findResources);
+
+    return _expectedPacks;
+}
+
+////////////////////////////////////////////////////////////////////
+
+int FilePaths::expectedPackVersion(string name)
+{
+    std::call_once(_initialized, findResources);
+
+    return _expectedPackVersions.count(name) ? _expectedPackVersions.at(name) : 0;
+}
+
+////////////////////////////////////////////////////////////////////
+
+int FilePaths::installedPackVersion(string name)
+{
+    std::call_once(_initialized, findResources);
+
+    return _installedPackVersions.count(name) ? _installedPackVersions.at(name) : 0;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/FilePaths.cpp
+++ b/SKIRT/core/FilePaths.cpp
@@ -20,6 +20,9 @@ namespace
     // the resource paths:  <filename, complete_path>
     std::unordered_map<string, string> _resourcePaths;
 
+    // the resource pack version numbers:  <packname, version>
+    std::unordered_map<string, int> _packVersions;
+
     // relative paths to check for presence of built-in resources
     const char* _intpaths[] = {"../../../git/SKIRT/resources", "../../../../git/SKIRT/resources"};
     const int _Nintpaths = sizeof(_intpaths) / sizeof(const char*);
@@ -37,6 +40,26 @@ namespace
         {
             if (!_resourcePaths.count(filename))
                 _resourcePaths.emplace(filename, System::canonicalPath(StringUtils::joinPaths(directory, filename)));
+
+            // remember the version numbers for each resource pack
+            if (filename == "version.txt")
+            {
+                auto segments = StringUtils::split(directory, "_");
+                if (segments.size() > 1)
+                {
+                    string packname = segments[segments.size()-1];
+                    int version = 0;
+                    try
+                    {
+                        std::ifstream versionfile(StringUtils::joinPaths(directory, filename));
+                        versionfile >> version;
+                    }
+                    catch (...) {};
+
+                    if (!_packVersions.count(packname) && version > 0)
+                        _packVersions.emplace(packname, version);
+                }
+            }
         }
 
         // search the subdirectories

--- a/SKIRT/core/FilePaths.hpp
+++ b/SKIRT/core/FilePaths.hpp
@@ -11,7 +11,61 @@
 ////////////////////////////////////////////////////////////////////
 
 /** The FilePaths class manages the paths for the input and output files of a simulation, and for
-    the resources included with the code or provided externally. */
+    the resources included with the code or provided externally.
+
+    <b>Input and output files</b>
+
+    A client program determines the input and output file paths and the prefix for output file
+    names, presumably from the command line options. It then stores this information in the
+    FilePaths instance held by the simulation, so that the simulation hierarchy can easily access
+    it.
+
+    <b>Resource files</b>
+
+    The FilePaths class also offers static functions for locating the resource files used by the
+    simulation hierarchy. These files can be provided as part of the build tree in the source code
+    repository, or can be installed in a directory next to (and thus outside of) the build tree.
+    This mechanism allows to provide small and frequently-used resource files as part of the source
+    code repository, while requiring larger resource files to be downloaded seperately.
+
+    Resource files are identified by their filename, without any directory or path information. In
+    other words, a given resource file could be located in any of the supported directories (or
+    nested subdirectory). On the other hand, this means there can be only a single resource with a
+    particular name.
+
+    Specifically, when first invoked, the FilePaths class builds a list of all available resource
+    files by iterating over the following directories and all nested subdirectories inside these
+    directories, recursively:
+
+    - the \c resources directory inside the SKIRT build tree.
+
+    - the \c resources directory (if any) next to the SKIRT \c git directory (i.e. outside of the
+    build tree).
+
+    The top-level directories are iterated in the order listed above. The iteration order for the
+    nested subdirectories inside the top-level directories is unspecified. The first occurrence of
+    a particular filename is stored; any subsequent occurrences of the same filename are ignored.
+
+    <b>Resource packs</b>
+
+    Finally, the FilePaths class offers static functions that support versioning for resource \em
+    packs, which are usually installed in the resource directory outside of the build tree.
+
+    A resource pack is a set of resource files contained in a resource subdirectory, called the
+    pack directory, that contains a file named \c version.txt. The first token in this text file's
+    contents is interpreted as the integer version number of the resource pack. The name of the
+    resource pack is determined by the segment of the pack directory name after the last
+    underscore. The resource files in the pack can reside in nested subdirectories.
+
+    Furthermore, a resource file named \c ExpectedResources.txt can be provided as part of the
+    build tree. This text file lists the names and version numbers of the resource packs expected
+    to be installed, one pack name and corresponding version number per line.
+
+    The FilePaths class offers functions to retrieve information on the expected and installed
+    resource packs from these files. This information can be used by the client program to verify
+    that the appropriate resource pack versions have been installed.
+
+    */
 class FilePaths : public SimulationItem
 {
     //============= Construction - Setup - Destruction =============
@@ -28,7 +82,7 @@ protected:
         any problems as early as possible in the program's lifecycle. */
     void setupSelfBefore() override;
 
-    //======== Setters & Getters for Discoverable Attributes =======
+    //======== Input and output file paths and names =======
 
 public:
     /** Sets the (absolute or relative) path for input files. An empty string (the default value)
@@ -37,6 +91,10 @@ public:
 
     /** Returns the (absolute or relative) path for input files. */
     string inputPath() const;
+
+    /** This function returns the absolute canonical path for an input file with the specified
+        name, relative to the input path returned by inputPath(). */
+    string input(string name) const;
 
     /** Sets the (absolute or relative) path for output files. An empty string (the default value)
         means the current directory. */
@@ -51,55 +109,48 @@ public:
     /** Returns the prefix for output file names. */
     string outputPrefix() const;
 
-    //======================== Other Functions =======================
-
-public:
-    /** This function returns the absolute canonical path for an input file with the specified
-        name, relative to the input path returned by inputPath(). */
-    string input(string name) const;
-
     /** This function returns the absolute canonical path for an output file with the specified
         name, relative to the output path returned by outputPath(). The prefix returned by
         outputPrefix() is inserted in front of the filename specified here. The prefix and the
         filename are separated by an underscore. */
     string output(string name) const;
 
-    /** This function returns the absolute canonical path for a resource with the specified
+    //======================== Resource files =======================
+
+public:
+    /** This function returns the absolute canonical path for a resource file with the specified
         filename. The filename should \em not include any directory segments (just the base
-        filename and filename extension). The function first searches resource files provided as
-        part of the SKIRT build tree in the source code repository, and then searches resource
-        files installed in a directory next to (and thus outside of) the SKIRT build tree. This
-        mechanism allows to provide small and frequently-used resource files as part of the source
-        code repository, while requiring larger resource files to be downloaded seperately.
-
-        Specifically, the function searches the following directories, and all nested
-        subdirectories inside these directories, recursively:
-
-        - the \c resources directory inside the SKIRT build tree.
-        - the \c resources directory (if any) next to the SKIRT \c git directory (i.e. outside of
-          the build tree).
-
-        The top-level directories are searched in the order listed above. The search order for the
-        nested directories inside the top-level directories is unspecified. The first occurrence of
-        the specified filename terminates the search. If the function cannot locate the specified
-        resource, a fatal error is thrown. */
+        filename and filename extension). The function searches the list of available resource
+        files as described in the class header. If the specified resource file cannot be located, a
+        fatal error is thrown. */
     static string resource(string name);
 
-    /** This function returns true if a resource with the specified filename is found, and false if
-        not. This function operates just like the resource() function, except that it does not
-        throw an error if the requested resource is not found. */
-    static bool hasResource(string name);
+    /** This function returns the filename (without directory segments) for a resource file with
+        the specified type and with a filename including the specified segments. The function
+        searches the list of available resource files as described in the class header.
 
-    /** This function returns the filename (without directory segments) for a resource with the
-        specified type and with a filename including the specified segments. The list of resources
-        scanned by this function is the same as that described for the resource() function.
-
-        For a resource to be considered by this function, the end of its filename (including the
-        filename extension) must match the specified type string, and the filename must also
-        contain each of the specified segments. If no resources or multiple resources match these
-        requirements, the function throws a fatal error. If a single resource matches, the function
-        returns its filename. */
+        For a resource file to be considered by this function, the end of its filename (including
+        the filename extension) must match the specified type string, and the filename must also
+        contain each of the specified segments. If no or multiple resources files match these
+        requirements, the function throws a fatal error. If a single resource file matches, the
+        function returns its filename. */
     static string resourceName(string type, const vector<string>& segments);
+
+    //======================== Resource packs =======================
+
+public:
+    /** This function returns a list of the names of all expected packs, in the order listed in the
+        \c ExpectedResources.txt resource file, or the empty list if that resource file is missing
+        or empty. */
+    static vector<string> expectedPacks();
+
+    /** This function returns the expected version number for the resource pack with the specified
+        name, or zero if the name is not in the list of expected packs. */
+    static int expectedPackVersion(string name);
+
+    /** This function returns the version number for the installed resource pack with the specified
+        name, or zero if the pack is not installed. */
+    static int installedPackVersion(string name);
 
     //======================== Data Members ========================
 


### PR DESCRIPTION
**Description**
SKIRT now logs a warning message both on the console and in each simulation's log file when one of the following issues arise:
  - the Core resource pack is not installed;
  - the version number of any installed resource pack does not match the expected version.

**Motivation**
We will shortly be releasing a new version of the Core resource pack with a small change that is hard to detect without verifying the version number. It is therefore important to notify users if they have the incorrect version installed.

**Tests**
All functional tests still run.
