### PR TITLE
Avoid compiler warning from GCC

### DIFF
--- a/SKIRT/core/AdaptiveMeshSnapshot.cpp
+++ b/SKIRT/core/AdaptiveMeshSnapshot.cpp
@@ -482,6 +482,7 @@ public:
                 if (ds() > 0.) return true;
             }
 
+            // intentionally falls through
             case State::Inside:
             {
                 // determine the segment from the current position to the first cell wall

--- a/SKIRT/core/CartesianSpatialGrid.cpp
+++ b/SKIRT/core/CartesianSpatialGrid.cpp
@@ -104,6 +104,7 @@ public:
                 if (ds() > 0.) return true;
             }
 
+            // intentionally falls through
             case State::Inside:
             {
                 // determine the segment from the current position to the first cell wall

--- a/SKIRT/core/Cylinder2DSpatialGrid.cpp
+++ b/SKIRT/core/Cylinder2DSpatialGrid.cpp
@@ -222,6 +222,7 @@ public:
                 if (ds() > 0.) return true;
             }
 
+            // intentionally falls through
             case State::Inside:
             {
                 switch (_phase)

--- a/SKIRT/core/Sphere1DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.cpp
@@ -155,6 +155,7 @@ public:
                 // fall through to determine the first actual segment
             }
 
+            // intentionally falls through
             case State::Inside:
             {
                 switch (_phase)

--- a/SKIRT/core/Sphere2DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere2DSpatialGrid.cpp
@@ -258,6 +258,7 @@ public:
                 // fall through to determine the first actual segment
             }
 
+            // intentionally falls through
             case State::Inside:
             {
                 while (true)  // the loop is executed more than once only if no exit point is found

--- a/SKIRT/core/TreeSpatialGrid.cpp
+++ b/SKIRT/core/TreeSpatialGrid.cpp
@@ -145,6 +145,7 @@ public:
                 if (ds() > 0.) return true;
             }
 
+            // intentionally falls through
             case State::Inside:
             {
                 // determine the segment from the current position to the first cell wall

--- a/SKIRT/core/VoronoiMeshSnapshot.cpp
+++ b/SKIRT/core/VoronoiMeshSnapshot.cpp
@@ -1083,6 +1083,7 @@ public:
                 if (ds() > 0.) return true;
             }
 
+            // intentionally falls through
             case State::Inside:
             {
                 // loop in case no exit point was found (which should happen only rarely)


### PR DESCRIPTION
**Description**
This change suppresses a compiler warning issued by recent GCC version for `switch` statements that include a fall-through `case`. The new path segment calculators include such a construct. The warning is suppressed by adding a specific comment that gets captured by the compiler.

**Motivation**
Compiler warnings are confusing.

**Tests**
There are no changes to the code itself.
