### PR TITLE
Add circular aperture to SED instrument

### DIFF
--- a/SKIRT/core/FrameInstrument.cpp
+++ b/SKIRT/core/FrameInstrument.cpp
@@ -48,7 +48,7 @@ int FrameInstrument::pixelOnDetector(const PhotonPacket* pp) const
     double x, y, z;
     pp->position().cartesian(x, y, z);
 
-    // transform to detector coordinates using inclination, azimuth, and position angle
+    // transform to detector coordinates using inclination, azimuth, and roll angle
     double xpp = -_sinphi * x + _cosphi * y;
     double ypp = -_cosphi * _costheta * x - _sinphi * _costheta * y + _sintheta * z;
     double xp = _cosomega * xpp - _sinomega * ypp;

--- a/SKIRT/core/FrameInstrument.hpp
+++ b/SKIRT/core/FrameInstrument.hpp
@@ -58,10 +58,9 @@ protected:
 
 public:
     /** This function simulates the detection of a photon packet by the instrument. It determines
-        the projected position of the photon packet's last interaction site on the instrument
-        frame, calculates the optical depth of the path from the photon packet's last interaction
-        site to the instrument, and then calls the detect() function of the FluxRecorder instance
-        associated with this instrument. */
+        the projected position of the photon packet's last interaction site on the instrument frame
+        and then calls the detect() function of the FluxRecorder instance associated with this
+        instrument. */
     void detect(PhotonPacket* pp) override;
 
 private:
@@ -69,7 +68,7 @@ private:
         will be hit by a photon packet, or -1 if the photon packet does not hit the detector. Given
         the position \f${\boldsymbol{x}}=(x,y,z)\f$ of the last emission or scattering event of the
         photon packet, the direction \f${\boldsymbol{k}}_{\text{obs}} = (\theta,\varphi)\f$ towards
-        the observer, and the position angle \f$\omega\f$ of the instrument, the impact coordinates
+        the observer, and the roll angle \f$\omega\f$ of the instrument, the impact coordinates
         \f$(x_{\text{p}},y_{\text{p}})\f$ are given by the following Euler-like transformation,
         where \f$z_{\text{p}}\f$ is ignored: \f[ \begin{bmatrix}x_{\text{p}} \\ y_{\text{p}} \\
         z_{\text{p}} \end{bmatrix} = \begin{bmatrix}\cos\omega & -\sin\omega & 0\\ \sin\omega &
@@ -81,9 +80,9 @@ private:
         the azimuth angle \f$\varphi\f$ (with a minus sign because the observer is looking towards
         the center rather than along the specified direction), then rotated about the new Y-axis
         over the inclination angle \f$\theta\f$, and finally rotated about the new Z-axis over the
-        position angle \f$\omega\f$ reduced by 90 degrees (this constant transformation over -90
+        roll angle \f$\omega\f$ reduced by 90 degrees (this constant transformation over -90
         degrees is represented above as a separate matrix). The 90 degree correction on the
-        position angle is introduced so that it would be more natural to specify this angle; in
+        roll angle is introduced so that it would be more natural to specify this angle; in
         most cases it can be left to its default value of 0. Given these impact coordinates, the
         pixel indices \f$i\f$ and \f$j\f$ are determined as \f[ \begin{split} i &=
         \frac{{\text{floor}}(x_{\text{p}}-x_{\text{min}})}{\Delta x} \\ j &=

--- a/SKIRT/core/SEDInstrument.cpp
+++ b/SKIRT/core/SEDInstrument.cpp
@@ -5,6 +5,7 @@
 
 #include "SEDInstrument.hpp"
 #include "FluxRecorder.hpp"
+#include "PhotonPacket.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
@@ -14,12 +15,36 @@ void SEDInstrument::setupSelfBefore()
 
     // configure flux recorder
     instrumentFluxRecorder()->includeFluxDensityForDistant();
+
+    // precalculate information needed by detect() function
+    _radius2 = radius() * radius();
+    _costheta = cos(inclination());
+    _sintheta = sin(inclination());
+    _cosphi = cos(azimuth());
+    _sinphi = sin(azimuth());
 }
 
 ////////////////////////////////////////////////////////////////////
 
 void SEDInstrument::detect(PhotonPacket* pp)
 {
+    // if the instrument has an aperture
+    if (_radius2)
+    {
+        // get the photon packet position
+        double x, y, z;
+        pp->position().cartesian(x, y, z);
+
+        // transform to detector coordinates using inclination and azimuth
+        // but without performing the roll, which would not alter the radius
+        double xpp = -_sinphi * x + _cosphi * y;
+        double ypp = -_cosphi * _costheta * x - _sinphi * _costheta * y + _sintheta * z;
+
+        // if the photon packet projects outside of the aperture, ignore it
+        double radius2 = xpp * xpp + ypp * ypp;
+        if (radius2 > _radius2) return;
+    }
+
     instrumentFluxRecorder()->detect(pp, 0);
 }
 

--- a/SKIRT/core/SEDInstrument.hpp
+++ b/SKIRT/core/SEDInstrument.hpp
@@ -10,12 +10,24 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** An SEDInstrument object represents a distant instrument that records the spatially
-    integrated flux density for each wavelength and outputs an %SED text column file. */
+/** An SEDInstrument object represents a distant instrument that records the spatially integrated
+    flux density for each wavelength and outputs an %SED text column file.
+
+    The instrument allows configuring the radius of a circular aperture centered on the origin of
+    the model coordinate system and in the plane perpendicular to the instrument's line of sight.
+    Photon packets arriving from a point that parallel projects outside of this aperture are
+    ignored. If the radius is zero (the default value), the instrument does not have an aperture
+    (or, equivalently, the aperture radius is infinite). */
 class SEDInstrument : public DistantInstrument
 {
     ITEM_CONCRETE(SEDInstrument, DistantInstrument,
                   "a distant instrument that outputs the spatially integrated flux density as an SED")
+
+        PROPERTY_DOUBLE(radius, "the radius of the circular aperture, or zero for no aperture")
+        ATTRIBUTE_QUANTITY(radius, "length")
+        ATTRIBUTE_MIN_VALUE(radius, "[0")
+        ATTRIBUTE_DEFAULT_VALUE(radius, "0")
+
     ITEM_END()
 
     //============= Construction - Setup - Destruction =============
@@ -27,11 +39,20 @@ protected:
     //======================== Other Functions =======================
 
 public:
-    /** This function simulates the detection of a photon packet by the instrument. It calculates
-        the optical depth of the path from the photon packet's last interaction site to the
-        instrument, and then calls the detect() function of the FluxRecorder instance associated
-        with this instrument. */
+    /** This function simulates the detection of a photon packet by the instrument. It verifies
+        that the arriving photon packet projects within the aperture and then calls the detect()
+        function of the FluxRecorder instance associated with this instrument. */
     void detect(PhotonPacket* pp) override;
+
+    //======================== Data Members ========================
+
+private:
+    // data members derived from the discoverable properties during setup, used in detect()
+    double _radius2{0};
+    double _costheta{0};
+    double _sintheta{0};
+    double _cosphi{0};
+    double _sinphi{0};
 };
 
 ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
This update adds an optional circular aperture to the SED instrument. 

Specifically, the `SEDInstrument` now allows configuring the radius of a circular aperture centered on the origin of the model coordinate system and in the plane perpendicular to the instrument's line of sight. Photon packets arriving from a point that parallel projects outside of this aperture are ignored. If the configured radius is zero (the default value), the instrument does not have an aperture, or, equivalently, the aperture radius is infinite.

**Motivation**
Similar functionality could be obtained by configuring a frame instrument and then (e.g. in Python) integrating the surface brightness over the pixels inside the circular aperture. However, this requires more memory during the simulation as the number of pixels should be sufficiently high for an accurate result.

Also note that limiting an (imported) input model to a spherical aperture does not produce the same results as configuring a circular aperture on the instrument, because the latter includes all emission in a cylinder cutting through the complete model.

**Tests**
Tests have been added to confirm that the new feature works. All existing tests still run because the default zero value for the radius reproduces the previous behavior.

**Context**
This feature has been requested by @anatrcka for use in her TNG50 post-processing project.
