### PR TITLE
Fix Lockfree::add for Microsoft Visual Studio compiler

### DIFF
--- a/SKIRT/utils/LockFree.hpp
+++ b/SKIRT/utils/LockFree.hpp
@@ -22,8 +22,8 @@ namespace LockFree
         operation on the target memory location. */
     inline void add(double& target, double value)
     {
-        // construct an atom over the target location without initialization (this produces no assembly code)
-        std::atomic<double>* atom = new (&target) std::atomic<double>;
+        // reinterpret the target location as an atom (this produces no assembly code)
+        auto atom = reinterpret_cast<std::atomic<double>*>(&target);
 
         // make a local copy of the target location's value
         double old = *atom;


### PR DESCRIPTION
**Description**
This pull-request fixes the incorrect results produced by SKIRT when compiled with recent versions of Microsoft Visual Studio. Specifically, it adjusts the `LockFree::add()` function so that it conforms both to C++14 and C++20 conventions.

**Technicalities**
The `LockFree::add()` function needs a compile-time construct to transform the target `double` (passed as a reference) to an `atomic<double>` used for the atomic add operation _without producing any machine instructions_. The previous code used a _placement_ `new` for this purpose, which allocates the `atomic<double>` variable at the regular `double`'s location. The new code uses an `interpret_cast<>` instead.

**Motivation**
The C++14 specification says that a placement `new` does not initialize the newly allocated variable (and hence generates no code). This apparently causes inconsistencies in some special cases with more complex data types, so it was decided to change this behavior. The C++20 specification says that the placement `new` does initialize the newly allocated variable (and thus in our case sets the value to zero, which is obviously not the intended behavior). It seems that the Microsoft Visual Studio compiler already uses the C++20 convention even when compiling in C++14 mode. Other compiler makers might follow this path, so this issue is important not just for Windows. The `interpret_cast<>` is guaranteed to generate no code when casting between two pointers to objects with the same alignment, so this should be safe for both C++14 and C++20.

**Tests**
I verified that
 - the new code seems to run fine when compiled with Microsoft Visual Studio on Windows, at least for a few basic tests,
 - Clang on Mac generates exactly the same machine code for the new and previous code versions,
 - all functional tests still run on Mac (which is unsurprising since the machine code did not change).
