### PR TITLE
Fix the asymmetry in Lyman-alpha SEDs for static spheres

### DIFF
--- a/SKIRT/core/LyaUtils.cpp
+++ b/SKIRT/core/LyaUtils.cpp
@@ -100,9 +100,7 @@ std::pair<Vec, bool> LyaUtils::sampleAtomVelocity(double lambda, double T, doubl
 
 double LyaUtils::shiftWavelength(double lambda, const Vec& vatom, const Direction& kin, const Direction& kout)
 {
-    double vp = (la - lambda) / lambda * c;                  // incoming photon velocity shift
-    vp = vp - Vec::dot(vatom, kin) + Vec::dot(vatom, kout);  // outgoing photon velocity shift
-    return la / (1 + vp / c);
+    return lambda / (1 - Vec::dot(kin, vatom) / c) * (1 - Vec::dot(kout, vatom) / c);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/LyaUtils.cpp
+++ b/SKIRT/core/LyaUtils.cpp
@@ -87,7 +87,7 @@ std::pair<Vec, bool> LyaUtils::sampleAtomVelocity(double lambda, double T, doubl
     // select the isotropic or the dipole phase function:
     // all wing events and 1/3 of core events are dipole, and the remaining 2/3 core events are isotropic,
     // where x=0.2 (in the atom frame) defines the transition between core and wings
-    bool dipole = x > 0.2 || random->uniform() < 1. / 3.;
+    bool dipole = abs(x) > 0.2 || random->uniform() < 1. / 3.;
 
     // scale the atom velocity from dimensionless to regular units
     u *= vth;


### PR DESCRIPTION
**Description**
This pull request fixes the slight but systematic asymmetry noted in Lyman-alpha SEDs for static sphere benchmarks. The culprit was a bug in the implementation of the choice between isotropic and dipole scattering phase functions (the dipole was selected only for wavelengths on one side of the Lyman-alpha line center).

Also, a minor performance optimization was made in the calculation of the wavelength shift for each scattering event.

**Tests**
All functional tests and benchmark results have been verified for this update.

**Context**
All 1D Lyman-alpha benchmarks now seem to run with satisfactory results.
