### PR TITLE
Avoid construction of Voronoi tessellation for some use cases

### DIFF
--- a/SKIRT/core/AdaptiveMeshMedium.cpp
+++ b/SKIRT/core/AdaptiveMeshMedium.cpp
@@ -22,8 +22,17 @@ Snapshot* AdaptiveMeshMedium::createAndOpenSnapshot()
     {
         case MassType::MassDensity: _adaptiveMeshSnapshot->importMassDensity(); break;
         case MassType::Mass: _adaptiveMeshSnapshot->importMass(); break;
+        case MassType::MassDensityAndMass:
+            _adaptiveMeshSnapshot->importMassDensity();
+            _adaptiveMeshSnapshot->importMass();
+            break;
+
         case MassType::NumberDensity: _adaptiveMeshSnapshot->importNumberDensity(); break;
         case MassType::Number: _adaptiveMeshSnapshot->importNumber(); break;
+        case MassType::NumberDensityAndNumber:
+            _adaptiveMeshSnapshot->importNumberDensity();
+            _adaptiveMeshSnapshot->importNumber();
+            break;
     }
 
     // set the domain extent

--- a/SKIRT/core/Configuration.cpp
+++ b/SKIRT/core/Configuration.cpp
@@ -15,6 +15,7 @@
 #include "OligoWavelengthGrid.hpp"
 #include "PhotonPacketOptions.hpp"
 #include "StringUtils.hpp"
+#include "VoronoiMeshSpatialGrid.hpp"
 #include <set>
 
 ////////////////////////////////////////////////////////////////////
@@ -202,6 +203,24 @@ void Configuration::setupSelfBefore()
     else
     {
         _modelDimension = ss->dimension();
+    }
+
+    // determine whether media must support the generatePosition() function
+    // currently, that function is called only by the VoronoiMeshSpatialGrid class for certain policies
+    if (_hasMedium)
+    {
+        auto grid = dynamic_cast<VoronoiMeshSpatialGrid*>(ms->grid());
+        if (grid)
+        {
+            auto policy = grid->policy();
+            if (policy == VoronoiMeshSpatialGrid::Policy::DustDensity
+                || policy == VoronoiMeshSpatialGrid::Policy::ElectronDensity
+                || policy == VoronoiMeshSpatialGrid::Policy::GasDensity
+                || policy == VoronoiMeshSpatialGrid::Policy::ImportedMesh)
+            {
+                _mediaNeedGeneratePosition = true;
+            }
+        }
     }
 
     // check for velocities in sources and media

--- a/SKIRT/core/Configuration.hpp
+++ b/SKIRT/core/Configuration.hpp
@@ -266,6 +266,13 @@ public:
         means spherical symmetry, 2 means axial symmetry and 3 means none of these symmetries. */
     int gridDimension() const { return _gridDimension; }
 
+    /** Returns true if the Medium::generatePosition() function may be called for the media in the
+        simulation. In the current implementation, this happens only if the simulation uses a
+        VoronoiMeshSpatialGrid instance to discretize the spatial domain. If there are no media or
+        the Medium::generatePosition() will never be called during this simulation, this function
+        returns false. */
+    bool mediaNeedGeneratePosition() const { return _mediaNeedGeneratePosition; }
+
     /** Returns true if one or more medium components in the simulation may have a nonzero velocity
         for some positions. If the function returns false, none of the media has a velocity. */
     bool hasMovingMedia() const { return _hasMovingMedia; }
@@ -394,6 +401,7 @@ private:
     // properties derived from the configuration at large
     int _modelDimension{0};
     int _gridDimension{0};
+    bool _mediaNeedGeneratePosition{false};
     bool _hasMovingSources{false};
     bool _hasMovingMedia{false};
     bool _hasVariableMedia{false};

--- a/SKIRT/core/MeshMedium.hpp
+++ b/SKIRT/core/MeshMedium.hpp
@@ -20,12 +20,18 @@
     requirements set by the ImportedMedium class. */
 class MeshMedium : public ImportedMedium
 {
-    /** The enumeration type indicating the type of mass quantity to be imported. */
-    ENUM_DEF(MassType, MassDensity, Mass, NumberDensity, Number)
+    /** The enumeration type indicating the type of mass quantity to be imported. The choices
+        specifying two columns (either both mass density and mass or both number density and
+        number) are intended for use in special cases where the volume of each imported entity
+        cannot be easily derived otherwise. In the current implementation, this is used only by the
+        VoronoiMeshMedium to avoid constructing a full Voronoi tessellation in certain cases. */
+    ENUM_DEF(MassType, MassDensity, Mass, MassDensityAndMass, NumberDensity, Number, NumberDensityAndNumber)
         ENUM_VAL(MassType, MassDensity, "mass density")
-        ENUM_VAL(MassType, Mass, "mass (volume-integrated mass density)")
+        ENUM_VAL(MassType, Mass, "mass (volume-integrated)")
+        ENUM_VAL(MassType, MassDensityAndMass, "both mass density and volume-integrated mass")
         ENUM_VAL(MassType, NumberDensity, "number density")
-        ENUM_VAL(MassType, Number, "number (volume-integrated number density)")
+        ENUM_VAL(MassType, Number, "number (volume-integrated)")
+        ENUM_VAL(MassType, NumberDensityAndNumber, "both number density and volume-integrated number")
     ENUM_END()
 
     ITEM_ABSTRACT(MeshMedium, ImportedMedium, "a geometry imported from mesh-based data")

--- a/SKIRT/core/Snapshot.hpp
+++ b/SKIRT/core/Snapshot.hpp
@@ -127,27 +127,31 @@ public:
     void importBox();
 
     /** This function configures the snapshot to import a mass density per unit of volume. The
-        default unit is Msun/pc3. The importMassDensity(), importMass(), importNumberDensity(), and
-        importNumber() options are mutually exclusive; calling more than one of these functions for
-        the same snapshot results in undefined behavior. */
+        default unit is Msun/pc3. It is allowed to combine the importMassDensity() and importMass()
+        options, supporting special use cases where the volume of the entity cannot be derived
+        otherwise. However, combining the "mass" family functions with the "number" family
+        functions is prohibited and leads to undefined behavior. */
     void importMassDensity();
 
     /** This function configures the snapshot to import a mass (i.e. mass density integrated over
-        volume). The default unit is Msun. The importMassDensity(), importMass(),
-        importNumberDensity(), and importNumber() options are mutually exclusive; calling more than
-        one of these functions for the same snapshot results in undefined behavior. */
+        volume). The default unit is Msun. It is allowed to combine the importMassDensity() and
+        importMass() options, supporting special use cases where the volume of the entity cannot be
+        derived otherwise. However, combining the "mass" family functions with the "number" family
+        functions is prohibited and leads to undefined behavior. */
     void importMass();
 
     /** This function configures the snapshot to import a number density per unit of volume. The
-        default unit is 1/cm3. The importMassDensity(), importMass(), importNumberDensity(), and
-        importNumber() options are mutually exclusive; calling more than one of these functions for
-        the same snapshot results in undefined behavior. */
+        default unit is 1/cm3. It is allowed to combine the importNumberDensity() and
+        importNumber() options, supporting special use cases where the volume of the entity cannot
+        be derived otherwise. However, combining the "mass" family functions with the "number"
+        family functions is prohibited and leads to undefined behavior. */
     void importNumberDensity();
 
     /** This function configures the snapshot to import a number (i.e. number density integrated
-        over volume). The default unit is 1. The importMassDensity(), importMass(),
-        importNumberDensity(), and importNumber() options are mutually exclusive; calling more than
-        one of these functions for the same snapshot results in undefined behavior. */
+        over volume). The default unit is 1. It is allowed to combine the importNumberDensity() and
+        importNumber() options, supporting special use cases where the volume of the entity cannot
+        be derived otherwise. However, combining the "mass" family functions with the "number"
+        family functions is prohibited and leads to undefined behavior. */
     void importNumber();
 
     /** This function configures the snapshot to import a (dimensionless) metallicity fraction. */

--- a/SKIRT/core/VoronoiMeshMedium.cpp
+++ b/SKIRT/core/VoronoiMeshMedium.cpp
@@ -31,9 +31,9 @@ Snapshot* VoronoiMeshMedium::createAndOpenSnapshot()
     }
 
     // determine whether to forego the Voronoi mesh
-    if (foregoVoronoMesh() && (massType() == MassType::MassDensity || massType() == MassType::NumberDensity)
+    if (foregoVoronoiMesh() && (massType() == MassType::MassDensity || massType() == MassType::NumberDensity)
         && !find<Configuration>()->mediaNeedGeneratePosition())
-        _voronoiMeshSnapshot->foregoVoronoMesh();
+        _voronoiMeshSnapshot->foregoVoronoiMesh();
 
     // set the domain extent
     _voronoiMeshSnapshot->setExtent(domain());

--- a/SKIRT/core/VoronoiMeshMedium.cpp
+++ b/SKIRT/core/VoronoiMeshMedium.cpp
@@ -21,18 +21,29 @@ Snapshot* VoronoiMeshMedium::createAndOpenSnapshot()
     // configure the position columns
     _voronoiMeshSnapshot->importPosition();
 
-    // configure the mass or density column
+    // configure the density and/or mass column(s)
+    bool bothDensityAndMass = false;
     switch (massType())
     {
         case MassType::MassDensity: _voronoiMeshSnapshot->importMassDensity(); break;
         case MassType::Mass: _voronoiMeshSnapshot->importMass(); break;
+        case MassType::MassDensityAndMass:
+            _voronoiMeshSnapshot->importMassDensity();
+            _voronoiMeshSnapshot->importMass();
+            bothDensityAndMass = true;
+            break;
+
         case MassType::NumberDensity: _voronoiMeshSnapshot->importNumberDensity(); break;
         case MassType::Number: _voronoiMeshSnapshot->importNumber(); break;
+        case MassType::NumberDensityAndNumber:
+            _voronoiMeshSnapshot->importNumberDensity();
+            _voronoiMeshSnapshot->importNumber();
+            bothDensityAndMass = true;
+            break;
     }
 
     // determine whether to forego the Voronoi mesh
-    if (foregoVoronoiMesh() && (massType() == MassType::MassDensity || massType() == MassType::NumberDensity)
-        && !find<Configuration>()->mediaNeedGeneratePosition())
+    if (bothDensityAndMass && !find<Configuration>()->mediaNeedGeneratePosition())
         _voronoiMeshSnapshot->foregoVoronoiMesh();
 
     // set the domain extent

--- a/SKIRT/core/VoronoiMeshMedium.cpp
+++ b/SKIRT/core/VoronoiMeshMedium.cpp
@@ -4,6 +4,7 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "VoronoiMeshMedium.hpp"
+#include "Configuration.hpp"
 #include "VoronoiMeshSnapshot.hpp"
 
 ////////////////////////////////////////////////////////////////////
@@ -28,6 +29,11 @@ Snapshot* VoronoiMeshMedium::createAndOpenSnapshot()
         case MassType::NumberDensity: _voronoiMeshSnapshot->importNumberDensity(); break;
         case MassType::Number: _voronoiMeshSnapshot->importNumber(); break;
     }
+
+    // determine whether to forego the Voronoi mesh
+    if (foregoVoronoMesh() && (massType() == MassType::MassDensity || massType() == MassType::NumberDensity)
+        && !find<Configuration>()->mediaNeedGeneratePosition())
+        _voronoiMeshSnapshot->foregoVoronoMesh();
 
     // set the domain extent
     _voronoiMeshSnapshot->setExtent(domain());

--- a/SKIRT/core/VoronoiMeshMedium.hpp
+++ b/SKIRT/core/VoronoiMeshMedium.hpp
@@ -66,12 +66,6 @@ class VoronoiMeshMedium : public MeshMedium, public VoronoiMeshInterface
 {
     ITEM_CONCRETE(VoronoiMeshMedium, MeshMedium, "a transfer medium imported from data represented on a Voronoi mesh")
         ATTRIBUTE_TYPE_INSERT(VoronoiMeshMedium, "VoronoiMeshInterface")
-
-        PROPERTY_BOOL(foregoVoronoiMesh, "forego constructing the Voronoi tessellation and use a search tree instead")
-        ATTRIBUTE_DEFAULT_VALUE(foregoVoronoiMesh, "false")
-        ATTRIBUTE_RELEVANT_IF(foregoVoronoiMesh, "massTypeMassDensity|massTypeNumberDensity")
-        ATTRIBUTE_DISPLAYED_IF(foregoVoronoiMesh, "Level3")
-
     ITEM_END()
 
     //============= Construction - Setup - Destruction =============

--- a/SKIRT/core/VoronoiMeshMedium.hpp
+++ b/SKIRT/core/VoronoiMeshMedium.hpp
@@ -66,6 +66,12 @@ class VoronoiMeshMedium : public MeshMedium, public VoronoiMeshInterface
 {
     ITEM_CONCRETE(VoronoiMeshMedium, MeshMedium, "a transfer medium imported from data represented on a Voronoi mesh")
         ATTRIBUTE_TYPE_INSERT(VoronoiMeshMedium, "VoronoiMeshInterface")
+
+        PROPERTY_BOOL(foregoVoronoMesh, "forego constructing the Voronoi tessellation and use a search tree instead")
+        ATTRIBUTE_DEFAULT_VALUE(foregoVoronoMesh, "false")
+        ATTRIBUTE_RELEVANT_IF(foregoVoronoMesh, "massTypeMassDensity|massTypeNumberDensity")
+        ATTRIBUTE_DISPLAYED_IF(foregoVoronoMesh, "Level3")
+
     ITEM_END()
 
     //============= Construction - Setup - Destruction =============

--- a/SKIRT/core/VoronoiMeshMedium.hpp
+++ b/SKIRT/core/VoronoiMeshMedium.hpp
@@ -67,10 +67,10 @@ class VoronoiMeshMedium : public MeshMedium, public VoronoiMeshInterface
     ITEM_CONCRETE(VoronoiMeshMedium, MeshMedium, "a transfer medium imported from data represented on a Voronoi mesh")
         ATTRIBUTE_TYPE_INSERT(VoronoiMeshMedium, "VoronoiMeshInterface")
 
-        PROPERTY_BOOL(foregoVoronoMesh, "forego constructing the Voronoi tessellation and use a search tree instead")
-        ATTRIBUTE_DEFAULT_VALUE(foregoVoronoMesh, "false")
-        ATTRIBUTE_RELEVANT_IF(foregoVoronoMesh, "massTypeMassDensity|massTypeNumberDensity")
-        ATTRIBUTE_DISPLAYED_IF(foregoVoronoMesh, "Level3")
+        PROPERTY_BOOL(foregoVoronoiMesh, "forego constructing the Voronoi tessellation and use a search tree instead")
+        ATTRIBUTE_DEFAULT_VALUE(foregoVoronoiMesh, "false")
+        ATTRIBUTE_RELEVANT_IF(foregoVoronoiMesh, "massTypeMassDensity|massTypeNumberDensity")
+        ATTRIBUTE_DISPLAYED_IF(foregoVoronoiMesh, "Level3")
 
     ITEM_END()
 

--- a/SKIRT/core/VoronoiMeshMedium.hpp
+++ b/SKIRT/core/VoronoiMeshMedium.hpp
@@ -61,7 +61,31 @@
 
     Finally, if the \em importVariableMixParams option is enabled, the remaining columns specify
     the parameters used by the configured material mix family to select a particular material mix
-    for the cell. */
+    for the cell.
+
+    <b>Avoiding construction of the Voronoi tessellation</b>
+
+    The algorithm used by the VoronoiMeshSnapshot class for constructing Voronoi tessellations
+    sometimes fails (for example, when generating sites are too close to each other). In those
+    cases, it can be desirable to forego the construction of the Voronoi tessellation and instead
+    use a nearest neighbor search for sampling the density distribution. This is possible as long
+    as the full tessellation is not needed for other purposes, such as to perform radiative
+    transfer or to generate random positions drawn from the density distribution. An important use
+    case is when the medium density distribution defined on the Voronoi grid is resampled to an
+    octree grid to perform radiative transfer. However, the octree subdivision algorithm requires
+    the total mass of the medium in addition to the density samples. Without the full Voronoi
+    tessellation, it is impossible to calculate the cell volume that would allow conversion between
+    cell density and mass.
+
+    To enable this use case, the \em massType option can be set to include both mass density and
+    volume-integrated mass (or both number density and volume-integrated number) in the imported
+    data file. Thus, if the \em massType option is set to one of these choices, the import file
+    must include two columns (mass density \f$\rho\f$ plus integrated mass \f$M\f$, or number
+    density \f$n\f$ plus integrated number density \f$N\f$ ). Furthermore, if the simulation
+    configuration allows it (i.e. the full Voronoi tessellation is not needed for other purposes),
+    the VoronoiMeshSnapshot class will use the information in these two columns to calculate the
+    cell volumes and the total medium mass, and it will forego construction of the Voronoi
+    tessellation. */
 class VoronoiMeshMedium : public MeshMedium, public VoronoiMeshInterface
 {
     ITEM_CONCRETE(VoronoiMeshMedium, MeshMedium, "a transfer medium imported from data represented on a Voronoi mesh")

--- a/SKIRT/core/VoronoiMeshSnapshot.cpp
+++ b/SKIRT/core/VoronoiMeshSnapshot.cpp
@@ -358,7 +358,7 @@ void VoronoiMeshSnapshot::readAndClose()
     Snapshot::readAndClose();
 
     // if we are allowed to build a Voronoi mesh
-    if (!_foregoVoronoMesh)
+    if (!_foregoVoronoiMesh)
     {
         // calculate the Voronoi cells
         buildMesh(false);
@@ -389,9 +389,9 @@ void VoronoiMeshSnapshot::setExtent(const Box& extent)
 
 ////////////////////////////////////////////////////////////////////
 
-void VoronoiMeshSnapshot::foregoVoronoMesh()
+void VoronoiMeshSnapshot::foregoVoronoiMesh()
 {
-    _foregoVoronoMesh = true;
+    _foregoVoronoiMesh = true;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -847,7 +847,7 @@ void VoronoiMeshSnapshot::buildSearchSingle()
     if (!numCells) return;
 
     // construct a single search tree on the site locations of all cells
-    log()->info("Building data structure to accelerate searching Voronoi sites");
+    log()->info("Building data structure to accelerate searching " + std::to_string(numCells) + " Voronoi sites");
     _blocktrees.resize(1);
     vector<int> ids(numCells);
     for (int m = 0; m != numCells; ++m) ids[m] = m;
@@ -1108,7 +1108,7 @@ int VoronoiMeshSnapshot::cellIndex(Position bfr) const
     // determine the block in which the point falls
     // if we didn't build a Voronoi mesh, the search tree is always in the first "block"
     int b = 0;
-    if (!_foregoVoronoMesh)
+    if (!_foregoVoronoiMesh)
     {
         int i, j, k;
         _extent.cellIndices(i, j, k, bfr, _nb, _nb, _nb);

--- a/SKIRT/core/VoronoiMeshSnapshot.hpp
+++ b/SKIRT/core/VoronoiMeshSnapshot.hpp
@@ -438,8 +438,8 @@ public:
 
 private:
     // data members initialized during configuration
-    Box _extent;                    // the spatial domain of the mesh
-    double _eps{0.};                // small fraction of extent
+    Box _extent;                     // the spatial domain of the mesh
+    double _eps{0.};                 // small fraction of extent
     bool _foregoVoronoiMesh{false};  // true if using search tree instead of Voronoi tessellation
 
     // data members initialized when processing snapshot input and further completed by BuildMesh()

--- a/SKIRT/core/VoronoiMeshSnapshot.hpp
+++ b/SKIRT/core/VoronoiMeshSnapshot.hpp
@@ -87,13 +87,10 @@ public:
     void setExtent(const Box& extent);
 
     /** This function configures the snapshot to skip construction of the actual Voronoi
-        tessellation and instead use a search tree across all sites. This disables a substantial
-        portion of the snapshot functionality, including calculating cell volumes (and hence
-        converting between mass and density), generating random positions in a cell, and tracing
-        paths through the grid. The only remaining supported capability is determining the density
-        at a given position, which is sufficient for the important use case of regridding an
-        imported Voronoi density distribution on an octree grid. Attempting to use any of the
-        disabled functionalities after calling this configuration function will result in undefined
+        tessellation and instead use a search tree across all sites. It should be called only if
+        (1) the snapshot has been configured to import both a mass/number density column \em and a
+        volume-integrated mass/number column, and (2) the snapshot will not be required to generate
+        random positions or trace paths. Violating these conditions will result in undefined
         behavior. */
     void foregoVoronoiMesh();
 
@@ -177,15 +174,15 @@ private:
         quite time-consuming because the Voronoi tessellation must be constructed twice. */
     void buildMesh(bool relax);
 
-    /** This private function calculates the densities and (cumulative) masses for all cells, and
-        logs some statistics. The function assumes that the Voronoi mesh has already been built. */
-    void calculateDensityAndMass();
+    /** This private function calculates the volumes for all cells without using the Voronoi mesh.
+        It assumes that both mass and mass density columns are being imported. */
+    void calculateVolume();
 
-    /** This private function calculates the densities for all cells without using the Voronoi
-        mesh. It assumes that the density is imported (rather than the mass) so that the cell
-        volume is not needed. The function does \em not calculate any masses, so the total mass
-        reported by the mass() function remains zero. */
-    void calculateDensity();
+    /** This private function calculates the densities and (cumulative) masses for all cells, and
+        logs some statistics. The function assumes that the cell volumes have been calculated,
+        either by building a Voronoi tessellation, or by deriving the volume from mass and mass
+        density columns being imported. */
+    void calculateDensityAndMass();
 
     /** Private function to recursively build a binary search tree (see
         en.wikipedia.org/wiki/Kd-tree) */

--- a/SKIRT/core/VoronoiMeshSnapshot.hpp
+++ b/SKIRT/core/VoronoiMeshSnapshot.hpp
@@ -95,7 +95,7 @@ public:
         imported Voronoi density distribution on an octree grid. Attempting to use any of the
         disabled functionalities after calling this configuration function will result in undefined
         behavior. */
-    void foregoVoronoMesh();
+    void foregoVoronoiMesh();
 
     //========== Specialty constructors ==========
 
@@ -443,7 +443,7 @@ private:
     // data members initialized during configuration
     Box _extent;                    // the spatial domain of the mesh
     double _eps{0.};                // small fraction of extent
-    bool _foregoVoronoMesh{false};  // true if using search tree instead of Voronoi tessellation
+    bool _foregoVoronoiMesh{false};  // true if using search tree instead of Voronoi tessellation
 
     // data members initialized when processing snapshot input and further completed by BuildMesh()
     vector<Cell*> _cells;  // cell objects, indexed on m


### PR DESCRIPTION
**Description**
This update offers the possibility to forego the construction of the Voronoi tessellation for imported VoronoiMesh media in case the full tessellation is not needed for purposes other than sampling the density distribution. An important use case is when the medium density distribution defined on the Voronoi grid is resampled to an octree grid to perform radiative transfer. To enable this use case, the massType option can be set to include both mass density and volume-integrated mass (or both number density and volume-integrated number) in the imported data file. 

**Motivation**
The algorithm used by the VoronoiMeshSnapshot class for constructing Voronoi tessellations sometimes fails (for example, when generating sites are too close to each other). In those cases, it can be desirable to forego the construction of the Voronoi tessellation and instead use a nearest neighbor search for sampling the density distribution. 

**Tests**
New tests have been added; all other functional tests still run.
