### PR TITLE
Correctly sample the anisotropic polarised emission profile

### DIFF
--- a/SKIRT/core/SecondarySourceSystem.cpp
+++ b/SKIRT/core/SecondarySourceSystem.cpp
@@ -427,7 +427,6 @@ namespace
             // create empty PDF and CDF arrays with the same size as the zenith angle grid
             const Array& thetas = _ms->mix(_m, _hv[0])->thetaGrid();
             Array pdf(thetas.size()), cdf(thetas.size());
-            ;
             // add the distributions for the different components
             for (int h : _hv)
             {

--- a/SKIRT/core/SecondarySourceSystem.cpp
+++ b/SKIRT/core/SecondarySourceSystem.cpp
@@ -421,40 +421,76 @@ namespace
         {
             // first generate a random azimuth angle
             const double phi = 2. * M_PI * random->uniform();
-            // compute its sine and cosine
-            const double cosphi = cos(phi);
-            const double sinphi = sin(phi);
 
             // now generate a random zenith angle
             // first, compute the cumulative distribution for a photon at the given wavelength
-            // create an empty array with the same size as the zenith angle grid
+            // create empty PDF and CDF arrays with the same size as the zenith angle grid
             const Array& thetas = _ms->mix(_m, _hv[0])->thetaGrid();
-            Array cdf(thetas.size());
+            Array pdf(thetas.size()), cdf(thetas.size());
+            ;
             // add the distributions for the different components
             for (int h : _hv)
             {
                 const Array& Qabs = _ms->mix(_m, h)->sectionsAbs(_lambda);
-                cdf += _ms->numberDensity(_m, h) * Qabs;
+                pdf += _ms->numberDensity(_m, h) * Qabs;
             }
-            // convert to a cumulative distribution
+            // the CDF is computed from the PDF by integration
+            // since this is an integration is spherical coordinates, we need to
+            // multiply the PDF with the volume element sin(theta)
+            for (size_t i = 0; i < thetas.size(); ++i)
+            {
+                pdf[i] *= std::sin(thetas[i]);
+            }
+            // convert to the CDF
+            // note that we use the midpoint of each bin as integration point
+            // and omit the common factors from the integration
             for (size_t i = 1; i < thetas.size(); ++i)
             {
-                cdf[i] += cdf[i - 1];
+                cdf[i] = cdf[i - 1] + pdf[i - 1] + pdf[i];
             }
-            // normalise the distribution
+            // normalise the CDF
             for (size_t i = 0; i < thetas.size(); ++i)
             {
                 cdf[i] /= cdf[thetas.size() - 1];
             }
-            // draw a random uniform deviate
-            // get the corresponding zenith angle
+            // draw a random zenith angle from the CDF
             const double theta = random->cdfLinLin(thetas, cdf);
-            // compute the sine and cosine
-            const double costheta = cos(theta);
-            const double sintheta = sin(theta);
 
             // generate a random direction
-            return Direction(sintheta * cosphi, sintheta * sinphi, costheta);
+            const Direction krand(theta, phi);
+
+            // The random direction is defined in a frame that has the B direction
+            // as z-axis (the x and y axis can be chosen arbitrarily because of the
+            // symmetry in phi)
+            // We need to (passively) rotate the random direction to the lab frame
+            // where the z-axis is the actual z-axis
+            // This corresponds to a rotation over -beta degrees along an axis
+            // that is perpendicular to the plane through the B direction and the
+            // z-axis, where beta is the angle between the B direction and the
+            // z-axis
+            // Note that in this case, it does not matter whether we rotate over
+            // beta or -beta degrees, since the difference between these two is
+            // simply a rotation over 180 degrees in phi, and we still sample a
+            // uniform distribution in phi.
+            // If the angle is small enough, we simply assume that B already lies
+            // along the z-axis and return immediately.
+            const double cosbeta = _B_direction.z();
+            if (fabs(cosbeta) < 0.99999)
+            {
+                // B is not the z-axis. Compute beta and sin(beta)
+                const double beta = std::acos(cosbeta);
+                const double sinbeta = std::sin(beta);
+                // compute the direction of the rotation axis, z x B
+                const Direction n(Vec::cross(Vec(0., 0., 1.), _B_direction));
+                // now use Rodrigues' rotation formula to carry out the rotation
+                const Direction krand2(krand * cosbeta + Vec::cross(n, krand) * sinbeta
+                                       + n * Vec::dot(n, krand) * (1. - cosbeta));
+                return krand2;
+            }
+            else
+            {
+                return krand;
+            }
         }
 
         // this PolarizationProfileInterface implementation returns the Stokes vector for the given emission direction


### PR DESCRIPTION
**Description**
Turns out the sampling of random photon packet directions for polarised secondary emission was wrong: the directions were not sampled correctly. There were two issues: first of all, there was a small issue with the calculation of the cumulative distribution function for the sampling. Second and most important, in the old implementation the randomly generated direction was not transformed from the dust frame (reference frame with the z-axis along the magnetic field direction) to the lab frame, leading to a completely incorrect sampling of the anisotropic emission profile.

**Motivation**
This issue was discovered while running a dedicated test case for secondary emission, described in detail below.

**Tests**
To test the intensity and polarisation state of secondary emission photon packets that contribute to the random walk, we set up a test in the grid depicted below:
![grid](https://user-images.githubusercontent.com/7336967/87799092-1ba42280-c84d-11ea-99f8-8d38428a4c55.png)
The central cell is filled with spheroidal dust particles that align with a magnetic field that has an arbitrary direction (out of the plane of the grid and on purpose not aligned with any coordinate direction). In the center of the central cell, a single source is located that emits polarised radiation according to a `SineSquaredPolarizationProfile`, at a single frequency. The source will heat the dust and cause secondary emission.
The 4 cells at the edges of the cross that has the central cell at its center are filled with electrons, so that light is Thomson scattered towards an observer that looks down onto the xy plane. During this scattering, the Stokes I and Q components mix up, making the observed intensities depend on both the intensity and polarization state of the emission (in a predictable way). We can test that we understand our setup by observing the scattered light from the source, since this has a known polarization state (and this polarization should work correctly).
We then test the same scenario for polarised dust emission by constructing a custom optical property table with different behaviour at 3 distinct wavelengths:
 - at 50 micron, light is emitted isotropically, but polarised (this is identical to what happens for the source),
 - at 100 micron, light is emitted anistropically, but without polarisation
 - at 200 micron, light is emitted anisotropically and with polarization. This is the realistic scenario.

By only studying the emission at these 3 wavelengths, we can test both the polarization, the anisotropy and the combination in one test.
The result is shown in the image below:
![result](https://user-images.githubusercontent.com/7336967/87800082-4347ba80-c84e-11ea-93fd-65f537391af7.png)
The top row shows the anistropic observed intensity. While this is anistropic at all wavelengths, this has various reasons: the source light and 50 micron emission are anistropic because of the mixing of Stokes I and Q during electron scattering, while the 100 micron emission is anistropic because the emission is anistropic. The 200 micron emission is anistropic because of both reasons. For all cases, the observed light from the central source has the correct polarisation direction (perpendicular to the transverse component of the magnetic field), and is observed without any noticeable Stokes U intensity (as it should be). The (normalised) Stokes Q and I intensities match the expected values for all cases.
The source files (and README) for this test can be found in [test.tar.gz](https://github.com/SKIRT/SKIRT9/files/4938484/test.tar.gz).


**Guidelines**
The code was automatically formatted using the formatting script.