### PR TITLE
Check that unzip is available in downloadResources

### DIFF
--- a/downloadResources.sh
+++ b/downloadResources.sh
@@ -27,6 +27,13 @@ else
     exit 1
 fi
 
+# before we download: check that unzip is available
+if ! which unzip >/dev/null
+then
+    echo error: no unzip available to unzip files
+    exit 1
+fi
+
 # loop over the list of expected archives and versions given in the text file in the SKIRT repository
 while read -u 3 LINE        # use explicit file descriptor 3 to allow nested read from terminal
 do


### PR DESCRIPTION
**Description**
The `downloadResources.sh` script did not check that `unzip` is available before downloading the resources, which would lead to an unnecessary download of 650MB. I added an additional check before the download starts to make sure the downloaded archives can be unzipped.

**Context**
When installing SKIRT within a Docker container, the base image might not have `unzip` available. Installing `unzip` takes a few seconds, but if you only notice it is missing after the download completed, this leads to a lot of unnecessary network traffic.