### PR TITLE
Repeatlog

### DIFF
--- a/SKIRT/core/Simulation.cpp
+++ b/SKIRT/core/Simulation.cpp
@@ -34,6 +34,20 @@ void Simulation::setupAndRun()
     // setup and run the simulation
     setupSimulation();
     runSimulation();
+
+    // repeat any warnings and errors that have been issued during this simulation
+    vector<string> messages = _log->warningsIssued();
+    if (!messages.empty())
+    {
+        _log->warning("The following warning messages were issued during this simulation:", false);
+        for (const string& message : messages) _log->warning("  " + message, false);
+    }
+    messages = _log->errorsIssued();
+    if (!messages.empty())
+    {
+        _log->error("The following error messages were issued during this simulation:", false);
+        for (const string& message : messages) _log->error("  " + message, false);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/Simulation.cpp
+++ b/SKIRT/core/Simulation.cpp
@@ -36,17 +36,20 @@ void Simulation::setupAndRun()
     runSimulation();
 
     // repeat any warnings and errors that have been issued during this simulation
-    vector<string> messages = _log->warningsIssued();
-    if (!messages.empty())
+    if (ProcessManager::isRoot())
     {
-        _log->warning("The following warning messages were issued during this simulation:", false);
-        for (const string& message : messages) _log->warning("  " + message, false);
-    }
-    messages = _log->errorsIssued();
-    if (!messages.empty())
-    {
-        _log->error("The following error messages were issued during this simulation:", false);
-        for (const string& message : messages) _log->error("  " + message, false);
+        vector<string> messages = _log->warningsIssued();
+        if (!messages.empty())
+        {
+            _log->warning("The following warning messages were issued during this simulation:", false);
+            for (const string& message : messages) _log->warning("  " + message, false);
+        }
+        messages = _log->errorsIssued();
+        if (!messages.empty())
+        {
+            _log->error("The following error messages were issued during this simulation:", false);
+            for (const string& message : messages) _log->error("  " + message, false);
+        }
     }
 }
 

--- a/SKIRT/core/Simulation.cpp
+++ b/SKIRT/core/Simulation.cpp
@@ -41,13 +41,19 @@ void Simulation::setupAndRun()
         vector<string> messages = _log->warningsIssued();
         if (!messages.empty())
         {
-            _log->warning("The following warning messages were issued during this simulation:", false);
+            if (messages.size() == 1)
+                _log->warning("The following warning message was issued during this simulation:", false);
+            else
+                _log->warning("The following warning messages were issued during this simulation:", false);
             for (const string& message : messages) _log->warning("  " + message, false);
         }
         messages = _log->errorsIssued();
         if (!messages.empty())
         {
-            _log->error("The following error messages were issued during this simulation:", false);
+            if (messages.size() == 1)
+                _log->error("The following error message was issued during this simulation:", false);
+            else
+                _log->error("The following error messages were issued during this simulation:", false);
             for (const string& message : messages) _log->error("  " + message, false);
         }
     }

--- a/SKIRT/main/SkirtCommandLineHandler.cpp
+++ b/SKIRT/main/SkirtCommandLineHandler.cpp
@@ -120,23 +120,6 @@ namespace
         log->info("Available memory: " + StringUtils::toMemSizeString(avail) + " -- Peak memory usage: "
                   + StringUtils::toMemSizeString(peak) + " (" + StringUtils::toString(peakPerCent, 'f', 1) + "%)");
     }
-
-    // repeat errors and warnings that have been stored by the specified log instance
-    void repeatErrorsAndWarnings(Log* log)
-    {
-        vector<string> messages = log->warningsIssued();
-        if (!messages.empty())
-        {
-            log->warning("The following warning messages were issued during this simulation:", false);
-            for (const string& message : messages) log->warning("  " + message, false);
-        }
-        messages = log->errorsIssued();
-        if (!messages.empty())
-        {
-            log->error("The following error messages were issued during this simulation:", false);
-            for (const string& message : messages) log->error("  " + message, false);
-        }
-    }
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -383,7 +366,6 @@ void SkirtCommandLineHandler::doSimulation(size_t index)
         {
             running = true;
             simulation->setupAndRun();
-            repeatErrorsAndWarnings(simulation->log());
         }
         catch (FatalError& error)
         {


### PR DESCRIPTION
**Description**
Repeat warning messages and non-fatal error messages at the end of the simulation log (only in the root process).

**Motivation**
In long log files these messages were easily missed, causing the user to inadvertently ignore the warning or error being reported.

**Tests**
All functional tests run; manually tested the various parallelization modes.

**Context**
This feature was requested by @mstalevski 
