### PR TITLE
Add snapshot import from list of cuboidal cells (as simpler alternative for AMR)

### DIFF
--- a/SKIRT/core/CellGeometry.cpp
+++ b/SKIRT/core/CellGeometry.cpp
@@ -1,0 +1,34 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "CellGeometry.hpp"
+#include "CellSnapshot.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+Snapshot* CellGeometry::createAndOpenSnapshot()
+{
+    // create and open the snapshot
+    auto snapshot = new CellSnapshot;
+    snapshot->open(this, filename(), "cuboidal cells");
+
+    // honor custom column reordering
+    snapshot->useColumns(useColumns());
+
+    // configure the cell bounding box columns
+    snapshot->importBox();
+
+    // configure the mass or density column
+    switch (massType())
+    {
+        case MassType::MassDensity: snapshot->importMassDensity(); break;
+        case MassType::Mass: snapshot->importMass(); break;
+        case MassType::NumberDensity: snapshot->importNumberDensity(); break;
+        case MassType::Number: snapshot->importNumber(); break;
+    }
+    return snapshot;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/CellGeometry.hpp
+++ b/SKIRT/core/CellGeometry.hpp
@@ -1,0 +1,73 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef CELLGEOMETRY_HPP
+#define CELLGEOMETRY_HPP
+
+#include "ImportedGeometry.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** A CellGeometry instance represents a 3D geometry with a spatial density distribution described
+    by a list of cuboidal cells lined up with the coordinate axes; refer to the CellSnapshot class
+    for more information. The cell data is usually extracted from a cosmological simulation
+    snapshot, and it must be provided in a column text file formatted as described below. The total
+    mass in the geometry is normalized to unity after importing the data.
+
+    Refer to the description of the TextInFile class for information on overall formatting and on
+    how to include header lines specifying the units for each column in the input file. In case the
+    input file has no unit specifications, the default units mentioned below are used instead. The
+    number of columns in the input file depends on the options configured by the user for this
+    CellGeometry instance:
+
+    \f[ x_\mathrm{min}\,(\mathrm{pc}) \quad y_\mathrm{min}\,(\mathrm{pc}) \quad
+    z_\mathrm{min}\,(\mathrm{pc}) \quad x_\mathrm{max}\,(\mathrm{pc}) \quad
+    y_\mathrm{max}\,(\mathrm{pc}) \quad z_\mathrm{max}\,(\mathrm{pc}) \quad \{\,
+    \rho\,(\text{M}_\odot\,\text{pc}^{-3}) \;\;|\;\; M\,(\text{M}_\odot) \;\;|\;\;
+    n\,(\text{cm}^{-3}) \;\;|\;\; N\,(1) \,\} \quad [Z\,(1)] \quad [T\,(\mathrm{K})] \f]
+
+    The first six columns specify the coordinates of the lower-left and upper-right corners of the
+    cell. Depending on the value of the \em massType option, the seventh column lists the average
+    mass density \f$\rho\f$, the integrated mass \f$M\f$, the average number density \f$n\f$, or
+    the integrated number density \f$N\f$ for the cell. The precise units for this field are
+    irrelevant because the total mass in the geometry will be normalized to unity after importing
+    the data. However, the import procedure still insists on knowing the units.
+
+    If the \em importMetallicity option is enabled, the next column specifies a "metallicity"
+    fraction, which in this context is simply multiplied with the mass/density column to obtain the
+    actual mass/density of the cell. If the \em importTemperature option is enabled, the next
+    column specifies a temperature. If this temperature is higher than the maximum configured
+    temperature, the mass and density of the cell are set to zero, regardless of the mass or
+    density specified in the seventh column. If the \em importTemperature option is disabled, or
+    the maximum temperature value is set to zero, such a cutoff is not applied. */
+class CellGeometry : public ImportedGeometry
+{
+    /** The enumeration type indicating the type of mass quantity to be imported. */
+    ENUM_DEF(MassType, MassDensity, Mass, NumberDensity, Number)
+        ENUM_VAL(MassType, MassDensity, "mass density")
+        ENUM_VAL(MassType, Mass, "mass (volume-integrated mass density)")
+        ENUM_VAL(MassType, NumberDensity, "number density")
+        ENUM_VAL(MassType, Number, "number (volume-integrated number density)")
+    ENUM_END()
+
+    ITEM_CONCRETE(CellGeometry, ImportedGeometry, "a geometry imported from cuboidal cell data")
+
+        PROPERTY_ENUM(massType, MassType, "the type of mass quantity to be imported")
+        ATTRIBUTE_DEFAULT_VALUE(massType, "MassDensity")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function constructs a new CellSnapshot object, calls its open() function, configures
+        it to import a mass or density column, and finally returns a pointer to the object.
+        Ownership of the Snapshot object is transferred to the caller. */
+    Snapshot* createAndOpenSnapshot() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/CellMedium.cpp
+++ b/SKIRT/core/CellMedium.cpp
@@ -1,0 +1,34 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "CellMedium.hpp"
+#include "CellSnapshot.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+Snapshot* CellMedium::createAndOpenSnapshot()
+{
+    // create and open the snapshot
+    auto snapshot = new CellSnapshot;
+    snapshot->open(this, filename(), "cuboidal cells");
+
+    // honor custom column reordering
+    snapshot->useColumns(useColumns());
+
+    // configure the cell bounding box columns
+    snapshot->importBox();
+
+    // configure the mass or density column
+    switch (massType())
+    {
+        case MassType::MassDensity: snapshot->importMassDensity(); break;
+        case MassType::Mass: snapshot->importMass(); break;
+        case MassType::NumberDensity: snapshot->importNumberDensity(); break;
+        case MassType::Number: snapshot->importNumber(); break;
+    }
+    return snapshot;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/CellMedium.hpp
+++ b/SKIRT/core/CellMedium.hpp
@@ -1,0 +1,91 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef CELLMEDIUM_HPP
+#define CELLMEDIUM_HPP
+
+#include "ImportedMedium.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** A CellMedium instance represents a transfer medium with a spatial density distribution (and,
+    optionally, other properties) described by a list of cuboidal cells lined up with the
+    coordinate axes; refer to the CellSnapshot class for more information. The cell data is usually
+    extracted from a cosmological simulation snapshot, and it must be provided in a column text
+    file formatted as described below.
+
+    Refer to the description of the TextInFile class for information on overall formatting and on
+    how to include header lines specifying the units for each column in the input file. In case the
+    input file has no unit specifications, the default units mentioned below are used instead. The
+    number of columns expected in the input file depends on the options configured by the user for
+    this CellMedium instance:
+
+    \f[ x_\mathrm{min}\,(\mathrm{pc}) \quad y_\mathrm{min}\,(\mathrm{pc}) \quad
+    z_\mathrm{min}\,(\mathrm{pc}) \quad x_\mathrm{max}\,(\mathrm{pc}) \quad
+    y_\mathrm{max}\,(\mathrm{pc}) \quad z_\mathrm{max}\,(\mathrm{pc}) \quad \{\,
+    \rho\,(\text{M}_\odot\,\text{pc}^{-3}) \;\;|\;\; M\,(\text{M}_\odot) \;\;|\;\;
+    n\,(\text{cm}^{-3}) \;\;|\;\; N\,(1) \,\} \quad [Z\,(1)] \quad [T\,(\mathrm{K})] \f] \f[ [
+    v_x\,(\mathrm{km/s}) \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) ] \quad [
+    B_x\,(\mu\mathrm{G}) \quad B_y\,(\mu\mathrm{G}) \quad B_z\,(\mu\mathrm{G}) ] \quad [
+    \dots\text{mix family params}\dots ] \f]
+
+    The first six columns specify the coordinates of the lower-left and upper-right corners of the
+    cell. Depending on the value of the \em massType option, the seventh column lists the average
+    mass density \f$\rho\f$, the integrated mass \f$M\f$, the average number density \f$n\f$, or
+    the integrated number density \f$N\f$ for the cell.
+
+    If the \em importMetallicity option is enabled, the next column specifies a "metallicity"
+    fraction, which is multiplied with the mass/density column to obtain the actual mass/density of
+    the cell. If the \em importTemperature option is enabled, the next column specifies a
+    temperature. If this temperature is higher than the maximum configured temperature, the mass
+    and density of the cell are set to zero, regardless of the mass or density specified in the
+    seventh column. If the \em importTemperature option is disabled, or the maximum temperature
+    value is set to zero, such a cutoff is not applied.
+
+    If both the \em importMetallicity and \em importTemperature options are enabled, this leads to
+    the following expression for the mass of an imported particle:
+
+    \f[ M_\mathrm{imported} = \begin{cases} f_\mathrm{mass}\,Z\,M & \mathrm{if}\; T<T_\mathrm{max}
+    \;\mathrm{or}\; T_\mathrm{max}=0 \\ 0 & \mathrm{otherwise} \end{cases} \f]
+
+    If the \em importVelocity option is enabled, the subsequent three columns specify the
+    \f$v_x\f$, \f$v_y\f$, \f$v_z\f$ velocity components of the particle (considered as the bulk
+    velocity for the mass represented by the particle).
+
+    If the \em importMagneticField option is enabled, the subsequent three columns specify the
+    \f$B_x\f$, \f$B_y\f$, \f$B_z\f$ magnetic field vector components for the cell.
+
+    Finally, if the \em importVariableMixParams option is enabled, the remaining columns specify
+    the parameters used by the configured material mix family to select a particular material mix
+    for the cell. */
+class CellMedium : public ImportedMedium
+{
+    /** The enumeration type indicating the type of mass quantity to be imported. */
+    ENUM_DEF(MassType, MassDensity, Mass, NumberDensity, Number)
+        ENUM_VAL(MassType, MassDensity, "mass density")
+        ENUM_VAL(MassType, Mass, "mass (volume-integrated mass density)")
+        ENUM_VAL(MassType, NumberDensity, "number density")
+        ENUM_VAL(MassType, Number, "number (volume-integrated number density)")
+    ENUM_END()
+
+    ITEM_CONCRETE(CellMedium, ImportedMedium, "a transfer medium imported from cuboidal cell data")
+
+        PROPERTY_ENUM(massType, MassType, "the type of mass quantity to be imported")
+        ATTRIBUTE_DEFAULT_VALUE(massType, "MassDensity")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function constructs a new CellSnapshot object, calls its open() function, configures
+        it to import a mass or density column, it, and finally returns a pointer to the object.
+        Ownership of the Snapshot object is transferred to the caller. */
+    Snapshot* createAndOpenSnapshot() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/CellSnapshot.cpp
+++ b/SKIRT/core/CellSnapshot.cpp
@@ -1,0 +1,431 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "CellSnapshot.hpp"
+#include "Log.hpp"
+#include "NR.hpp"
+#include "Random.hpp"
+#include "StringUtils.hpp"
+#include "TextInFile.hpp"
+#include "Units.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // returns a Box object corresponding to the six elements in the given properties array starting at the given index
+    Box box(const Array& prop, int i)
+    {
+        return Box(prop[i], prop[i + 1], prop[i + 2], prop[i + 3], prop[i + 4], prop[i + 5]);
+    }
+
+    // builds a smart grid in the specified spatial direction (box+0=x, box+1=y, box+2=z) and with the specified size,
+    // and stores it in output parameter "grid", along with the minimum and maximum coordinate enclosing the cells
+    void makegrid(const vector<Array>& propv, int dir, int gridsize, Array& grid, double& cmin, double& cmax)
+    {
+        int n = propv.size();
+
+        // find the spatial range of the cells in the specified direction
+        cmin = +std::numeric_limits<double>::infinity();
+        cmax = -std::numeric_limits<double>::infinity();
+        for (const Array& prop : propv)
+        {
+            cmin = min(cmin, prop[dir]);
+            cmax = max(cmax, prop[dir+3]);
+        }
+
+        // determine the cell distribution by binning at a decent resolution
+        int nbins = gridsize * 100;
+        double binwidth = (cmax - cmin) / nbins;
+        vector<int> bins(nbins);
+        for (const Array& prop : propv)
+        {
+            double center = 0.5 * (prop[dir] + prop[dir+3]);
+            bins[static_cast<int>((center - cmin) / binwidth)] += 1;
+        }
+
+        // determine grid separation points based on the cumulative distribution
+        grid.resize(gridsize + 1);
+        grid[0] = -std::numeric_limits<double>::infinity();
+        int percell = n / gridsize;  // target number of particles per cell
+        int cumul = 0;               // cumulative number of particles in processed bins
+        int gridindex = 1;           // index of the next grid separation point to be filled
+        for (int binindex = 0; binindex < nbins; binindex++)
+        {
+            cumul += bins[binindex];
+            if (cumul > percell * gridindex)
+            {
+                grid[gridindex] = cmin + (binindex + 1) * binwidth;
+                gridindex += 1;
+                if (gridindex >= gridsize) break;
+            }
+        }
+        grid[gridsize] = std::numeric_limits<double>::infinity();
+    }
+
+    // returns the linear index for element (i,j,k) in a p*p*p table
+    inline int index(int p, int i, int j, int k) { return ((i * p) + j) * p + k; }
+}
+
+////////////////////////////////////////////////////////////////////
+
+// This is a helper class for organizing cuboidal cells in a smart grid, so that
+// it is easy to retrieve the first cell that overlaps a given point in space.
+// The Box object on which this class is based specifies a cuboid guaranteed to
+// enclose all cells in the grid.
+class CellSnapshot::CellGrid : public Box
+{
+    // data members initialized during construction
+    const vector<Array>& _propv; // reference to the original list of cells
+    int _i;     // the box index in the properties list of each cell
+    int _p;                                          // number of grid cells in each spatial direction
+    Array _xgrid, _ygrid, _zgrid;                    // the m+1 grid separation points for each spatial direction
+    vector<vector<int>> _listv;  // the m*m*m lists of indices for cells overlapping each grid cell
+    int _pmin, _pmax, _ptotal;  // minimum, maximum nr of cells in list; total nr of cells in listv
+
+public:
+    // The constructor creates a cuboidal grid of the specified number of grid cells in each
+    // spatial direction, and for each of the grid cells it builds a list of all cells
+    // overlapping the grid cell. In an attempt to distribute the cells evenly over the
+    // grid cells, the sizes of the grid cells in each spatial direction are chosen so that
+    // the cell centers are evenly distributed over the grid cells.
+    CellGrid(const vector<Array>& propv, int boxindex, int gridsize)
+        : _propv(propv), _i(boxindex), _p(gridsize)
+    {
+        // build the grids in each spatial direction
+        double xmin, ymin, zmin, xmax, ymax, zmax;
+        makegrid(propv, boxindex+0, gridsize, _xgrid, xmin, xmax);
+        makegrid(propv, boxindex+1, gridsize, _ygrid, ymin, ymax);
+        makegrid(propv, boxindex+2, gridsize, _zgrid, zmin, zmax);
+        setExtent(xmin, ymin, zmin, xmax, ymax, zmax);
+
+        // make room for p*p*p grid cells
+        _listv.resize(gridsize * gridsize * gridsize);
+
+        // add each cell to the list for every grid cell that it overlaps
+        int n = propv.size();
+        for (int m = 0; m != n; ++m)
+        {
+            Box cell = box(propv[m], boxindex);
+
+            // find indices for first and last grid cell overlapped by cell, in each spatial direction
+            int i1 = NR::locateClip(_xgrid, cell.xmin());
+            int i2 = NR::locateClip(_xgrid, cell.xmax());
+            int j1 = NR::locateClip(_ygrid, cell.ymin());
+            int j2 = NR::locateClip(_ygrid, cell.ymax());
+            int k1 = NR::locateClip(_zgrid, cell.zmin());
+            int k2 = NR::locateClip(_zgrid, cell.zmax());
+
+            // add the cell to all grid cells in that 3D range
+            for (int i = i1; i <= i2; i++)
+                for (int j = j1; j <= j2; j++)
+                    for (int k = k1; k <= k2; k++)
+                    {
+                        _listv[index(gridsize, i, j, k)].push_back(m);
+                    }
+        }
+
+        // calculate statistics
+        _pmin = n;
+        _pmax = 0;
+        _ptotal = 0;
+        for (int index = 0; index < gridsize * gridsize * gridsize; index++)
+        {
+            int size = _listv[index].size();
+            _pmin = min(_pmin, size);
+            _pmax = max(_pmax, size);
+            _ptotal += size;
+        }
+
+    }
+
+    // This function returns the smallest number of cells overlapping a single grid cell.
+    int minCellRefsPerCell() const
+    {
+        return _pmin;
+    }
+
+    // This function returns the largest number of cells overlapping a single grid cell.
+    int maxCellRefsPerCell() const
+    {
+        return _pmax;
+    }
+
+    // This function returns the total number of cell references for all cells in the grid.
+    int totalCellRefs() const
+    {
+        return _ptotal;
+    }
+
+    // This function returns the index (in the list originally passed to the constructor)
+    // of the first cell in the list that overlaps the specified position,
+    // or -1 if none of the cells in the list overlap the specified position.
+    int cellIndexFor(Position r)
+    {
+        // locate the grid cell containing the specified position
+        int i = NR::locateClip(_xgrid, r.x());
+        int j = NR::locateClip(_ygrid, r.y());
+        int k = NR::locateClip(_zgrid, r.z());
+
+        // search the list of cells for that grid cell
+        for (int m : _listv[index(_p, i, j, k)])
+        {
+            if (box(_propv[m], _i).contains(r)) return m;
+        }
+        return -1;
+    }
+};
+
+////////////////////////////////////////////////////////////////////
+
+CellSnapshot::~CellSnapshot()
+{
+    delete _grid;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void CellSnapshot::readAndClose()
+{
+    // read the snapshot cell info into memory
+    _propv = infile()->readAllRows();
+
+    // close the file
+    Snapshot::readAndClose();
+
+    // if a mass density policy has been set, calculate masses and densities for all cells
+    if (hasMassDensityPolicy())
+    {
+        // allocate vectors for mass and density
+        size_t n = _propv.size();
+        Array Mv(n);
+        _rhov.resize(n);
+
+        // get the maximum temperature, or zero of there is none
+        double maxT = useTemperatureCutoff() ? maxTemperature() : 0.;
+
+        // initialize statistics
+        double totalOriginalMass = 0;
+        double totalMetallicMass = 0;
+        double totalEffectiveMass = 0;
+
+        // loop over all sites/cells
+        int numIgnored = 0;
+        for (size_t m = 0; m != n; ++m)
+        {
+            const Array& prop = _propv[m];
+
+            // original mass is zero if temperature is above cutoff or if imported mass/density is not positive
+            double originalMass = 0.;
+            if (maxT && prop[temperatureIndex()] > maxT)
+                numIgnored++;
+            else
+                originalMass = max(0., massIndex() >= 0 ? prop[massIndex()]
+                                                        : prop[densityIndex()] * box(prop, boxIndex()).volume());
+
+            double metallicMass = originalMass * (useMetallicity() ? prop[metallicityIndex()] : 1.);
+            double effectiveMass = metallicMass * multiplier();
+
+            Mv[m] = effectiveMass;
+            _rhov[m] = effectiveMass / box(prop, boxIndex()).volume();
+
+            totalOriginalMass += originalMass;
+            totalMetallicMass += metallicMass;
+            totalEffectiveMass += effectiveMass;
+        }
+
+        // log mass statistics
+        if (numIgnored) log()->info("  Ignored mass in " + std::to_string(numIgnored) + " high-temperature cells");
+        log()->info("  Total original mass : " + StringUtils::toString(units()->omass(totalOriginalMass), 'e', 4) + " "
+                    + units()->umass());
+        if (useMetallicity())
+            log()->info("  Total metallic mass : " + StringUtils::toString(units()->omass(totalMetallicMass), 'e', 4)
+                        + " " + units()->umass());
+        log()->info("  Total effective mass: " + StringUtils::toString(units()->omass(totalEffectiveMass), 'e', 4) + " "
+                    + units()->umass());
+
+        // remember the effective mass
+        _mass = totalEffectiveMass;
+
+        // build further data structures only if there are cells
+        if (n)
+        {
+            // construct a vector with the normalized cumulative cell densities
+            NR::cdf(_cumrhov, Mv);
+
+            // construct a 3D-grid over the domain, and create a list of cells that overlap each grid cell
+            int gridsize = max(20, static_cast<int>(pow(n, 1. / 3.) / 5));
+            string size = std::to_string(gridsize);
+            log()->info("Constructing intermediate " + size + "x" + size + "x" + size + " grid for cells...");
+            _grid = new CellGrid(_propv, boxIndex(), gridsize);
+            log()->info("  Smallest number of cells per grid cell: " + std::to_string(_grid->minCellRefsPerCell()));
+            log()->info("  Largest  number of cells per grid cell: " + std::to_string(_grid->maxCellRefsPerCell()));
+            log()->info(
+                "  Average  number of cells per grid cell: "
+                + StringUtils::toString(_grid->totalCellRefs() / double(gridsize * gridsize * gridsize), 'f', 1));
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////
+
+Box CellSnapshot::extent() const
+{
+    // if there are no cells, return an empty box
+    if (_propv.empty()) return Box();
+
+    // if there is a cell grid, ask it to return the extent (it is already calculated)
+    if (_grid) return _grid->extent();
+
+    // otherwise find the spatial range of the cells
+    double xmin = +std::numeric_limits<double>::infinity();
+    double xmax = -std::numeric_limits<double>::infinity();
+    double ymin = +std::numeric_limits<double>::infinity();
+    double ymax = -std::numeric_limits<double>::infinity();
+    double zmin = +std::numeric_limits<double>::infinity();
+    double zmax = -std::numeric_limits<double>::infinity();
+    for (const Array& prop : _propv)
+    {
+        xmin = min(xmin, prop[boxIndex() + 0]);
+        xmax = max(xmax, prop[boxIndex() + 3]);
+        ymin = min(ymin, prop[boxIndex() + 1]);
+        ymax = max(ymax, prop[boxIndex() + 4]);
+        zmin = min(zmin, prop[boxIndex() + 2]);
+        zmax = max(zmax, prop[boxIndex() + 5]);
+    }
+    return Box(xmin, ymin, zmin, xmax, ymax, zmax);
+}
+
+////////////////////////////////////////////////////////////////////
+
+int CellSnapshot::numEntities() const
+{
+    return _propv.size();
+}
+
+////////////////////////////////////////////////////////////////////
+
+Position CellSnapshot::position(int m) const
+{
+    return Position(box(_propv[m], boxIndex()).center());
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CellSnapshot::temperature(int m) const
+{
+    return _propv[m][temperatureIndex()];
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CellSnapshot::temperature(Position bfr) const
+{
+    int m = _grid ? _grid->cellIndexFor(bfr) : -1;
+    return m >= 0 ? temperature(m) : 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Vec CellSnapshot::velocity(int m) const
+{
+    return Vec(_propv[m][velocityIndex() + 0], _propv[m][velocityIndex() + 1], _propv[m][velocityIndex() + 2]);
+}
+
+////////////////////////////////////////////////////////////////////
+
+Vec CellSnapshot::velocity(Position bfr) const
+{
+    int m = _grid ? _grid->cellIndexFor(bfr) : -1;
+    return m >= 0 ? velocity(m) : Vec();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CellSnapshot::velocityDispersion(int m) const
+{
+    return _propv[m][velocityDispersionIndex()];
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CellSnapshot::velocityDispersion(Position bfr) const
+{
+    int m = _grid ? _grid->cellIndexFor(bfr) : -1;
+    return m >= 0 ? velocityDispersion(m) : 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Vec CellSnapshot::magneticField(int m) const
+{
+    return Vec(_propv[m][magneticFieldIndex() + 0], _propv[m][magneticFieldIndex() + 1],
+               _propv[m][magneticFieldIndex() + 2]);
+}
+
+////////////////////////////////////////////////////////////////////
+
+Vec CellSnapshot::magneticField(Position bfr) const
+{
+    int m = _grid ? _grid->cellIndexFor(bfr) : -1;
+    return m >= 0 ? magneticField(m) : Vec();
+}
+
+////////////////////////////////////////////////////////////////////
+
+void CellSnapshot::parameters(int m, Array& params) const
+{
+    int n = numParameters();
+    params.resize(n);
+    for (int i = 0; i != n; ++i) params[i] = _propv[m][parametersIndex() + i];
+}
+
+////////////////////////////////////////////////////////////////////
+
+void CellSnapshot::parameters(Position bfr, Array& params) const
+{
+    int m = _grid ? _grid->cellIndexFor(bfr) : -1;
+    if (m >= 0)
+        parameters(m, params);
+    else
+        params.resize(numParameters());
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CellSnapshot::density(Position bfr) const
+{
+    int m = _grid ? _grid->cellIndexFor(bfr) : -1;
+    return m >= 0 ? _rhov[m] : 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CellSnapshot::mass() const
+{
+    return _mass;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Position CellSnapshot::generatePosition(int m) const
+{
+    return random()->position(box(_propv[m], boxIndex()));
+}
+
+////////////////////////////////////////////////////////////////////
+
+Position CellSnapshot::generatePosition() const
+{
+    // if there are no cells, return the origin
+    if (_propv.empty()) return Position();
+
+    // select a cell according to its mass contribution
+    int m = NR::locateClip(_cumrhov, random()->uniform());
+
+    return generatePosition(m);
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/CellSnapshot.cpp
+++ b/SKIRT/core/CellSnapshot.cpp
@@ -33,7 +33,7 @@ namespace
         for (const Array& prop : propv)
         {
             cmin = min(cmin, prop[dir]);
-            cmax = max(cmax, prop[dir+3]);
+            cmax = max(cmax, prop[dir + 3]);
         }
 
         // determine the cell distribution by binning at a decent resolution
@@ -42,7 +42,7 @@ namespace
         vector<int> bins(nbins);
         for (const Array& prop : propv)
         {
-            double center = 0.5 * (prop[dir] + prop[dir+3]);
+            double center = 0.5 * (prop[dir] + prop[dir + 3]);
             bins[static_cast<int>((center - cmin) / binwidth)] += 1;
         }
 
@@ -78,12 +78,12 @@ namespace
 class CellSnapshot::CellGrid : public Box
 {
     // data members initialized during construction
-    const vector<Array>& _propv; // reference to the original list of cells
-    int _i;     // the box index in the properties list of each cell
-    int _p;                                          // number of grid cells in each spatial direction
-    Array _xgrid, _ygrid, _zgrid;                    // the m+1 grid separation points for each spatial direction
-    vector<vector<int>> _listv;  // the m*m*m lists of indices for cells overlapping each grid cell
-    int _pmin, _pmax, _ptotal;  // minimum, maximum nr of cells in list; total nr of cells in listv
+    const vector<Array>& _propv;   // reference to the original list of cells
+    int _i;                        // the box index in the properties list of each cell
+    int _p;                        // number of grid cells in each spatial direction
+    Array _xgrid, _ygrid, _zgrid;  // the m+1 grid separation points for each spatial direction
+    vector<vector<int>> _listv;    // the m*m*m lists of indices for cells overlapping each grid cell
+    int _pmin, _pmax, _ptotal;     // minimum, maximum nr of cells in list; total nr of cells in listv
 
 public:
     // The constructor creates a cuboidal grid of the specified number of grid cells in each
@@ -91,14 +91,13 @@ public:
     // overlapping the grid cell. In an attempt to distribute the cells evenly over the
     // grid cells, the sizes of the grid cells in each spatial direction are chosen so that
     // the cell centers are evenly distributed over the grid cells.
-    CellGrid(const vector<Array>& propv, int boxindex, int gridsize)
-        : _propv(propv), _i(boxindex), _p(gridsize)
+    CellGrid(const vector<Array>& propv, int boxindex, int gridsize) : _propv(propv), _i(boxindex), _p(gridsize)
     {
         // build the grids in each spatial direction
         double xmin, ymin, zmin, xmax, ymax, zmax;
-        makegrid(propv, boxindex+0, gridsize, _xgrid, xmin, xmax);
-        makegrid(propv, boxindex+1, gridsize, _ygrid, ymin, ymax);
-        makegrid(propv, boxindex+2, gridsize, _zgrid, zmin, zmax);
+        makegrid(propv, boxindex + 0, gridsize, _xgrid, xmin, xmax);
+        makegrid(propv, boxindex + 1, gridsize, _ygrid, ymin, ymax);
+        makegrid(propv, boxindex + 2, gridsize, _zgrid, zmin, zmax);
         setExtent(xmin, ymin, zmin, xmax, ymax, zmax);
 
         // make room for p*p*p grid cells
@@ -138,26 +137,16 @@ public:
             _pmax = max(_pmax, size);
             _ptotal += size;
         }
-
     }
 
     // This function returns the smallest number of cells overlapping a single grid cell.
-    int minCellRefsPerCell() const
-    {
-        return _pmin;
-    }
+    int minCellRefsPerCell() const { return _pmin; }
 
     // This function returns the largest number of cells overlapping a single grid cell.
-    int maxCellRefsPerCell() const
-    {
-        return _pmax;
-    }
+    int maxCellRefsPerCell() const { return _pmax; }
 
     // This function returns the total number of cell references for all cells in the grid.
-    int totalCellRefs() const
-    {
-        return _ptotal;
-    }
+    int totalCellRefs() const { return _ptotal; }
 
     // This function returns the index (in the list originally passed to the constructor)
     // of the first cell in the list that overlaps the specified position,
@@ -194,6 +183,9 @@ void CellSnapshot::readAndClose()
 
     // close the file
     Snapshot::readAndClose();
+
+    // inform the user
+    log()->info("  Number of cells: " + std::to_string(_propv.size()));
 
     // if a mass density policy has been set, calculate masses and densities for all cells
     if (hasMassDensityPolicy())

--- a/SKIRT/core/CellSnapshot.hpp
+++ b/SKIRT/core/CellSnapshot.hpp
@@ -1,0 +1,164 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef CELLSNAPSHOT_HPP
+#define CELLSNAPSHOT_HPP
+
+#include "Snapshot.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** A CellSnapshot object represents the data in a Cartesian mesh-based snapshot imported from a
+    column text file. Each line in the text file represents a cuboidal cell lined up with the
+    coordinate axes, specifying the coordinates of the lower-left and upper-right corners of the
+    cell along with properties such as the density in the cell. The intention is for the cells to
+    define a partition of the spatial domain, and usually they will, however this is not enforced.
+    When two or more cells overlap at a given position, the properties for that position will be
+    taken from the cell that is listed first in the imported file. When no cells overlap a given
+    position, the density at that position is considered to be zero. To avoid thin slices of zero
+    density between cells, the coordinates for common walls or corners in neighboring cells should
+    be identical.
+
+    This class is an alternative to the AdaptiveMeshSnapshot class, which requires listing cells in
+    Morton order. This can be hard to accomplish, especially when extracting a particular subdomain
+    from a larger mesh. In contrast, the CellSnapshot class allows cells to be listed in arbitrary
+    order and allows the spatial partition to be imperfect. For example, the outer border of the
+    domain can be ragged, with some cells extending farther out than others.
+
+    This class is based on the Snapshot class; it uses the facilities offered there to configure
+    and read the snapshot data, and it implements all functions in the general Snapshot public
+    interface. If the snapshot configuration requires the ability to determine the density at a
+    given spatial position, an effort is made to accelerate the search for the cell containing that
+    position even for a large number of cells. */
+class CellSnapshot : public Snapshot
+{
+    //================= Construction - Destruction =================
+
+public:
+    /** The destructor deletes the search data structure, if it was constructed. */
+    ~CellSnapshot();
+
+    //========== Reading ==========
+
+public:
+    /** This function reads the snapshot data from the input file, honoring the options set through
+        the configuration functions, stores the data for later use, and closes the file by calling
+        the base class Snapshot::readAndClose() function.
+
+        Cells with an associated temperature above the cutoff temperature (if one has been
+        configured) are assigned a density value of zero, so that they have zero mass regardless of
+        the imported mass/density properties. Note that we cannot simply ignore these cells because
+        an empty cell may overlap and thus hide (a portion of) a nonempty cell later in the list.
+
+        The function also logs some statistical information about the import. If the snapshot
+        configuration requires the ability to determine the density at a given spatial position,
+        this function builds a data structure that accelerates the search for the appropriate cell.
+        */
+    void readAndClose() override;
+
+    //=========== Interrogation ==========
+
+public:
+    /** This function returns the bounding box lined up with the coordinate axes surrounding all
+        cells. */
+    Box extent() const override;
+
+    /** This function returns the number of cells in the snapshot. */
+    int numEntities() const override;
+
+    /** This function returns the position of the center of the cell with index \em m. If the index
+        is out of range, the behavior is undefined. */
+    Position position(int m) const override;
+
+    /** This function returns the temperature of the cell with index \em m. If the temperature is
+        not being imported, or the index is out of range, the behavior is undefined. */
+    double temperature(int m) const override;
+
+    /** This function returns the temperature of the cell containing the specified point
+        \f${\bf{r}}\f$. If the point is not inside any cell, the function returns zero. If the
+        temperature is not being imported, the behavior is undefined. */
+    double temperature(Position bfr) const override;
+
+    /** This function returns the velocity of the cell with index \em m. If the velocity is not
+        being imported, or the index is out of range, the behavior is undefined. */
+    Vec velocity(int m) const override;
+
+    /** This function returns the velocity of the cell containing the specified point
+        \f${\bf{r}}\f$. If the point is not inside any cell, the function returns zero velocity. If
+        the velocity is not being imported, the behavior is undefined. */
+    Vec velocity(Position bfr) const override;
+
+    /** This function returns the velocity dispersion of the cell with index \f$0\le m \le
+        N_\mathrm{ent}-1\f$. If the velocity dispersion is not being imported, or the index is out
+        of range, the behavior is undefined. */
+    double velocityDispersion(int m) const override;
+
+    /** This function returns the velocity dispersion of the cell containing the specified point
+        \f${\bf{r}}\f$. If the point is not inside any cell, the function returns zero dispersion.
+        If the velocity dispersion is not being imported, the behavior is undefined. */
+    double velocityDispersion(Position bfr) const override;
+
+    /** This function returns the magnetic field vector of the cell with index \em m. If the
+        magnetic field is not being imported, or the index is out of range, the behavior is
+        undefined. */
+    Vec magneticField(int m) const override;
+
+    /** This function returns the magnetic field vector of the cell containing the specified point
+        \f${\bf{r}}\f$. If the point is not inside any cell, the function returns a zero magnetic
+        field. If the magnetic field is not being imported, the behavior is undefined. */
+    Vec magneticField(Position bfr) const override;
+
+    /** This function stores the parameters of the cell with index \em m into the given array. If
+        parameters are not being imported, or the index is out of range, the behavior is undefined.
+        */
+    void parameters(int m, Array& params) const override;
+
+    /** This function stores the parameters of the cell containing the specified point
+        \f${\bf{r}}\f$ into the given array. If the point is not inside any cell, the function
+        returns the appropriate number of zero parameter values. If parameters are not being
+        imported, the behavior is undefined. */
+    void parameters(Position bfr, Array& params) const override;
+
+    /** This function returns the mass density of the cell containing the specified point
+        \f${\bf{r}}\f$. If the point is not inside any cell, the function returns zero. If no
+        density policy has been set or no mass information is being imported, the behavior is
+        undefined. */
+    double density(Position bfr) const override;
+
+    /** This function returns the total mass represented by the snapshot, in other words the sum of
+        the masses of all cells. If no density policy has been set or no mass information is being
+        imported, the behavior is undefined. */
+    double mass() const override;
+
+    /** This function returns a random position drawn uniformly from the cell with index \em m. If
+        the index is out of range, the behavior is undefined. */
+    Position generatePosition(int m) const override;
+
+    /** This function returns a random position within the spatial domain of the snapshot, drawn
+        from the mass density distribution represented by the snapshot. The function first selects
+        a random cell from the discrete probability distribution formed by the respective cell
+        masses, and then generates a random position within that cell. If no density policy has
+        been set or no mass information is being imported, the behavior is undefined. */
+    Position generatePosition() const override;
+
+    //======================== Data Members ========================
+
+private:
+    // data members initialized when reading the input file
+    vector<Array> _propv;  // cell properties as imported
+
+    // data members initialized after reading the input file if a density policy has been set
+    Array _rhov;       // density for each cell (not normalized)
+    Array _cumrhov;    // normalized cumulative density distribution for cells
+    double _mass{0.};  // total effective mass
+
+    // data members initialized after reading the input file if a density policy has been set
+    class CellGrid;
+    CellGrid* _grid{nullptr};  // smart grid for locating the cell at a given location
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/CellSource.cpp
+++ b/SKIRT/core/CellSource.cpp
@@ -1,0 +1,25 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "CellSource.hpp"
+#include "CellSnapshot.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+Snapshot* CellSource::createAndOpenSnapshot()
+{
+    // create and open the snapshot
+    auto snapshot = new CellSnapshot;
+    snapshot->open(this, filename(), "cuboidal source cells");
+
+    // honor custom column reordering
+    snapshot->useColumns(useColumns());
+
+    // configure the cell bounding box columns
+    snapshot->importBox();
+    return snapshot;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/CellSource.hpp
+++ b/SKIRT/core/CellSource.hpp
@@ -1,0 +1,58 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef CELLSOURCE_HPP
+#define CELLSOURCE_HPP
+
+#include "ImportedSource.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** A CellSource instance represents a primary radiation source with a spatial and spectral
+    luminosity distribution described by a list of cuboidal cells lined up with the coordinate
+    axes; refer to the CellSnapshot class for more information. The cell data is usually extracted
+    from a cosmological simulation snapshot, and it must be provided in a column text file
+    formatted as described below.
+
+    Refer to the description of the TextInFile class for information on overall formatting and on
+    how to include header lines specifying the units for each column in the input file. In case the
+    input file has no unit specifications, the default units mentioned below are used instead. The
+    number of columns expected in the input file depends on the options configured by the user for
+    this CellSource instance, including the selected %SEDFamily.
+
+    \f[ x_\mathrm{min}\,(\mathrm{pc}) \quad y_\mathrm{min}\,(\mathrm{pc}) \quad
+    z_\mathrm{min}\,(\mathrm{pc}) \quad x_\mathrm{max}\,(\mathrm{pc}) \quad
+    y_\mathrm{max}\,(\mathrm{pc}) \quad z_\mathrm{max}\,(\mathrm{pc}) \quad [ v_x\,(\mathrm{km/s})
+    \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) \quad [ \sigma_v\,(\mathrm{km/s}) ] ]
+    \quad \dots \text{SED family parameters}\dots \f]
+
+    The first six columns specify the coordinates of the lower-left and upper-right corners of the
+    cell. If the \em importVelocity option is enabled, the next three columns specify the
+    \f$v_x\f$, \f$v_y\f$, \f$v_z\f$ bulk velocity components of the source population represented
+    by the cell. If additionally the \em importVelocityDispersion option is enabled, the next
+    column specifies the velocity dispersion \f$\sigma_v\f$, adjusting the velocity for each photon
+    packet launch with a random offset sampled from a spherically symmetric Gaussian distribution.
+
+    The remaining columns specify the parameters required by the configured %SED family to select
+    and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining
+    columns provide the initial mass, the metallicity, and the age of the stellar population
+    represented by the cell. Refer to the documentation of the configured type of SEDFamily for
+    information about the expected parameters and their default units. */
+class CellSource : public ImportedSource
+{
+    ITEM_CONCRETE(CellSource, ImportedSource, "a primary source imported from cuboidal cell data")
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function constructs a new CellSnapshot object, calls its open() function, and returns
+        a pointer to the object. Ownership of the Snapshot object is transferred to the caller. */
+    Snapshot* createAndOpenSnapshot() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -26,6 +26,9 @@
 #include "CartesianSpatialGrid.hpp"
 #include "CastelliKuruczSED.hpp"
 #include "CastelliKuruczSEDFamily.hpp"
+#include "CellGeometry.hpp"
+#include "CellMedium.hpp"
+#include "CellSource.hpp"
 #include "ClumpyGeometryDecorator.hpp"
 #include "CombineGeometryDecorator.hpp"
 #include "ConfigurableBandWavelengthGrid.hpp"
@@ -273,6 +276,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<GeometricSource>();
     ItemRegistry::add<ImportedSource>();
     ItemRegistry::add<ParticleSource>();
+    ItemRegistry::add<CellSource>();
     ItemRegistry::add<MeshSource>();
     ItemRegistry::add<AdaptiveMeshSource>();
     ItemRegistry::add<VoronoiMeshSource>();
@@ -379,6 +383,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<ReadFitsGeometry>();
     ItemRegistry::add<ImportedGeometry>();
     ItemRegistry::add<ParticleGeometry>();
+    ItemRegistry::add<CellGeometry>();
     ItemRegistry::add<MeshGeometry>();
     ItemRegistry::add<AdaptiveMeshGeometry>();
     ItemRegistry::add<VoronoiMeshGeometry>();
@@ -448,6 +453,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<GeometricMedium>();
     ItemRegistry::add<ImportedMedium>();
     ItemRegistry::add<ParticleMedium>();
+    ItemRegistry::add<CellMedium>();
     ItemRegistry::add<MeshMedium>();
     ItemRegistry::add<AdaptiveMeshMedium>();
     ItemRegistry::add<VoronoiMeshMedium>();

--- a/SKIRT/core/Snapshot.cpp
+++ b/SKIRT/core/Snapshot.cpp
@@ -73,6 +73,20 @@ void Snapshot::importSize()
 
 ////////////////////////////////////////////////////////////////////
 
+void Snapshot::importBox()
+{
+    _boxIndex = _nextIndex;
+    _nextIndex += 6;
+    _infile->addColumn("box xmin", "length", "pc");
+    _infile->addColumn("box ymin", "length", "pc");
+    _infile->addColumn("box zmin", "length", "pc");
+    _infile->addColumn("box xmax", "length", "pc");
+    _infile->addColumn("box ymax", "length", "pc");
+    _infile->addColumn("box zmax", "length", "pc");
+}
+
+////////////////////////////////////////////////////////////////////
+
 void Snapshot::importMassDensity()
 {
     _densityIndex = _nextIndex++;

--- a/SKIRT/core/Snapshot.hpp
+++ b/SKIRT/core/Snapshot.hpp
@@ -122,6 +122,10 @@ public:
         pc. */
     void importSize();
 
+    /** This function configures the snapshot to import a cuboid lined up with the coordinate axes,
+        defined by six components (xmin,ymin,zmin,xmax,ymax,zmax). The default unit is pc. */
+    void importBox();
+
     /** This function configures the snapshot to import a mass density per unit of volume. The
         default unit is Msun/pc3. The importMassDensity(), importMass(), importNumberDensity(), and
         importNumber() options are mutually exclusive; calling more than one of these functions for
@@ -201,6 +205,10 @@ protected:
     /** This function returns the column index of the size field, or -1 if this is not being
         imported, for use by subclasses. */
     int sizeIndex() const { return _sizeIndex; }
+
+    /** This function returns the column index of the first box field, or -1 if this is not
+        being imported, for use by subclasses. */
+    int boxIndex() const { return _boxIndex; }
 
     /** This function returns the column index of the density field, or -1 if this is not being
         imported, for use by subclasses. */
@@ -392,6 +400,7 @@ private:
     int _nextIndex{0};
     int _positionIndex{-1};
     int _sizeIndex{-1};
+    int _boxIndex{-1};
     int _densityIndex{-1};
     int _massIndex{-1};
     int _metallicityIndex{-1};


### PR DESCRIPTION
**Description**
This pull request adds the the capability to import snapshot data (for media and sources) from a list of cuboidal cells.
Each line in the input text file represents a cuboidal cell lined up with the coordinate axes, specifying the coordinates of the lower-left and upper-right corners of the cell along with any relevant cell properties. The intention is for the cells to define a partition of the spatial domain, however this is not enforced. When two or more cells overlap at a given position, the properties for that position will be taken from the cell that is listed first in the imported file. When no cells overlap a given    position, the density at that position is considered to be zero. **To avoid thin slices of zero density between cells, the coordinates for common walls or corners in neighboring cells should be identical.**

**Motivation**
This new functionality is an alternative for using the adaptive mesh import capability, which requires listing cells in Morton order. This can be hard to accomplish, especially when extracting a particular subdomain from a larger mesh. In contrast, the new option allows cells to be listed in arbitrary order and allows the spatial partition to be imperfect. For example, the outer border of the domain can be ragged, with some cells extending farther out than others.

**Tests**
The new capability has been thoroughly tested with synthetic examples but could use a real field test. Virtually no changes were required to existing code, so the risk of breaking existing functionality is essentially zero.

**Guidelines**
The new code has been properly formatted.
