### PR TITLE
Remove the carbon emission lines from the Mappings dust continuum

### DIFF
--- a/SKIRT/resources/ExpectedResources.txt
+++ b/SKIRT/resources/ExpectedResources.txt
@@ -1,1 +1,1 @@
-Core 2
+Core 3


### PR DESCRIPTION
**Description**
Increase the expected version of the Core resource pack from 2 to 3. The updated resource pack must be downloaded separately by running `./downloadResources.sh` from the `~SKIRT/git' directory. It contains a version of the Mappings SED family templates from which the three overly prominent Carbon emission lines have been removed from the dust continuum.

**Motivation**
The problem is that these emission lines are defined in the templates through just a single point in a coarse wavelength grid. As a result they are much wider than they should be and thus they carry much more energy than physically justified. The plot below shows the original templates in reddish color and the adjusted templates (overplotted) in blueish color. The dots show convolved fluxes for the Herschel bands. As you can see, in the original templates the convolved fluxes are too far above the continuum curve; this is fixed in the adjusted templates.

<img width="457" alt="Afbeelding-1" src="https://user-images.githubusercontent.com/7975955/81556880-59875500-938b-11ea-881a-13200e5c7c77.png">

The offending lines are the [CII] line at 158 micron and the [CI] lines at 370 and 609 micron. According to results published by Rosenberg et al. (2015) for some galaxies from the HerCULES survey, the contribution of the [CII] line to the total FIR flux is a few times 0.1%, whereas the joint contribution of the two [CI] lines is more than an order of magnitude lower. So it is certainly justified to cut the overly energetic line definitions from the Mappings templates.

**Tests**
The updated Mappings templates have been tested by investigating SKIRT results for various template parameter values. The other resource files are identical to the previous version.

**Context**
For determining the fluxes published in the EAGLE database (calculated by SKIRT using the Mappings templates), these same three line definitions were removed from the SKIRT output spectrum after the fact. This is no longer an option in SKIRT 9 when using a broadband wavelength grid, because the instrument then performs on-the-fly convolution of the spectrum with the filter.
