### PR TITLE
Fix surface brightness calibration and coordinate transforms for local instruments

### DIFF
--- a/SKIRT/core/AllSkyInstrument.cpp
+++ b/SKIRT/core/AllSkyInstrument.cpp
@@ -72,7 +72,7 @@ void AllSkyInstrument::setupSelfBefore()
     double inc = M_PI / _Ny;
 
     // configure flux recorder
-    instrumentFluxRecorder()->includeSurfaceBrightnessForLocal(_Nx, _Ny, omega, inc, inc, 0., 0., "posangle");
+    instrumentFluxRecorder()->includeSurfaceBrightnessForLocal(_Nx, _Ny, omega, -inc, inc, 0., 0., "posangle");
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/AllSkyInstrument.cpp
+++ b/SKIRT/core/AllSkyInstrument.cpp
@@ -105,26 +105,6 @@ Direction AllSkyInstrument::bfkobs(const Position& bfr) const
 
 ////////////////////////////////////////////////////////////////////
 
-Direction AllSkyInstrument::bfkx(const Position& bfr) const
-{
-    // vector and distance from launch to observer
-    Vec k = Vec(_Ox, _Oy, _Oz) - bfr;
-    double d = k.norm();
-
-    // if the distance is very small, return something arbitrary - the photon packet will not be detected anyway
-    if (d <= _radius) return Direction();
-
-    // vector in the plane normal to the line launch-observer
-    // oriented perpendicular to the projection of the up direction in that plane
-    Vec ku(_Ux, _Uy, _Uz);
-    Vec kx = Vec::cross(ku, k);
-
-    // return unit vector along y-axis
-    return Direction(kx / kx.norm());
-}
-
-////////////////////////////////////////////////////////////////////
-
 Direction AllSkyInstrument::bfky(const Position& bfr) const
 {
     // vector and distance from launch to observer

--- a/SKIRT/core/AllSkyInstrument.cpp
+++ b/SKIRT/core/AllSkyInstrument.cpp
@@ -59,7 +59,7 @@ void AllSkyInstrument::setupSelfBefore()
         double u = sqrt(k * k + l * l);
         _transform.rotateZ(l / u, -k / u);
     }
-    // rather than flipping the z-axis as is done for the perspective transformation,
+
     // rotate the axes into the alignment appropriate for our purposes (z-axis up, x-axis towards crosshair)
     _transform.rotateX(0., 1.);
     _transform.rotateZ(0., -1.);
@@ -80,10 +80,9 @@ void AllSkyInstrument::setupSelfBefore()
 void AllSkyInstrument::determineSameObserverAsPreceding(const Instrument* precedingInstrument)
 {
     auto other = dynamic_cast<const AllSkyInstrument*>(precedingInstrument);
-    if (other && projection()->type() == other->projection()->type() && radius() == other->radius()
-        && observerX() == other->observerX() && observerY() == other->observerY() && observerZ() == other->observerZ()
-        && crossX() == other->crossX() && crossY() == other->crossY() && crossZ() == other->crossZ()
-        && upX() == other->upX() && upY() == other->upY() && upZ() == other->upZ())
+    if (other && radius() == other->radius() && observerX() == other->observerX() && observerY() == other->observerY()
+        && observerZ() == other->observerZ() && crossX() == other->crossX() && crossY() == other->crossY()
+        && crossZ() == other->crossZ() && upX() == other->upX() && upY() == other->upY() && upZ() == other->upZ())
     {
         setSameObserverAsPreceding();
     }

--- a/SKIRT/core/AllSkyInstrument.cpp
+++ b/SKIRT/core/AllSkyInstrument.cpp
@@ -61,14 +61,14 @@ void AllSkyInstrument::setupSelfBefore()
     }
 
     // rotate the axes into the alignment appropriate for our purposes (z-axis up, x-axis towards crosshair)
-    _transform.rotateX(0., 1.);
-    _transform.rotateZ(0., -1.);
+    _transform.rotateX(0., -1.);
+    _transform.rotateZ(0., 1.);
 
     // determine the solid angle corresponding to each pixel, assuming an area preserving projection
     // and a usage fraction in the output rectangle of pi/4
     double omega = 16. / (_Nx * _Ny);
 
-    // determine the angular size of a pixel in the output map, i.e. in geographical coordinates
+    // determine the scale of the output map axes, i.e. in geographical coordinates
     double inc = M_PI / _Ny;
 
     // configure flux recorder

--- a/SKIRT/core/AllSkyInstrument.hpp
+++ b/SKIRT/core/AllSkyInstrument.hpp
@@ -18,27 +18,16 @@
     the HEALPixSkyInstrument class for an instrument that does \em not perform such a projection).
 
     An all-sky instrument consists of a sphere with a given radius, centered at the location of the
-    instrument, on which model's radiation is projected. When a peel-off photon packet arrives, the
-    spherical coordinates of its origin relative to the instrument location are determined. The two
-    resulting angular coordinates are transformed to pixel coordinates in the image frame using the
-    selected all-sky projection. The radial coordinate (i.e. the distance from the photon packet's
-    origin to the instrument location) is used for converting the photon packet's luminosity
-    contribution to a flux density. In addition to the distance, this conversion also requires a
-    pixel size, which is determined from the radius of the instrument's sphere (this is in fact the
-    only purpose for specifying this quantity).
+    instrument. Only photon packets originating outside of this sphere are detected. When a
+    peel-off photon packet arrives, the spherical coordinates of its origin relative to the
+    instrument location are determined. The two resulting angular coordinates are transformed to
+    pixel coordinates in the image frame using the selected all-sky projection. The radial
+    coordinate (i.e. the distance from the photon packet's origin to the instrument location) is
+    used for adjusting the photon packet's luminosity contribution to the surface brightness in its
+    target pixel. More details on the flux calibration for this "local" instrument are provided in
+    the header of the FluxRecorder class.
 
-    The surface brightness calibration for this instrument (as for the HEALPixSkyInstrument) is
-    tricky. While the angular size of the individual pixels is known, the angular size of the
-    pixels as seen from a distant object is not, since the pixels do not have an actual physical
-    size. We can define such a physical size by defining a radius for the instrument, which is then
-    used to convert the angular size to a physical size. This radius is quite arbitrary, but should
-    nonetheless be chosen with some care: if the radius is too small, then recorded flux values
-    will be very high or even overflow. A good rule of thumb is to use a radius that has a similar
-    size to your object of study. For example, for a galaxy, with sizes in kpc, a radius of 1 pc
-    works well. It is always possible to recalibrate the fluxes afterwards by using the same radius
-    and adjusting to the pixel size of an actual instrument.
-
-    This instrument does \em not seperately record spatially integrated flux densities. */
+    This instrument does \em not support recording of spatially integrated flux densities. */
 class AllSkyInstrument : public Instrument
 {
     ITEM_CONCRETE(AllSkyInstrument, Instrument, "an all-sky instrument (for observing inside a model)")
@@ -142,9 +131,6 @@ private:
     // data members derived from the published attributes during setup
     int _Nx{0};                       // number of pixels in the x direction
     int _Ny{0};                       // number of pixels in the y direction
-    double _s{0.};                    // estimated linear size of a pixel
-    Direction _bfkx;                  // unit vector along the viewport's x-axis
-    Direction _bfky;                  // unit vector along the viewport's y-axis
     HomogeneousTransform _transform;  // transform from world to observer coordinates
 };
 

--- a/SKIRT/core/AllSkyInstrument.hpp
+++ b/SKIRT/core/AllSkyInstrument.hpp
@@ -18,14 +18,14 @@
     the HEALPixSkyInstrument class for an instrument that does \em not perform such a projection).
 
     An all-sky instrument consists of a sphere with a given radius, centered at the location of the
-    instrument. Only photon packets originating outside of this sphere are detected. When a
-    peel-off photon packet arrives, the spherical coordinates of its origin relative to the
-    instrument location are determined. The two resulting angular coordinates are transformed to
-    pixel coordinates in the image frame using the selected all-sky projection. The radial
-    coordinate (i.e. the distance from the photon packet's origin to the instrument location) is
-    used for adjusting the photon packet's luminosity contribution to the surface brightness in its
-    target pixel. More details on the flux calibration for this "local" instrument are provided in
-    the header of the FluxRecorder class.
+    instrument. Only photon packets originating outside of this sphere are detected. When a photon
+    packet arrives, the spherical coordinates of its originating position relative to the
+    instrument coordinate system are determined. The two resulting angular coordinates are
+    transformed to pixel coordinates in the image frame using the selected all-sky projection. The
+    radial coordinate (i.e. the distance from the photon packet's origin to the instrument
+    location) is used for adjusting the photon packet's luminosity contribution to the surface
+    brightness in its target pixel. More details on the flux calibration for this "local"
+    instrument are provided in the header of the FluxRecorder class.
 
     This instrument does \em not support recording of spatially integrated flux densities. */
 class AllSkyInstrument : public Instrument

--- a/SKIRT/core/AllSkyInstrument.hpp
+++ b/SKIRT/core/AllSkyInstrument.hpp
@@ -100,11 +100,6 @@ public:
         position, expressed in model coordinates. */
     Direction bfkobs(const Position& bfr) const override;
 
-    /** Returns the direction along the positive x-axis in a plane normal to the vector towards the
-        observer from the given photon packet launching position, expressed in model coordinates.
-        */
-    Direction bfkx(const Position& bfr) const override;
-
     /** Returns the direction along the positive y-axis in a plane normal to the vector towards the
         observer from the given photon packet launching position, expressed in model coordinates.
         */

--- a/SKIRT/core/AllSkyProjection.cpp
+++ b/SKIRT/core/AllSkyProjection.cpp
@@ -10,7 +10,7 @@
 void AllSkyProjection::fromSphereToRectangle(double inclination, double azimuth, double& x, double& y) const
 {
     double longitude = -azimuth;
-    double latitude = inclination - M_PI_2;
+    double latitude = M_PI_2 - inclination;
     fromGlobeToRectangle(longitude, latitude, x, y);
 }
 
@@ -20,7 +20,7 @@ bool AllSkyProjection::fromRectangleToSphere(double x, double y, double& inclina
 {
     double longitude, latitude;
     bool success = fromRectangleToGlobe(x, y, longitude, latitude);
-    inclination = latitude + M_PI_2;
+    inclination = M_PI_2 - latitude;
     azimuth = -longitude;
     return success;
 }

--- a/SKIRT/core/AllSkyProjection.hpp
+++ b/SKIRT/core/AllSkyProjection.hpp
@@ -31,10 +31,10 @@
         Longitude ranges from \f$-\pi\f$ to \f$\pi\f$, and latitude from \f$-\pi/2\f$ to \f$\pi/2\f$
 
     Including an east-west flip because an all-sky projection looks from inside the sphere, while a
-    geographical map looks from outside of the sphere; conversion from spherical to geographical
+    geographical map looks from outside of the sphere, conversion from spherical to geographical
     coordinates reads:
       -  longitude = -azimuth
-      -  latitude = inclination - \f$\pi/2\f$
+      -  latitude = \f$\pi/2\f$ - inclination
 
     <b>Projection properties</b>
 

--- a/SKIRT/core/AllSkyProjection.hpp
+++ b/SKIRT/core/AllSkyProjection.hpp
@@ -36,6 +36,15 @@
       -  longitude = -azimuth
       -  latitude = inclination - \f$\pi/2\f$
 
+    <b>Projection properties</b>
+
+    Projecting a sphere to a rectangle necessarily introduces distortions to distance, angle,
+    shape, and/or area. To properly work with the SKIRT instrument flux calibration, an all-sky
+    projection must be preserve area ("equal area"), while it may and probably will distort
+    distance, angle and shape. Furthermore, in the rectangular coordinates defined above, the
+    portion of the rectangle that maps to the sphere (the "used" portion) must be a circle with
+    radius one.
+
     */
 class AllSkyProjection : public SimulationItem
 {

--- a/SKIRT/core/DistantInstrument.cpp
+++ b/SKIRT/core/DistantInstrument.cpp
@@ -43,8 +43,6 @@ void DistantInstrument::setupSelfBefore()
 
     // calculate relevant directions
     _bfkobs = Direction(_inclination, _azimuth);
-    _bfkx = Direction(+cosphi * costheta * sinomega - sinphi * cosomega,
-                      +sinphi * costheta * sinomega + cosphi * cosomega, -sintheta * sinomega);
     _bfky = Direction(-cosphi * costheta * cosomega - sinphi * sinomega,
                       -sinphi * costheta * cosomega + cosphi * sinomega, +sintheta * cosomega);
 }
@@ -66,13 +64,6 @@ void DistantInstrument::determineSameObserverAsPreceding(const Instrument* prece
 Direction DistantInstrument::bfkobs(const Position& /*bfr*/) const
 {
     return _bfkobs;
-}
-
-////////////////////////////////////////////////////////////////////
-
-Direction DistantInstrument::bfkx(const Position& /*bfr*/) const
-{
-    return _bfkx;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/DistantInstrument.hpp
+++ b/SKIRT/core/DistantInstrument.hpp
@@ -105,12 +105,6 @@ public:
         */
     Direction bfkobs(const Position& bfr) const override;
 
-    /** Returns the direction along the positive x-axis of the instrument frame, expressed in model
-        coordinates. The function applies the inverse instrument transformation to the pixel
-        frame's x-axis. The provided photon packet's launching position is not used because the
-        orientation of the instrument frame does not depend on it. */
-    Direction bfkx(const Position& bfr) const override;
-
     /** Returns the direction along the positive y-axis of the instrument frame, expressed in model
         coordinates. The function applies the inverse instrument transformation to the pixel
         frame's y-axis. The provided photon packet's launching position is not used because the
@@ -122,7 +116,6 @@ public:
     // data members derived from the discoverable properties during setup
 private:
     Direction _bfkobs;
-    Direction _bfkx;
     Direction _bfky;
 };
 

--- a/SKIRT/core/FluxRecorder.cpp
+++ b/SKIRT/core/FluxRecorder.cpp
@@ -86,25 +86,41 @@ void FluxRecorder::setObserverFrameRedshift(double redshift, double angularDiame
 
 ////////////////////////////////////////////////////////////////////
 
-void FluxRecorder::includeFluxDensity()
+void FluxRecorder::includeFluxDensityForDistant()
 {
     _includeFluxDensity = true;
 }
 
 ////////////////////////////////////////////////////////////////////
 
-void FluxRecorder::includeSurfaceBrightness(int numPixelsX, int numPixelsY, double pixelSizeX, double pixelSizeY,
-                                            double centerX, double centerY, bool convertToAngularSize)
+void FluxRecorder::includeSurfaceBrightnessForDistant(int numPixelsX, int numPixelsY, double pixelSizeX,
+                                                      double pixelSizeY, double centerX, double centerY)
 {
     _includeSurfaceBrightness = true;
     _numPixelsX = numPixelsX;
     _numPixelsY = numPixelsY;
     _pixelSizeX = pixelSizeX;
     _pixelSizeY = pixelSizeY;
-    _pixelSizeAverage = sqrt(pixelSizeX * pixelSizeY);
     _centerX = centerX;
     _centerY = centerY;
-    _convertToAngularSize = convertToAngularSize;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void FluxRecorder::includeSurfaceBrightnessForLocal(int numPixelsX, int numPixelsY, double solidAnglePerPixel,
+                                                    double incrementX, double incrementY, double centerX,
+                                                    double centerY, string quantityXY)
+{
+    _includeSurfaceBrightness = true;
+    _local = true;
+    _numPixelsX = numPixelsX;
+    _numPixelsY = numPixelsY;
+    _solidAnglePerPixel = solidAnglePerPixel;
+    _incrementX = incrementX;
+    _incrementY = incrementY;
+    _centerX = centerX;
+    _centerY = centerY;
+    _quantityXY = quantityXY;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -201,11 +217,9 @@ void FluxRecorder::detect(PhotonPacket* pp, int l, double distance)
         double L = pp->luminosity() * _lambdagrid->transmission(ell, wavelength);
 
         // adjust the luminosity for near distance if needed
-        if (distance < _luminosityDistance)
+        if (_local)
         {
-            double r = _pixelSizeAverage / (2. * distance);
-            double rar = r / atan(r);
-            L *= rar * rar;
+            L /= distance * distance;
         }
 
         // apply the extinction along the path to the recorder
@@ -350,10 +364,12 @@ void FluxRecorder::calibrateAndWrite()
     // calibrate and write only in the root process
     if (!ProcessManager::isRoot()) return;
 
-    // calculate front factors for converting from recorded quantities to output quantities:
-    double fourpid2 = 4. * M_PI * _luminosityDistance * _luminosityDistance;
-    double omega =
-        4. * atan(0.5 * _pixelSizeX / _angularDiameterDistance) * atan(0.5 * _pixelSizeY / _angularDiameterDistance);
+    // calculate front factors for converting from recorded quantities to output quantities
+    // (for local instruments, the distance correction already happened)
+    double fourpid2 = 4. * M_PI * (_local ? 1. : _luminosityDistance * _luminosityDistance);
+    double omega = _local ? _solidAnglePerPixel
+                          : 4. * atan(0.5 * _pixelSizeX / _angularDiameterDistance)
+                                * atan(0.5 * _pixelSizeY / _angularDiameterDistance);
 
     // convert from recorded quantities to output quantities and from internal units to user-selected output units
     // (for performance reasons, determine the units scaling factor only once for each wavelength)
@@ -528,24 +544,37 @@ void FluxRecorder::calibrateAndWrite()
         for (int ell = 0; ell != numWavelengths; ++ell)
             wavegrid[ell] = units->owavelength(_lambdagrid->wavelength(ell));
 
-        // determine coordinate axes values and units, converted to angular size if requested
+        // determine coordinate axes values and units
         double incx, incy, cx, cy;
         string unitsxy;
-        if (_convertToAngularSize)
+        if (_local)
         {
+            // for local instruments, use the metadata provided by the instrument
+            if (_quantityXY.empty())
+            {
+                incx = _incrementX;
+                incy = _incrementY;
+                cx = _centerX;
+                cy = _centerY;
+                unitsxy = "1";
+            }
+            else
+            {
+                incx = units->out(_quantityXY, _incrementX);
+                incy = units->out(_quantityXY, _incrementY);
+                cx = units->out(_quantityXY, _centerX);
+                cy = units->out(_quantityXY, _centerY);
+                unitsxy = units->unit(_quantityXY);
+            }
+        }
+        else
+        {
+            // for distant instruments, convert to angular sizes
             incx = units->oangle(2. * atan(0.5 * _pixelSizeX / _angularDiameterDistance));
             incy = units->oangle(2. * atan(0.5 * _pixelSizeY / _angularDiameterDistance));
             cx = units->oangle(2. * atan(0.5 * _centerX / _angularDiameterDistance));
             cy = units->oangle(2. * atan(0.5 * _centerY / _angularDiameterDistance));
             unitsxy = units->uangle();
-        }
-        else
-        {
-            incx = units->olength(_pixelSizeX);
-            incy = units->olength(_pixelSizeY);
-            cx = units->olength(_centerX);
-            cy = units->olength(_centerY);
-            unitsxy = units->ulength();
         }
 
         // output the files (ignoring empty arrays)

--- a/SKIRT/core/FrameInstrument.cpp
+++ b/SKIRT/core/FrameInstrument.cpp
@@ -14,8 +14,8 @@ void FrameInstrument::setupSelfBefore()
     DistantInstrument::setupSelfBefore();
 
     // configure flux recorder
-    instrumentFluxRecorder()->includeSurfaceBrightness(numPixelsX(), numPixelsY(), fieldOfViewX() / numPixelsX(),
-                                                       fieldOfViewY() / numPixelsY(), centerX(), centerY(), true);
+    instrumentFluxRecorder()->includeSurfaceBrightnessForDistant(
+        numPixelsX(), numPixelsY(), fieldOfViewX() / numPixelsX(), fieldOfViewY() / numPixelsY(), centerX(), centerY());
 
     // precalculate information needed by pixelOnDetector() function
     _costheta = cos(inclination());

--- a/SKIRT/core/FullInstrument.cpp
+++ b/SKIRT/core/FullInstrument.cpp
@@ -13,7 +13,7 @@ void FullInstrument::setupSelfBefore()
     FrameInstrument::setupSelfBefore();
 
     // add SED to FrameInstrument's flux recorder's configuration
-    instrumentFluxRecorder()->includeFluxDensity();
+    instrumentFluxRecorder()->includeFluxDensityForDistant();
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/HEALPixSkyInstrument.cpp
+++ b/SKIRT/core/HEALPixSkyInstrument.cpp
@@ -114,26 +114,6 @@ Direction HEALPixSkyInstrument::bfkobs(const Position& bfr) const
 
 ////////////////////////////////////////////////////////////////////
 
-Direction HEALPixSkyInstrument::bfkx(const Position& bfr) const
-{
-    // vector and distance from launch to observer
-    Vec k = Vec(_Ox, _Oy, _Oz) - bfr;
-    double d = k.norm();
-
-    // if the distance is very small, return something arbitrary - the photon packet will not be detected anyway
-    if (d < _radius) return Direction();
-
-    // vector in the plane normal to the line launch-observer
-    // oriented perpendicular to the projection of the up direction in that plane
-    Vec ku(_Ux, _Uy, _Uz);
-    Vec kx = Vec::cross(ku, k);
-
-    // return unit vector along y-axis
-    return Direction(kx / kx.norm());
-}
-
-////////////////////////////////////////////////////////////////////
-
 Direction HEALPixSkyInstrument::bfky(const Position& bfr) const
 {
     // vector and distance from launch to observer

--- a/SKIRT/core/HEALPixSkyInstrument.hpp
+++ b/SKIRT/core/HEALPixSkyInstrument.hpp
@@ -146,11 +146,6 @@ public:
         position, expressed in model coordinates. */
     Direction bfkobs(const Position& bfr) const override;
 
-    /** Returns the direction along the positive x-axis in a plane normal to the vector towards the
-        observer from the given photon packet launching position, expressed in model coordinates.
-        */
-    Direction bfkx(const Position& bfr) const override;
-
     /** Returns the direction along the positive y-axis in a plane normal to the vector towards the
         observer from the given photon packet launching position, expressed in model coordinates.
         */

--- a/SKIRT/core/HEALPixSkyInstrument.hpp
+++ b/SKIRT/core/HEALPixSkyInstrument.hpp
@@ -65,18 +65,17 @@
     existing 2D image functionality for output, and that we can easily map output pixels to the
     corresponding HEALPix pixels in ring ordering during analysis.
 
-    The surface brightness calibration for this instrument (as for the AllSkyInstrument) is tricky.
-    While the angular size of the individual HEALPix pixels is known, the angular size of the
-    pixels as seen from a distant object is not, since the pixels do not have an actual physical
-    size. We can define such a physical size by defining a radius for the instrument, which is then
-    used to convert the angular size to a physical size. This radius is quite arbitrary, but should
-    nonetheless be chosen with some care: if the radius is too small, then recorded flux values
-    will be very high or even overflow. A good rule of thumb is to use a radius that has a similar
-    size to your object of study. For example, for a galaxy, with sizes in kpc, a radius of 1 pc
-    works well. It is always possible to recalibrate the fluxes afterwards by using the same radius
-    and adjusting to the pixel size of an actual instrument.
+    An HEALPix sky instrument consists of a sphere with a given radius, centered at the location of
+    the instrument. Only photon packets originating outside of this sphere are detected. When a
+    photon packet arrives, the spherical coordinates of its originating position relative to the
+    instrument coordinate system are determined. The two resulting angular coordinates are
+    transformed to pixel coordinates on the HEALPix sphere. The radial coordinate (i.e. the
+    distance from the photon packet's origin to the instrument location) is used for adjusting the
+    photon packet's luminosity contribution to the surface brightness in its target pixel. More
+    details on the flux calibration for this "local" instrument are provided in the header of the
+    FluxRecorder class.
 
-    This instrument does \em not seperately record spatially integrated flux densities. */
+    This instrument does \em not support recording of spatially integrated flux densities. */
 class HEALPixSkyInstrument : public Instrument
 {
     ITEM_CONCRETE(HEALPixSkyInstrument, Instrument,
@@ -179,9 +178,6 @@ private:
     int _Nx{0};                       // number of pixels in the x direction
     int _Ny{0};                       // number of pixels in the y direction
     int _Nside{0};                    // number of pixels in one direction of a HEALPix base pixel
-    double _s{0.};                    // estimated linear size of a pixel
-    Direction _bfkx;                  // unit vector along the viewport's x-axis
-    Direction _bfky;                  // unit vector along the viewport's y-axis
     HomogeneousTransform _transform;  // transform from world to observer coordinates
 };
 

--- a/SKIRT/core/Instrument.hpp
+++ b/SKIRT/core/Instrument.hpp
@@ -130,11 +130,6 @@ public:
         subclass. */
     virtual Direction bfkobs(const Position& bfr) const = 0;
 
-    /** This function returns the direction along the positive x-axis of the instrument frame,
-        expressed in model coordinates, given the photon packet's launching position. The
-        implementation must be provided in a subclass. */
-    virtual Direction bfkx(const Position& bfr) const = 0;
-
     /** This function returns the direction along the positive y-axis of the instrument frame,
         expressed in model coordinates, given the photon packet's launching position. The
         implementation must be provided in a subclass. */

--- a/SKIRT/core/OpticalDepthMapProbe.cpp
+++ b/SKIRT/core/OpticalDepthMapProbe.cpp
@@ -104,7 +104,7 @@ namespace
             string description =
                 "optical depth map at λ = " + StringUtils::toString(units->owavelength(probe->wavelength())) + " "
                 + units->uwavelength();
-            FITSInOut::write(probe, description, filename, tauv, "", Nx, Ny, units->oposangle(2 * M_PI / Nx),
+            FITSInOut::write(probe, description, filename, tauv, "", Nx, Ny, units->oposangle(-2 * M_PI / Nx),
                              units->oposangle(M_PI / Ny), 0., 0., units->uposangle());
         }
     };

--- a/SKIRT/core/OpticalDepthMapProbe.cpp
+++ b/SKIRT/core/OpticalDepthMapProbe.cpp
@@ -149,11 +149,11 @@ void OpticalDepthMapProbe::probe()
         auto ms = find<MediumSystem>();
 
         // setup the transformation from observer to world coordinates;
-        // we need the inverse of the translation used by the all-sky instrument,
+        // we need the inverse of the transformation used by the all-sky instrument,
         // but without the translation because we will transform just the direction
         HomogeneousTransform transform;
-        transform.rotateZ(0., 1.);
-        transform.rotateX(0., -1.);
+        transform.rotateZ(0., -1.);
+        transform.rotateX(0., 1.);
 
         Vec kn(_Ox - _Cx, _Oy - _Cy, _Oz - _Cz);
         kn /= kn.norm();

--- a/SKIRT/core/PerspectiveInstrument.cpp
+++ b/SKIRT/core/PerspectiveInstrument.cpp
@@ -80,10 +80,13 @@ void PerspectiveInstrument::setupSelfBefore()
     _transform.scale(1. / _s, 1. / _s, 1.);
     _transform.translate(_Nx / 2., _Ny / 2., 0);
 
-    // configure flux recorder with a large distance relative to the pixel size so that atan(s/2d) = s/2d
-    // and the default calibration can be easily corrected when detecting each individual photon packet
-    instrumentFluxRecorder()->setRestFrameDistance(_s * 1e8);
-    instrumentFluxRecorder()->includeSurfaceBrightness(_Nx, _Ny, _s, _s, 0, 0, false);
+    // determine the solid angle subtended by a pixel in the center of the viewport
+    // and use this as an approximate, representative solid angle for all pixels
+    double alpha = 2. * atan(0.5 * _s / _Fe);
+    double omega = alpha * alpha;
+
+    // configure flux recorder
+    instrumentFluxRecorder()->includeSurfaceBrightnessForLocal(_Nx, _Ny, omega, _s, _s, 0., 0., "length");
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -110,7 +113,7 @@ Direction PerspectiveInstrument::bfkobs(const Position& bfr) const
     double D = norm(_Ex - Px, _Ey - Py, _Ez - Pz);
 
     // if the distance is very small, return something silly - the photon packet is behind the viewport anyway
-    if (D < 1e-20) return Direction();
+    if (D < _s / 10.) return Direction();
 
     // otherwise return a unit vector in the direction from launch to eye
     return Direction((_Ex - Px) / D, (_Ey - Py) / D, (_Ez - Pz) / D);

--- a/SKIRT/core/PerspectiveInstrument.cpp
+++ b/SKIRT/core/PerspectiveInstrument.cpp
@@ -43,8 +43,6 @@ void PerspectiveInstrument::setupSelfBefore()
     Vec kn(_Vx - _Cx, _Vy - _Cy, _Vz - _Cz);
     Vec ku(_Ux, _Uy, _Uz);
     Vec ky = Vec::cross(kn, Vec::cross(ku, kn));
-    Vec kx = Vec::cross(ky, kn);
-    _bfkx = Direction(kx / kx.norm());
     _bfky = Direction(ky / ky.norm());
 
     // the perspective transformation
@@ -117,13 +115,6 @@ Direction PerspectiveInstrument::bfkobs(const Position& bfr) const
 
     // otherwise return a unit vector in the direction from launch to eye
     return Direction((_Ex - Px) / D, (_Ey - Py) / D, (_Ez - Pz) / D);
-}
-
-////////////////////////////////////////////////////////////////////
-
-Direction PerspectiveInstrument::bfkx(const Position& /*bfr*/) const
-{
-    return _bfkx;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/PerspectiveInstrument.hpp
+++ b/SKIRT/core/PerspectiveInstrument.hpp
@@ -91,11 +91,6 @@ public:
     /** Returns the direction towards the eye from the given photon packet launching position. */
     Direction bfkobs(const Position& bfr) const override;
 
-    /** Returns the direction along the positive x-axis of the instrument frame, expressed in model
-        coordinates. The provided photon packet's launching position is not used because the
-        orientation of the instrument frame does not depend on it. */
-    Direction bfkx(const Position& bfr) const override;
-
     /** Returns the direction along the positive y-axis of the instrument frame, expressed in model
         coordinates. The provided photon packet's launching position is not used because the
         orientation of the instrument frame does not depend on it. */
@@ -126,7 +121,6 @@ private:
     // data members derived from the published attributes during setup
     double _s{0.};                     // width and height of a pixel
     double _Ex{0.}, _Ey{0.}, _Ez{0.};  // eye position
-    Direction _bfkx;                   // unit vector along the viewport's x-axis
     Direction _bfky;                   // unit vector along the viewport's y-axis
     HomogeneousTransform _transform;   // transform from world to pixel coordinates
 };

--- a/SKIRT/core/PerspectiveInstrument.hpp
+++ b/SKIRT/core/PerspectiveInstrument.hpp
@@ -15,7 +15,8 @@
     arbitrary placement of the viewport outside or inside the model. Only photon packets arriving
     from the front are recorded; light emitted behind the viewport is ignored. For each wavelength
     the instrument outputs the detected surface brightness in every pixel of a given frame as a
-    data cube in a FITS file. The instrument does \em not record an integrated flux density.
+    data cube in a FITS file. The instrument does \em not support recording of spatially integrated
+    flux densities.
 
     The perspective instrument is intended mostly for making movies. Each movie frame is generated
     by a separate perspective instrument with the appropriate parameters. */

--- a/SKIRT/core/SEDInstrument.cpp
+++ b/SKIRT/core/SEDInstrument.cpp
@@ -13,7 +13,7 @@ void SEDInstrument::setupSelfBefore()
     DistantInstrument::setupSelfBefore();
 
     // configure flux recorder
-    instrumentFluxRecorder()->includeFluxDensity();
+    instrumentFluxRecorder()->includeFluxDensityForDistant();
 }
 
 ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
This update fixes the surface brightness calibration and some coordinate transform issues for local instruments, including the `AllSkyInstrument`, the `HEALPixSkyInstrument`, and the `PerspectiveInstrument`. Distant instruments, including the `SEDInstrument`, the `FrameInstrument`, and the `FullInstrument`, are not affected.

For all instruments, the contribution of a given source to the flux detected in a particular pixel depends on the source's distance and on the solid angle subtended by the pixel. Because distant instruments assume that all sources in the model are at the same (large) distance from the instrument, this "calibration" can occur at the end of the simulation after all photon packet contributions have been accumulated. For local instruments, however, the effective distance from a photon packet's originating position must be taken into account for each individual photon packet. This was implemented incorrectly for local instruments in the previous SKIRT version.

Furthermore, we decided to adjust the output images produced by the `AllSkyInstrument` and the `HEALPixSkyInstrument` to follow the convention in the literature where the longitude increases from right to left. As a result, the pixels have been east-west flipped (as compared to the previous version) and the axis information in the FITS header has been updated to reflect this change. The order of the pixels in the `HEALPixSkyInstrument` output is also updated to ensure the proper north-south and east-west result. The PTS methods to read this output and project it to a planar map are correspondingly updated in a separate, accompanying pull request.

**Motivation**
The calibration for the all-sky instruments depended on an arbitrary radius configured by the user, which does not make any sense. Furthermore, the dependency on distance was incorrect, causing distant objects to appear brighter than they should. This made it impossible to properly compare fluxes with observational results (e.g. the Planck all-sky maps)

**Context**
The current pull request includes (an adjusted version of) the changes suggested by pull request #86. The issues indicated in that pull request turned out to exist for all local instruments, so that a more generic implementation was called for. Consequently, pull request #86 will be closed without being merged with the master branch.

**Tests**
The existing test cases involving local instruments were updated, and new test cases created to explicitly test the issues raised and fixed here. This includes the test case proposed in pull request #86. We note that the output of all distant instruments remains binary identical to the previous version, confirming that this pull request does not affect distant instruments.
