### PR TITLE
HEALPixSkyInstrument calibration and coordinate transformation fixes

### DIFF
--- a/SKIRT/core/FluxRecorder.hpp
+++ b/SKIRT/core/FluxRecorder.hpp
@@ -166,6 +166,15 @@ public:
     void includeSurfaceBrightness(int numPixelsX, int numPixelsY, double pixelSizeX, double pixelSizeY, double centerX,
                                   double centerY, bool convertToAngularSize);
 
+    /** This function enables recording of IFU data cubes of the entire sky, i.e. a surface brightness
+        image frame for each wavelength with a fixed angular pixel size and a flux calibration that
+        depends on the actual distance between an object and the observer.
+        This function is similar to includeSurfaceBrightness(), but includes some sensible defaults for
+        some of the parameters. It also sets all the distances of the instrument, replacing calls to
+        setRestFrameDistance() or setObserverFrameRedshift().
+        */
+    void includeAllSkySurfaceBrightness(int numPixelsX, int numPixelsY, double angularPixelSize);
+
     /** This function completes the configuration of the recorder. It must be called after any of
         the configuration functions, and before the first invocation of the detect() function. */
     void finalizeConfiguration();
@@ -284,6 +293,10 @@ private:
     double _centerX{0};
     double _centerY{0};
     bool _convertToAngularSize{false};
+
+    // recorder configuration for all-sky maps, received from client during configuration
+    bool _fixAngularPixelSize{false};
+    double _angularPixelSize{0};
 
     // cached info, initialized when configuration is finalized
     MediumSystem* _ms{nullptr};   // pointer to medium system, if present (used only if hasMedium is true)

--- a/SKIRT/core/HEALPixSkyInstrument.cpp
+++ b/SKIRT/core/HEALPixSkyInstrument.cpp
@@ -8,6 +8,7 @@
 #include "FluxRecorder.hpp"
 #include "Log.hpp"
 #include "PhotonPacket.hpp"
+#include <iostream>
 
 ////////////////////////////////////////////////////////////////////
 
@@ -16,12 +17,17 @@ void HEALPixSkyInstrument::setupSelfBefore()
     Instrument::setupSelfBefore();
 
     // verify consistency of vector properties
-    Vec co(_Ox - _Cx, _Oy - _Cy, _Oz - _Cz);  // vector in direction from crosshair to observer
+    Vec co(_Cx - _Ox, _Cy - _Oy, _Cz - _Oz);  // vector in direction from observer to crosshair
     Vec up(_Ux, _Uy, _Uz);                    // vector in the upward direction
     if (co.norm() < 1e-20) throw FATALERROR("Crosshair is too close to observer");
     if (up.norm() < 1e-20) throw FATALERROR("Upwards direction cannot be null vector");
-    if (Vec::cross(co, up).norm() < 1e-20)
-        throw FATALERROR("Upwards direction cannot be parallel to viewing direction");
+    if (Vec::dot(co, up) > 1e-20) throw FATALERROR("Crosshair direction and upwards direction are not orthogonal!");
+
+    _bfax = co / co.norm();
+    _bfaz = up / up.norm();
+    _bfay = Vec::cross(_bfaz, _bfax);
+    // correct for possible rounding issues
+    _bfay /= _bfay.norm();
 
     // compute the side length of the subdivision within a single HEALPix base pixel
     _Nside = 1 << _order;
@@ -34,50 +40,9 @@ void HEALPixSkyInstrument::setupSelfBefore()
     // each HEALPix pixel has the same spherical area pi/(3*_Nside^2)
     // we assume that the pixels are squares with this surface area
     // due to the calibration of the FrameInstrument, we need to multiply this with the radius of the instrument
-    _s = sqrt(M_PI / (3 * _Nside * _Nside)) * _radius;
+    double omega = M_PI / (3 * _Nside * _Nside);
 
-    // setup the transformation from world to observer coordinates
-
-    // translate to observer position
-    _transform.translate(-_Ox, -_Oy, -_Oz);
-
-    // unit vector in direction from crosshair to observer
-    Vec kn(_Ox - _Cx, _Oy - _Cy, _Oz - _Cz);
-    kn /= kn.norm();
-    double a = kn.x();
-    double b = kn.y();
-    double c = kn.z();
-
-    // rotate from world to observer coordinates just as for the perspective transformation
-    double v = sqrt(b * b + c * c);
-    if (v > 0.3)
-    {
-        _transform.rotateX(c / v, -b / v);
-        _transform.rotateY(v, -a);
-        double k = (b * b + c * c) * _Ux - a * b * _Uy - a * c * _Uz;
-        double l = c * _Uy - b * _Uz;
-        double u = sqrt(k * k + l * l);
-        _transform.rotateZ(l / u, -k / u);
-    }
-    else
-    {
-        v = sqrt(a * a + c * c);
-        _transform.rotateY(c / v, -a / v);
-        _transform.rotateX(v, -b);
-        double k = c * _Ux - a * _Uz;
-        double l = (a * a + c * c) * _Uy - a * b * _Ux - b * c * _Uz;
-        double u = sqrt(k * k + l * l);
-        _transform.rotateZ(l / u, -k / u);
-    }
-    // rather than flipping the z-axis as is done for the perspective transformation,
-    // rotate the axes into the alignment appropriate for our purposes (z-axis up, x-axis towards crosshair)
-    _transform.rotateX(0., 1.);
-    _transform.rotateZ(0., -1.);
-
-    // configure flux recorder with a large distance relative to the pixel size so that atan(s/2d) = s/2d
-    // and the default calibration can be easily corrected when detecting each individual photon packet
-    instrumentFluxRecorder()->setRestFrameDistance(_s * 1e8);
-    instrumentFluxRecorder()->includeSurfaceBrightness(_Nx, _Ny, _s, _s, 0, 0, false);
+    instrumentFluxRecorder()->includeAllSkySurfaceBrightness(_Nx, _Ny, omega);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -85,9 +50,10 @@ void HEALPixSkyInstrument::setupSelfBefore()
 void HEALPixSkyInstrument::determineSameObserverAsPreceding(const Instrument* precedingInstrument)
 {
     auto other = dynamic_cast<const HEALPixSkyInstrument*>(precedingInstrument);
-    if (other && radius() == other->radius() && observerX() == other->observerX() && observerY() == other->observerY()
-        && observerZ() == other->observerZ() && crossX() == other->crossX() && crossY() == other->crossY()
-        && crossZ() == other->crossZ() && upX() == other->upX() && upY() == other->upY() && upZ() == other->upZ())
+    if (other && smallRadius() == other->smallRadius() && observerX() == other->observerX()
+        && observerY() == other->observerY() && observerZ() == other->observerZ() && crossX() == other->crossX()
+        && crossY() == other->crossY() && crossZ() == other->crossZ() && upX() == other->upX() && upY() == other->upY()
+        && upZ() == other->upZ())
     {
         setSameObserverAsPreceding();
     }
@@ -102,7 +68,7 @@ Direction HEALPixSkyInstrument::bfkobs(const Position& bfr) const
     double d = k.norm();
 
     // if the distance is very small, return something arbitrary - the photon packet will not be detected anyway
-    if (d < _s) return Direction();
+    if (d < _smallRadius) return Direction();
 
     // otherwise return a unit vector in the direction from launch to observer
     return Direction(k / d);
@@ -117,7 +83,7 @@ Direction HEALPixSkyInstrument::bfkx(const Position& bfr) const
     double d = k.norm();
 
     // if the distance is very small, return something arbitrary - the photon packet will not be detected anyway
-    if (d < _s) return Direction();
+    if (d < _smallRadius) return Direction();
 
     // vector in the plane normal to the line launch-observer
     // oriented perpendicular to the projection of the up direction in that plane
@@ -137,7 +103,7 @@ Direction HEALPixSkyInstrument::bfky(const Position& bfr) const
     double d = k.norm();
 
     // if the distance is very small, return something arbitrary - the photon packet will not be detected anyway
-    if (d < _s) return Direction();
+    if (d < _smallRadius) return Direction();
 
     // vector in the plane normal to the line launch-observer
     // oriented along the projection of the up direction in that plane
@@ -152,16 +118,20 @@ Direction HEALPixSkyInstrument::bfky(const Position& bfr) const
 
 void HEALPixSkyInstrument::detect(PhotonPacket* pp)
 {
-    // transform launch position from world to observer coordinates
-    Position p(_transform.transform(pp->position()));
+    // transform from world coordinates to observer coordinates:
+    //  - first translate to a frame with the observer at the origin
+    Vec relpos(pp->position().x() - _Ox, pp->position().y() - _Oy, pp->position().z() - _Oz);
+    //  - now rotate by projecting the position along the new coordinate axes
+    Position p(Vec::dot(relpos, _bfax), Vec::dot(relpos, _bfay), Vec::dot(relpos, _bfaz));
 
     // get the spherical coordinates of the launch position relative to the observer
     double d, theta, phi;
     p.spherical(d, theta, phi);
+    // put the crosshair in the centre of the image rather than at the edge
     phi += M_PI;
 
     // if the radial distance is very small, ignore the photon packet
-    if (d < _s) return;
+    if (d < _smallRadius) return;
 
     // the HEALPix mapping algorithm expects theta in [0, pi] and phi in [0, 2*pi]
     if (theta < 0.) theta += M_PI;

--- a/SKIRT/core/HEALPixSkyInstrument.cpp
+++ b/SKIRT/core/HEALPixSkyInstrument.cpp
@@ -21,13 +21,14 @@ void HEALPixSkyInstrument::setupSelfBefore()
     Vec up(_Ux, _Uy, _Uz);                    // vector in the upward direction
     if (co.norm() < 1e-20) throw FATALERROR("Crosshair is too close to observer");
     if (up.norm() < 1e-20) throw FATALERROR("Upwards direction cannot be null vector");
-    if (Vec::dot(co, up) > 1e-20) throw FATALERROR("Crosshair direction and upwards direction are not orthogonal!");
+    _bfay = Vec::cross(up, co);
+    if (_bfay.norm() < 1e-20) throw FATALERROR("Upwards direction cannot be parallel to viewing direction");
+
+    _bfaz = Vec::cross(co, _bfay);
 
     _bfax = co / co.norm();
-    _bfaz = up / up.norm();
-    _bfay = Vec::cross(_bfaz, _bfax);
-    // correct for possible rounding issues
     _bfay /= _bfay.norm();
+    _bfaz /= _bfaz.norm();
 
     // compute the side length of the subdivision within a single HEALPix base pixel
     _Nside = 1 << _order;

--- a/SKIRT/core/HEALPixSkyInstrument.hpp
+++ b/SKIRT/core/HEALPixSkyInstrument.hpp
@@ -82,11 +82,12 @@
     The orientation and position of the instrument is governed by a position (that sets the origin
     of the observer reference frame) and two directions: a crosshair direction that determines the
     direction of the x-axis of the observer reference frame, and an upward direction that determines
-    the direction of the z-axis of the observer reference frame. These directions should be
-    orthogonal to each other. The HEALPix pixels are labelled with the spherical coordinate angles
-    \f$\theta{}\f$ and \f$\phi{}\f$ within this frame. The resulting image data cube is rotated
-    around the z-axis over an additional angle \f$\phi{}'=180^\circ{}\f$ to place the crosshair at
-    the centre of the output image.
+    the direction of the z-axis of the observer reference frame. These directions should not be parallel
+    to each other. If the upward direction is not orthogonal to the crosshair direction, the actual
+    z-axis will be the projection of the upward direction onto the plane perpendicular to the crosshair
+    direction. The HEALPix pixels are labelled with the spherical coordinate angles \f$\theta{}\f$ and
+    \f$\phi{}\f$ within this frame. The resulting image data cube is rotated around the z-axis over an
+    additional angle \f$\phi{}'=180^\circ{}\f$ to place the crosshair at the centre of the output image.
 
     This instrument does \em not seperately record spatially integrated flux densities. */
 class HEALPixSkyInstrument : public Instrument


### PR DESCRIPTION
**Description**
The flux calibration in the `HEALPixSkyInstrument` was wrong, leading to fluxes that did not respect some basic physical laws, like the law that states that a flux should decrease with the distance to an object. It is very likely that the same is true for the `AllSkyInstrument` and the `PerspectiveInstrument`. This pull request adds an additional configuration flag and variable to `FluxRecorder` that allows for a proper calibration of the fluxes (upon detection of a photon packet) without affecting the calibration for other instruments. The pull request also gets rid of the current coordinate transformation used by the `HEALPixSkyInstrument` to convert from world coordinates to the observer coordinate frame, since this transformation did not yield intuitive results. The instrument documentation was updated to reflect all changes.

**Motivation**
The original `HEALPixSkyInstrument` calibration depended on an arbitrary radius and scaled accordingly. This made it impossible to compare fluxes with observational results (e.g. the Planck all-sky maps), and also turned out to be wrong, since distant objects appeared brighter than they should.

**Tests**
[sourcecube.zip](https://github.com/SKIRT/SKIRT9/files/5965152/sourcecube.zip) contains the files required to set up a simple test case, consisting of a cube with side length 2 kpc and centred at the origin that has a number of sources on its faces, edges and corners. The sources are observed by a `HEALPixSkyInstrument` at the origin. The base idea is to put sources at the centres of all 6 faces, the centres of all 12 edges, and on all 8 corners. However, this leads to symmetric positions for the observed fluxes, which makes it impossible to test the projected positions. For this reason, only a quarter of the cube is actually used. All sources have the same luminosity, and since we know all distances and solid angles involved, it is possible to predict the observed fluxes. The results match the predictions:
![result](https://user-images.githubusercontent.com/7336967/107636493-040b0c00-6c6d-11eb-8656-8365fb5acee5.png)
The `.zip` file contains a template `.ski` file without sources, a script (`write_sourcecube_ski.py`) to generate the actual `.ski` file for the test, and an analysis script (`results.py`) that generates the above image. The latter uses PTS to match sky angles to HEALPix pixels.

**Guidelines**
Code was formatted with the formatting script.

**Context**
The changes to `FluxRecorder` have been made in such a way that they do not currently affect the other instruments. Since I am however more and more convinced that the calibration for `AllSkyInstrument` and `PerspectiveInstrument` is also wrong, it might be good to revise these as well before merging this request.