### PR TITLE
Added a 3D geometry read from a .fits datacube

### DIFF
--- a/SKIRT/core/ReadFits3DGeometry.cpp
+++ b/SKIRT/core/ReadFits3DGeometry.cpp
@@ -4,7 +4,6 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "ReadFits3DGeometry.hpp"
-#include "FatalError.hpp"
 #include "FITSInOut.hpp"
 #include "NR.hpp"
 #include "Random.hpp"
@@ -25,53 +24,48 @@ void ReadFits3DGeometry::setupSelfBefore()
     NR::cdf(_Xv, _datacube);
 
     // Calculate the boundaries of the datacube in physical coordinates
-    _xmin = -(_nx/2.)*_pixelScale;
-    _xmax =  (_nx/2.)*_pixelScale;
-    _ymin = -(_ny/2.)*_pixelScale;
-    _ymax =  (_ny/2.)*_pixelScale;
-    _zmin = -(_nz/2.)*_pixelScale;
-    _zmax =  (_nz/2.)*_pixelScale;
-
+    _xmin = -(_nx / 2.) * _pixelScale;
+    _xmax = (_nx / 2.) * _pixelScale;
+    _ymin = -(_ny / 2.) * _pixelScale;
+    _ymax = (_ny / 2.) * _pixelScale;
+    _zmin = -(_nz / 2.) * _pixelScale;
+    _zmax = (_nz / 2.) * _pixelScale;
 }
 
 ////////////////////////////////////////////////////////////////////
 
 double ReadFits3DGeometry::density(Position bfr) const
 {
-    double x,y,z;
-    bfr.cartesian(x,y,z);
+    double x, y, z;
+    bfr.cartesian(x, y, z);
 
     // Find the corresponding spaxel in the datacube
-    int i = static_cast<int>(floor((x-_xmin)/_pixelScale));
-    int j = static_cast<int>(floor((y-_ymin)/_pixelScale));
-    int k = static_cast<int>(floor((z-_zmin)/_pixelScale));
-    if (i<0 || i>=_nx || j<0 || j>=_ny|| k<0 || k>=_nz) return 0.0;
+    int i = static_cast<int>(floor((x - _xmin) / _pixelScale));
+    int j = static_cast<int>(floor((y - _ymin) / _pixelScale));
+    int k = static_cast<int>(floor((z - _zmin) / _pixelScale));
+    if (i < 0 || i >= _nx || j < 0 || j >= _ny || k < 0 || k >= _nz) return 0.;
 
     // Return the density
-    return _datacube[i + _nx*j + _nx*_ny*k];
+    return _datacube[i + _nx * j + _nx * _ny * k];
 }
 
 ////////////////////////////////////////////////////////////////////
 
 Position ReadFits3DGeometry::generatePosition() const
 {
-    // Draw a random position in cube based on the
-    // cumulative distribution in each spaxel
-    double X1 = random()->uniform();
-    int Xindex = NR::locate(_Xv,X1);
-
-    int i = (Xindex%(_nx*_ny))%_nx;
-    int j = ((Xindex-i)%(_nx*_ny))/_nx;
-    int k = (Xindex-_nx*j - i)/(_nx*_ny);
+    // Draw a random position in cube based on the cumulative density distribution
+    int index = NR::locate(_Xv, random()->uniform());
+    int i = (index % (_nx * _ny)) % _nx;
+    int j = ((index - i) % (_nx * _ny)) / _nx;
+    int k = (index - _nx * j - i) / (_nx * _ny);
 
     // Determine the x, y and z coordinate in the datacube
-    double x = _xmin + (i+random()->uniform())*_pixelScale;
-    double y = _ymin + (j+random()->uniform())*_pixelScale;
-    double z = _zmin + (k+random()->uniform())*_pixelScale;
-
+    double x = _xmin + (i + random()->uniform()) * _pixelScale;
+    double y = _ymin + (j + random()->uniform()) * _pixelScale;
+    double z = _zmin + (k + random()->uniform()) * _pixelScale;
 
     // Return the position
-    return Position(x,y,z);
+    return Position(x, y, z);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -80,16 +74,16 @@ double ReadFits3DGeometry::SigmaX() const
 {
     double sum = 0;
     const int NSAMPLES = 10000;
-    double step = (_xmax-_xmin)/NSAMPLES;
+    double step = (_xmax - _xmin) / NSAMPLES;
 
     // For each position, get the density and add it to the total
     for (int k = 0; k < NSAMPLES; k++)
     {
-        sum += density(Position(_xmin + k*step, 0, 0));
+        sum += density(Position(_xmin + k * step, 0, 0));
     }
 
     // Return the x-axis surface density
-    return sum*step;
+    return sum * step;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -98,16 +92,16 @@ double ReadFits3DGeometry::SigmaY() const
 {
     double sum = 0;
     const int NSAMPLES = 10000;
-    double step = (_ymax-_ymin)/NSAMPLES;
+    double step = (_ymax - _ymin) / NSAMPLES;
 
     // For each position, get the density and add it to the total
     for (int k = 0; k < NSAMPLES; k++)
     {
-        sum += density(Position(_ymin + k*step, 0, 0));
+        sum += density(Position(_ymin + k * step, 0, 0));
     }
 
     // Return the y-axis surface density
-    return sum*step;
+    return sum * step;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -116,16 +110,16 @@ double ReadFits3DGeometry::SigmaZ() const
 {
     double sum = 0;
     const int NSAMPLES = 10000;
-    double step = (_zmax-_zmin)/NSAMPLES;
+    double step = (_zmax - _zmin) / NSAMPLES;
 
     // For each position, get the density and add it to the total
     for (int k = 0; k < NSAMPLES; k++)
     {
-        sum += density(Position(0, _zmin + k*step, 0));
+        sum += density(Position(0, _zmin + k * step, 0));
     }
 
     // Return the z-axis surface density
-    return sum*step;
+    return sum * step;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ReadFits3DGeometry.cpp
+++ b/SKIRT/core/ReadFits3DGeometry.cpp
@@ -1,0 +1,131 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "ReadFits3DGeometry.hpp"
+#include "FatalError.hpp"
+#include "FITSInOut.hpp"
+#include "NR.hpp"
+#include "Random.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void ReadFits3DGeometry::setupSelfBefore()
+{
+    GenGeometry::setupSelfBefore();
+
+    // Read in the datacube
+    FITSInOut::read(this, _filename, _datacube, _nx, _ny, _nz);
+
+    // Normalize the datacube
+    _datacube /= _datacube.sum();
+
+    // Construct a vector with the normalized cumulative distribution
+    NR::cdf(_Xv, _datacube);
+
+    // Calculate the boundaries of the datacube in physical coordinates
+    _xmin = -(_nx/2.)*_pixelScale;
+    _xmax =  (_nx/2.)*_pixelScale;
+    _ymin = -(_ny/2.)*_pixelScale;
+    _ymax =  (_ny/2.)*_pixelScale;
+    _zmin = -(_nz/2.)*_pixelScale;
+    _zmax =  (_nz/2.)*_pixelScale;
+
+}
+
+////////////////////////////////////////////////////////////////////
+
+double ReadFits3DGeometry::density(Position bfr) const
+{
+    double x,y,z;
+    bfr.cartesian(x,y,z);
+
+    // Find the corresponding spaxel in the datacube
+    int i = static_cast<int>(floor((x-_xmin)/_pixelScale));
+    int j = static_cast<int>(floor((y-_ymin)/_pixelScale));
+    int k = static_cast<int>(floor((z-_zmin)/_pixelScale));
+    if (i<0 || i>=_nx || j<0 || j>=_ny|| k<0 || k>=_nz) return 0.0;
+
+    // Return the density
+    return _datacube[i + _nx*j + _nx*_ny*k];
+}
+
+////////////////////////////////////////////////////////////////////
+
+Position ReadFits3DGeometry::generatePosition() const
+{
+    // Draw a random position in cube based on the
+    // cumulative distribution in each spaxel
+    double X1 = random()->uniform();
+    int Xindex = NR::locate(_Xv,X1);
+
+    int i = (Xindex%(_nx*_ny))%_nx;
+    int j = ((Xindex-i)%(_nx*_ny))/_nx;
+    int k = (Xindex-_nx*j - i)/(_nx*_ny);
+
+    // Determine the x, y and z coordinate in the datacube
+    double x = _xmin + (i+random()->uniform())*_pixelScale;
+    double y = _ymin + (j+random()->uniform())*_pixelScale;
+    double z = _zmin + (k+random()->uniform())*_pixelScale;
+
+
+    // Return the position
+    return Position(x,y,z);
+}
+
+////////////////////////////////////////////////////////////////////
+
+double ReadFits3DGeometry::SigmaX() const
+{
+    double sum = 0;
+    const int NSAMPLES = 10000;
+    double step = (_xmax-_xmin)/NSAMPLES;
+
+    // For each position, get the density and add it to the total
+    for (int k = 0; k < NSAMPLES; k++)
+    {
+        sum += density(Position(_xmin + k*step, 0, 0));
+    }
+
+    // Return the x-axis surface density
+    return sum*step;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double ReadFits3DGeometry::SigmaY() const
+{
+    double sum = 0;
+    const int NSAMPLES = 10000;
+    double step = (_ymax-_ymin)/NSAMPLES;
+
+    // For each position, get the density and add it to the total
+    for (int k = 0; k < NSAMPLES; k++)
+    {
+        sum += density(Position(_ymin + k*step, 0, 0));
+    }
+
+    // Return the y-axis surface density
+    return sum*step;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double ReadFits3DGeometry::SigmaZ() const
+{
+    double sum = 0;
+    const int NSAMPLES = 10000;
+    double step = (_zmax-_zmin)/NSAMPLES;
+
+    // For each position, get the density and add it to the total
+    for (int k = 0; k < NSAMPLES; k++)
+    {
+        sum += density(Position(0, _zmin + k*step, 0));
+    }
+
+    // Return the z-axis surface density
+    return sum*step;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ReadFits3DGeometry.cpp
+++ b/SKIRT/core/ReadFits3DGeometry.cpp
@@ -73,17 +73,17 @@ Position ReadFits3DGeometry::generatePosition() const
 double ReadFits3DGeometry::SigmaX() const
 {
     double sum = 0;
-    const int NSAMPLES = 10000;
-    double step = (_xmax - _xmin) / NSAMPLES;
 
     // For each position, get the density and add it to the total
-    for (int k = 0; k < NSAMPLES; k++)
+    int j = static_cast<int>(floor(_ny / 2.));
+    int k = static_cast<int>(floor(_nz / 2.));
+    for (int i = 0; i < _nx; i++)
     {
-        sum += density(Position(_xmin + k * step, 0, 0));
+        sum += _datacube[i + _nx * j + _nx * _ny * k];
     }
 
     // Return the x-axis surface density
-    return sum * step;
+    return sum * _pixelScale;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -91,17 +91,17 @@ double ReadFits3DGeometry::SigmaX() const
 double ReadFits3DGeometry::SigmaY() const
 {
     double sum = 0;
-    const int NSAMPLES = 10000;
-    double step = (_ymax - _ymin) / NSAMPLES;
 
     // For each position, get the density and add it to the total
-    for (int k = 0; k < NSAMPLES; k++)
+    int i = static_cast<int>(floor(_nx / 2.));
+    int k = static_cast<int>(floor(_nz / 2.));
+    for (int j = 0; j < _ny; j++)
     {
-        sum += density(Position(_ymin + k * step, 0, 0));
+        sum += _datacube[i + _nx * j + _nx * _ny * k];
     }
 
     // Return the y-axis surface density
-    return sum * step;
+    return sum * _pixelScale;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -109,17 +109,17 @@ double ReadFits3DGeometry::SigmaY() const
 double ReadFits3DGeometry::SigmaZ() const
 {
     double sum = 0;
-    const int NSAMPLES = 10000;
-    double step = (_zmax - _zmin) / NSAMPLES;
 
     // For each position, get the density and add it to the total
-    for (int k = 0; k < NSAMPLES; k++)
+    int i = static_cast<int>(floor(_nx / 2.));
+    int j = static_cast<int>(floor(_ny / 2.));
+    for (int k = 0; k < _nz; k++)
     {
-        sum += density(Position(0, _zmin + k * step, 0));
+        sum += _datacube[i + _nx * j + _nx * _ny * k];
     }
 
     // Return the z-axis surface density
-    return sum * step;
+    return sum * _pixelScale;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ReadFits3DGeometry.hpp
+++ b/SKIRT/core/ReadFits3DGeometry.hpp
@@ -13,10 +13,24 @@
 
 /** The ReadFits3DGeometry class is a subclass of the GenGeometry class, and describes an arbitary
     3D geometry for a single component, read from a 3D (.fits file) datacube. The model geometry is
-    set by two parameters: the input filename and the pixel scale. */
+    set by two parameters: the input filename and the pixel scale (i.e. the physical length per pixel).
+
+    The input geometry should be provided as a 3D datacube (i.e. an ndarray with shape (nx, ny, nz)),
+    stored in an HDU of the .fits input file. The order of axes is x, y, z and the header corresponding
+    to this data array resembles:
+    """
+    NAXIS   =                    3 / number of array dimensions
+    NAXIS1  =                   nx
+    NAXIS2  =                   ny
+    NAXIS3  =                   nz
+    """
+    with nx, ny and nz the number of cells in each spatial dimension. The input filename should include
+    the (.fits) extension. By default, the first HDU with nonempty data is used. Using the data from
+    another HDU in the provided .fits file is possible by specifying this HDU name between square brackets
+    after the input filename, for example: geometry.fits[USETHISHDU].*/
 class ReadFits3DGeometry : public GenGeometry
 {
-    ITEM_CONCRETE(ReadFits3DGeometry, GenGeometry, "a 3D geometry read from a FITS file")
+    ITEM_CONCRETE(ReadFits3DGeometry, GenGeometry, "a geometry read from a 3D FITS file")
         ATTRIBUTE_TYPE_DISPLAYED_IF(ReadFits3DGeometry, "Level2")
 
         PROPERTY_STRING(filename, "the filename of the datacube")

--- a/SKIRT/core/ReadFits3DGeometry.hpp
+++ b/SKIRT/core/ReadFits3DGeometry.hpp
@@ -13,15 +13,15 @@
 
 /** The ReadFits3DGeometry class is a subclass of the GenGeometry class, and describes an arbitary
     3D geometry for a single component, read from a 3D (.fits file) datacube. The model geometry is
-    set by two parameters: the input filename and the pixelscale \f$pix\f$. */
-class ReadFits3DGeometry: public GenGeometry
+    set by two parameters: the input filename and the pixel scale. */
+class ReadFits3DGeometry : public GenGeometry
 {
     ITEM_CONCRETE(ReadFits3DGeometry, GenGeometry, "a 3D geometry read from a FITS file")
-        //ATTRIBUTE_TYPE_DISPLAYED_IF(ReadFits3DGeometry, "Level2")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(ReadFits3DGeometry, "Level2")
 
-    PROPERTY_STRING(filename, "the filename of the datacube")
+        PROPERTY_STRING(filename, "the filename of the datacube")
 
-    PROPERTY_DOUBLE(pixelScale, "the pixelscale for the datacube (i.e. the physical length per pixel)")
+        PROPERTY_DOUBLE(pixelScale, "the pixel scale for the datacube (i.e. the physical length per pixel)")
         ATTRIBUTE_QUANTITY(pixelScale, "length")
         ATTRIBUTE_MIN_VALUE(pixelScale, "]0")
 
@@ -30,8 +30,9 @@ class ReadFits3DGeometry: public GenGeometry
     //============= Construction - Setup - Destruction =============
 
 protected:
-    /** This function reads in the .fits datacube. A vector with the normalized cumulative distribution in
-        each spaxel is computed, satisfying the condition that the total mass equals 1. */
+    /** This function reads in the .fits datacube. A vector with the normalized cumulative
+        distribution in each spaxel is computed, satisfying the condition that the total mass
+        equals 1. */
     void setupSelfBefore() override;
 
     //======================== Other Functions =======================
@@ -40,17 +41,18 @@ public:
     /** This function returns the density \f$\rho(x,y,z)\f$ at the position (x,y,z). */
     double density(Position bfr) const override;
 
-    /** This function generates a random position \f$(x,y,z)\f$ from the geometry, by drawing a random point
-        from the appropriate probability density distribution function. The \f$(x,y,z)\f$ coordinates are
-        derived from the normalized cumulative distribution vector. */
+    /** This function generates a random position \f$(x,y,z)\f$ from the geometry, by drawing a
+        random point from the appropriate probability density distribution function. The
+        \f$(x,y,z)\f$ coordinates are derived from the normalized cumulative distribution vector.
+        */
     Position generatePosition() const override;
 
-    /** This function returns the X-axis surface density, i.e. the integration of the density along the
-        entire X-axis, \f[ \Sigma_X = \int_{-\infty}^\infty \rho(x,0,0) \, \text{d} x \f] */
+    /** This function returns the X-axis surface density, i.e. the integration of the density along
+        the entire X-axis, \f[ \Sigma_X = \int_{-\infty}^\infty \rho(x,0,0) \, \text{d} x \f] */
     double SigmaX() const override;
 
-    /** This function returns the Y-axis surface density, i.e. the integration of the density along the
-        entire Y-axis, \f[ \Sigma_Y = \int_{-\infty}^\infty \rho(0,y,0) \, \text{d} y \f] */
+    /** This function returns the Y-axis surface density, i.e. the integration of the density along
+        the entire Y-axis, \f[ \Sigma_Y = \int_{-\infty}^\infty \rho(0,y,0) \, \text{d} y \f] */
     double SigmaY() const override;
 
     /** This function returns the Z-axis surface density, i.e. the integration of the density along
@@ -60,15 +62,13 @@ public:
     //======================== Data Members ========================
 
 private:
-
     // the input datacube and the cumulative distribution
     Array _datacube;
     int _nx{0}, _ny{0}, _nz{0};
     Array _Xv;
 
     // other data members initialized during setup
-    double _xmax{0.}, _ymax{0.}, _zmax{0.}, _xmin{0.}, _ymin{0.}, _zmin{0.};
-
+    double _xmin{0.}, _xmax{0.}, _ymin{0.}, _ymax{0.}, _zmin{0.}, _zmax{0.};
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ReadFits3DGeometry.hpp
+++ b/SKIRT/core/ReadFits3DGeometry.hpp
@@ -11,23 +11,24 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** The ReadFits3DGeometry class is a subclass of the GenGeometry class, and describes an arbitary
-    3D geometry for a single component, read from a 3D (.fits file) datacube. The model geometry is
-    set by two parameters: the input filename and the pixel scale (i.e. the physical length per pixel).
+/** The ReadFits3DGeometry class is a subclass of the GenGeometry class, and describes an arbitrary
+    3D geometry for a single component read from a FITS file datacube. The model geometry is
+    defined by two parameters: the input filename and the pixel scale (i.e. the physical length per
+    pixel). The geometry is automatically centered on the origin.
 
-    The input geometry should be provided as a 3D datacube (i.e. an ndarray with shape (nx, ny, nz)),
-    stored in an HDU of the .fits input file. The order of axes is x, y, z and the header corresponding
-    to this data array resembles:
-    """
-    NAXIS   =                    3 / number of array dimensions
-    NAXIS1  =                   nx
-    NAXIS2  =                   ny
-    NAXIS3  =                   nz
-    """
-    with nx, ny and nz the number of cells in each spatial dimension. The input filename should include
-    the (.fits) extension. By default, the first HDU with nonempty data is used. Using the data from
-    another HDU in the provided .fits file is possible by specifying this HDU name between square brackets
-    after the input filename, for example: geometry.fits[USETHISHDU].*/
+    The input geometry should be provided as a 3D datacube, i.e. an ndarray with shape (nx, ny,
+    nz), stored in an HDU of the FITS input file. The order of axes is x, y, z and the header
+    corresponding to this data array resembles:
+
+        NAXIS   =                    3 / number of array dimensions
+        NAXIS1  =                   nx
+        NAXIS2  =                   ny
+        NAXIS3  =                   nz
+
+    with nx, ny and nz the number of cells in each spatial dimension. The input filename should
+    include the ".fits" filename extension. By default, the first HDU with nonempty data is used.
+    Using the data from another HDU in the provided file is possible by specifying this HDU name
+    between square brackets after the input filename, for example: "geometry.fits[USETHISHDU]". */
 class ReadFits3DGeometry : public GenGeometry
 {
     ITEM_CONCRETE(ReadFits3DGeometry, GenGeometry, "a geometry read from a 3D FITS file")
@@ -82,7 +83,7 @@ private:
     Array _Xv;
 
     // other data members initialized during setup
-    double _xmin{0.}, _xmax{0.}, _ymin{0.}, _ymax{0.}, _zmin{0.}, _zmax{0.};
+    double _xmin{0.}, _ymin{0.}, _zmin{0.};
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ReadFits3DGeometry.hpp
+++ b/SKIRT/core/ReadFits3DGeometry.hpp
@@ -1,0 +1,76 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef READFITS3DGEOMETRY_HPP
+#define READFITS3DGEOMETRY_HPP
+
+#include "Array.hpp"
+#include "GenGeometry.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** The ReadFits3DGeometry class is a subclass of the GenGeometry class, and describes an arbitary
+    3D geometry for a single component, read from a 3D (.fits file) datacube. The model geometry is
+    set by two parameters: the input filename and the pixelscale \f$pix\f$. */
+class ReadFits3DGeometry: public GenGeometry
+{
+    ITEM_CONCRETE(ReadFits3DGeometry, GenGeometry, "a 3D geometry read from a FITS file")
+        //ATTRIBUTE_TYPE_DISPLAYED_IF(ReadFits3DGeometry, "Level2")
+
+    PROPERTY_STRING(filename, "the filename of the datacube")
+
+    PROPERTY_DOUBLE(pixelScale, "the pixelscale for the datacube (i.e. the physical length per pixel)")
+        ATTRIBUTE_QUANTITY(pixelScale, "length")
+        ATTRIBUTE_MIN_VALUE(pixelScale, "]0")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function reads in the .fits datacube. A vector with the normalized cumulative distribution in
+        each spaxel is computed, satisfying the condition that the total mass equals 1. */
+    void setupSelfBefore() override;
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function returns the density \f$\rho(x,y,z)\f$ at the position (x,y,z). */
+    double density(Position bfr) const override;
+
+    /** This function generates a random position \f$(x,y,z)\f$ from the geometry, by drawing a random point
+        from the appropriate probability density distribution function. The \f$(x,y,z)\f$ coordinates are
+        derived from the normalized cumulative distribution vector. */
+    Position generatePosition() const override;
+
+    /** This function returns the X-axis surface density, i.e. the integration of the density along the
+        entire X-axis, \f[ \Sigma_X = \int_{-\infty}^\infty \rho(x,0,0) \, \text{d} x \f] */
+    double SigmaX() const override;
+
+    /** This function returns the Y-axis surface density, i.e. the integration of the density along the
+        entire Y-axis, \f[ \Sigma_Y = \int_{-\infty}^\infty \rho(0,y,0) \, \text{d} y \f] */
+    double SigmaY() const override;
+
+    /** This function returns the Z-axis surface density, i.e. the integration of the density along
+        the entire Z-axis, \f[ \Sigma_Z = \int_{-\infty}^\infty \rho(0,0,z) \, \text{d} z \f] */
+    double SigmaZ() const override;
+
+    //======================== Data Members ========================
+
+private:
+
+    // the input datacube and the cumulative distribution
+    Array _datacube;
+    int _nx{0}, _ny{0}, _nz{0};
+    Array _Xv;
+
+    // other data members initialized during setup
+    double _xmax{0.}, _ymax{0.}, _zmax{0.}, _xmin{0.}, _ymin{0.}, _zmin{0.};
+
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/ReadFitsGeometry.hpp
+++ b/SKIRT/core/ReadFitsGeometry.hpp
@@ -23,7 +23,7 @@
     (x,y) image coordinates \f$x_c\f$ and \f$y_c\f$ and the vertical scale height \f$h_z\f$. */
 class ReadFitsGeometry : public GenGeometry
 {
-    ITEM_CONCRETE(ReadFitsGeometry, GenGeometry, "a geometry read from a FITS file")
+    ITEM_CONCRETE(ReadFitsGeometry, GenGeometry, "a geometry read from a 2D FITS file")
         ATTRIBUTE_TYPE_DISPLAYED_IF(ReadFitsGeometry, "Level2")
 
         PROPERTY_STRING(filename, "the name of the input image file")

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -190,6 +190,7 @@
 #include "RadiationFieldPerCellProbe.hpp"
 #include "RadiationFieldWavelengthGridProbe.hpp"
 #include "Random.hpp"
+#include "ReadFits3DGeometry.hpp"
 #include "ReadFitsGeometry.hpp"
 #include "RingGeometry.hpp"
 #include "RotateGeometryDecorator.hpp"
@@ -391,6 +392,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<MultiGaussianExpansionGeometry>();
     ItemRegistry::add<GenGeometry>();
     ItemRegistry::add<UniformBoxGeometry>();
+    ItemRegistry::add<ReadFits3DGeometry>();
     ItemRegistry::add<ReadFitsGeometry>();
     ItemRegistry::add<ImportedGeometry>();
     ItemRegistry::add<ParticleGeometry>();


### PR DESCRIPTION
**Description**
Added the functionality to read the spatial luminosity distribution for sources or the spatial density distribution for the medium from a .fits datacube.

**Motivation**
This allows SKIRT users to introduce arbitrary, asymmetric geometries into the simulation. 

**Tests**
This class has been thoroughly tested using a simple cubic geometry (cube.fits used by cube.ski). To exhibit the possibilities a top-toy was imported into SKIRT (top.fits used by top.ski). Test files are available here: [ReadFits3DGeometry_TestFiles.zip](https://github.com/SKIRT/SKIRT9/files/5495571/ReadFits3DGeometry_TestFiles.zip)


**Guidelines**
The model geometry is set by two parameters: the input filename and the pixelscale (i.e. the physical length per pixel).

**Context**
The example cube.fits represents a geometry of dimensions (7 AU x 4 AU x 10 AU), with pixelscale 1 AU (i.e. 7 x 4 x 10 spaxels).
