### PR TITLE
HEALPixSkyInstrument flux calibration

### DIFF
--- a/SKIRT/core/AllSkyInstrument.hpp
+++ b/SKIRT/core/AllSkyInstrument.hpp
@@ -14,19 +14,31 @@
 
 /** The AllSkyInstrument class implements an all-sky view of the simulated model, with arbitrary
     placement of the observer outside or inside the model. The instrument's sky is transformed to a
-    rectangular image (for each wavelength) using one of the available all-sky projections.
+    rectangular image (for each wavelength) using one of the available all-sky projections. (See
+    the HEALPixSkyInstrument class for an instrument that does \em not perform such a projection).
 
-    Specifically, an all-sky instrument consists of a sphere with a given radius, centered at the
-    location of the instrument, on which model's radiation is projected. When a peel-off photon
-    packet arrives, the spherical coordinates of its origin relative to the instrument location are
-    determined. The two resulting angular coordinates are transformed to pixel coordinates in the
-    image frame using the selected all-sky projection. The radial coordinate (i.e. the distance
-    from the photon packet's origin to the instrument location) is used for converting the photon
-    packet's luminosity contribution to a flux density. In addition to the distance, this
-    conversion also requires a pixel size, which is determined from the radius of the instrument's
-    sphere (this is in fact the only purpose for specifying this quantity).
+    An all-sky instrument consists of a sphere with a given radius, centered at the location of the
+    instrument, on which model's radiation is projected. When a peel-off photon packet arrives, the
+    spherical coordinates of its origin relative to the instrument location are determined. The two
+    resulting angular coordinates are transformed to pixel coordinates in the image frame using the
+    selected all-sky projection. The radial coordinate (i.e. the distance from the photon packet's
+    origin to the instrument location) is used for converting the photon packet's luminosity
+    contribution to a flux density. In addition to the distance, this conversion also requires a
+    pixel size, which is determined from the radius of the instrument's sphere (this is in fact the
+    only purpose for specifying this quantity).
 
-    The all-sky instrument does \em not seperately record an integrated flux density. */
+    The surface brightness calibration for this instrument (as for the HEALPixSkyInstrument) is
+    tricky. While the angular size of the individual pixels is known, the angular size of the
+    pixels as seen from a distant object is not, since the pixels do not have an actual physical
+    size. We can define such a physical size by defining a radius for the instrument, which is then
+    used to convert the angular size to a physical size. This radius is quite arbitrary, but should
+    nonetheless be chosen with some care: if the radius is too small, then recorded flux values
+    will be very high or even overflow. A good rule of thumb is to use a radius that has a similar
+    size to your object of study. For example, for a galaxy, with sizes in kpc, a radius of 1 pc
+    works well. It is always possible to recalibrate the fluxes afterwards by using the same radius
+    and adjusting to the pixel size of an actual instrument.
+
+    This instrument does \em not seperately record spatially integrated flux densities. */
 class AllSkyInstrument : public Instrument
 {
     ITEM_CONCRETE(AllSkyInstrument, Instrument, "an all-sky instrument (for observing inside a model)")

--- a/SKIRT/core/HEALPixSkyInstrument.cpp
+++ b/SKIRT/core/HEALPixSkyInstrument.cpp
@@ -33,7 +33,8 @@ void HEALPixSkyInstrument::setupSelfBefore()
     // determine linear size of a single pixel
     // each HEALPix pixel has the same spherical area pi/(3*_Nside^2)
     // we assume that the pixels are squares with this surface area
-    _s = sqrt(M_PI / (3 * _Nside * _Nside));
+    // due to the calibration of the FrameInstrument, we need to multiply this with the radius of the instrument
+    _s = sqrt(M_PI / (3 * _Nside * _Nside)) * _radius;
 
     // setup the transformation from world to observer coordinates
 

--- a/SKIRT/core/HEALPixSkyInstrument.hpp
+++ b/SKIRT/core/HEALPixSkyInstrument.hpp
@@ -12,11 +12,12 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** The HEALPixSkyInstrument provides an all-sky instrument that does not perform any projection,
-    but instead records fluxes onto a HEALPix tessellation of the sky sphere that guarantees equal
-    surface areas for all pixels.
+/** The HEALPixSkyInstrument class provides an all-sky instrument that does not perform any
+    projection, but instead records fluxes onto a HEALPix tessellation of the sky sphere that
+    guarantees equal surface areas for all pixels. (See the AllSkyInstrument class for an
+    instrument that does perform a projection).
 
-    The instrument is based on the official HEALPix algorithm by Górski, K. M. et al. (2005)
+    This class is based on the official HEALPix algorithm by Górski, K. M. et al. (2005)
     (https://ui.adsabs.harvard.edu/abs/2005ApJ...622..759G/abstract), as available from
     https://healpix.sourceforge.io, but only uses the relevant part of the algorithm.
 
@@ -64,16 +65,18 @@
     existing 2D image functionality for output, and that we can easily map output pixels to the
     corresponding HEALPix pixels in ring ordering during analysis.
 
-    Note that the flux calibration for this instrument (as for the AllSkyInstrument) is not
-    clearly defined. While the angular size of the individual HEALPix pixels is known, the
-    angular size of the pixels as seen from a distant object is not, since the pixels do not
-    have an actual physical size. We can define such a physical size by defining a radius for
-    the instrument, which is then used to convert the angular size to a physical size. This radius
-    is quite arbitrary, but should nonetheless be chosen with some care: if the radius is too small,
-    then recorded flux values will be very high or even overflow. A good rule of thumb is to use a
-    radius that has a similar size to your object of study. For e.g. a galaxy (sizes in kpc), a radius of
-    1 pc works well. It is always possible to recalibrate the fluxes afterwards by using the same
-    radius and adjusting to the pixel size of an actual instrument. */
+    The surface brightness calibration for this instrument (as for the AllSkyInstrument) is tricky.
+    While the angular size of the individual HEALPix pixels is known, the angular size of the
+    pixels as seen from a distant object is not, since the pixels do not have an actual physical
+    size. We can define such a physical size by defining a radius for the instrument, which is then
+    used to convert the angular size to a physical size. This radius is quite arbitrary, but should
+    nonetheless be chosen with some care: if the radius is too small, then recorded flux values
+    will be very high or even overflow. A good rule of thumb is to use a radius that has a similar
+    size to your object of study. For example, for a galaxy, with sizes in kpc, a radius of 1 pc
+    works well. It is always possible to recalibrate the fluxes afterwards by using the same radius
+    and adjusting to the pixel size of an actual instrument.
+
+    This instrument does \em not seperately record spatially integrated flux densities. */
 class HEALPixSkyInstrument : public Instrument
 {
     ITEM_CONCRETE(HEALPixSkyInstrument, Instrument,

--- a/SKIRT/core/HEALPixSkyInstrument.hpp
+++ b/SKIRT/core/HEALPixSkyInstrument.hpp
@@ -62,7 +62,18 @@
     \f$4N_\mathrm{side}^2-16N\f$ pixels in the polar regions, similar to the empty pixels in
     projected AllSkyInstrument images. The advantage of this approach is that we can easily use the
     existing 2D image functionality for output, and that we can easily map output pixels to the
-    corresponding HEALPix pixels in ring ordering during analysis. */
+    corresponding HEALPix pixels in ring ordering during analysis.
+
+    Note that the flux calibration for this instrument (as for the AllSkyInstrument) is not
+    clearly defined. While the angular size of the individual HEALPix pixels is known, the
+    angular size of the pixels as seen from a distant object is not, since the pixels do not
+    have an actual physical size. We can define such a physical size by defining a radius for
+    the instrument, which is then used to convert the angular size to a physical size. This radius
+    is quite arbitrary, but should nonetheless be chosen with some care: if the radius is too small,
+    then recorded flux values will be very high or even overflow. A good rule of thumb is to use a
+    radius that has a similar size to your object of study. For e.g. a galaxy (sizes in kpc), a radius of
+    1 pc works well. It is always possible to recalibrate the fluxes afterwards by using the same
+    radius and adjusting to the pixel size of an actual instrument. */
 class HEALPixSkyInstrument : public Instrument
 {
     ITEM_CONCRETE(HEALPixSkyInstrument, Instrument,


### PR DESCRIPTION
**Description**
This pull request fixes the calibration of the fluxes within the HEALPixSkyInstrument.

**Motivation**
The flux calibration for the HEALPixSkyInstrument (and the AllSkyInstrument as well) is ill defined, since the pixels of the instrument only have an angular size, and no associated physical size. As a result, it is impossible to determine what the angular size of a pixel is as seen from a distant object. This size is however required to properly normalise the flux coming from that object.
The solution (as also used by the AllSkyInstrument) is to assume a physical radius for the instrument. This radius can be used to convert angular sizes into physical sizes, fixing the angular size of the pixels for all objects. The choice of radius is in principle arbitrary, but should still be somewhat sensible: choosing a value of 1 (as was done in the original HEALPixSkyInstrument) leads to a very large prefactor in the flux calibration that can easily lead to numerical overflow and `inf` fluxes. The arbitrary radius is hence best chosen more carefully (e.g. a radius of pc size for a galactic simulation).

**Tests**
The file [singlesource.zip](https://github.com/SKIRT/SKIRT9/files/4785579/singlesource.zip) contains a simple test with a single source that emits radiation at a single wavelength. The source is observed by two instruments: a FrameInstrument at 10 Mpc and a HEALPixSkyInstrument at 1 kpc. The included Python script analyses the results. Both instruments have a single pixel that is non-zero, and we can analytically predict the value of that pixel given the known distance to the instrument and the size of the pixel. For the FrameInstrument, we can recover the flux with an accuracy of 0.1%. For the HEALPixSkyInstrument we can do the same when taking the radius of the instrument into account. An interesting side effect is that we can also recover the correct flux by assuming that the source is at the distance of the instrument radius and is recorded by a pixel with the actual angular size of the pixel in the instrument. This last bit is not part of the Python script.