### PR TITLE
Fix out-of-range write in surface brightness statistics

### DIFF
--- a/SKIRT/core/FluxRecorder.cpp
+++ b/SKIRT/core/FluxRecorder.cpp
@@ -654,12 +654,15 @@ void FluxRecorder::recordContributions(ContributionList* contributionList)
             if (i + 1 == numContributions || contributions[i].ell() != contributions[i + 1].ell()
                 || contributions[i].l() != contributions[i + 1].l())
             {
-                size_t lell = contributions[i].l() + contributions[i].ell() * _numPixelsInFrame;
-                double wn = 1.;
-                for (int k = 0; k <= maxContributionPower; ++k)
+                if (contributions[i].l() >= 0)
                 {
-                    LockFree::add(_wifu[k][lell], wn);
-                    wn *= w;
+                    size_t lell = contributions[i].l() + contributions[i].ell() * _numPixelsInFrame;
+                    double wn = 1.;
+                    for (int k = 0; k <= maxContributionPower; ++k)
+                    {
+                        LockFree::add(_wifu[k][lell], wn);
+                        wn *= w;
+                    }
                 }
                 w = 0;
             }


### PR DESCRIPTION
**Description**
This pull request fixes a sometimes crashing bug in the `FluxRecorder` code that records statistics for surface brightness data cubes (or frames, for a single wavelength). The bug was reported as issue #91.

**Effects of the bug on results before this fix**
In summary, the effect on results is limited to a single corner pixel in the statistics frames produced by SKIRT.

The bug occurred only with enabled `recordStatistics` property for a `FrameInstrument` or `FullInstrument`. The surface brightness results were not affected. However, any contributions to the statistics by photon packets arriving outside of the field of view, rather than being discarded, were accumulated in one of the corner pixels in the frame for the _previous_ wavelength bin. For contributions in the first wavelength bin, the memory location being written was outside of the allocated data structure. Depending on the memory layout (determined by the compiler) this would sometimes do no harm, and other times result in a segmentation fault at the end of the simulation.

**Tests**
A new test was added that captures this bug. All other functional tests still run.

**Context**
This closes #91 .
