### PR TITLE
Add probe for radiation field at specified positions

### DIFF
--- a/SKIRT/core/RadiationFieldAtPositionsProbe.cpp
+++ b/SKIRT/core/RadiationFieldAtPositionsProbe.cpp
@@ -1,0 +1,80 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "RadiationFieldAtPositionsProbe.hpp"
+#include "Configuration.hpp"
+#include "DisjointWavelengthGrid.hpp"
+#include "InstrumentWavelengthGridProbe.hpp"
+#include "MediumSystem.hpp"
+#include "StringUtils.hpp"
+#include "TextInFile.hpp"
+#include "TextOutFile.hpp"
+#include "Units.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void RadiationFieldAtPositionsProbe::probeRun()
+{
+    if (find<Configuration>()->hasRadiationField())
+    {
+        // output the mean intensity for each position in the input file
+        {
+            auto wavelengthGrid = find<Configuration>()->radiationFieldWLG();
+            auto ms = find<MediumSystem>();
+            auto grid = ms->grid();
+            auto units = find<Units>();
+
+            // open the input file
+            TextInFile infile(this, filename(), "positions");
+            infile.useColumns(useColumns());
+            infile.addColumn("position x", "length", "pc");
+            infile.addColumn("position y", "length", "pc");
+            infile.addColumn("position z", "length", "pc");
+
+            // create the output file
+            TextOutFile outfile(this, itemName() + "_J", "mean intensity at positions");
+
+            // write the header
+            outfile.writeLine("# Mean radiation field intensities at imported positions");
+            outfile.addColumn("position x", units->ulength());
+            outfile.addColumn("position y", units->ulength());
+            outfile.addColumn("position z", units->ulength());
+            for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
+                outfile.addColumn(units->smeanintensity() + " at lambda = "
+                                      + StringUtils::toString(units->owavelength(wavelengthGrid->wavelength(ell)), 'g')
+                                      + " " + units->uwavelength(),
+                                  units->umeanintensity());
+
+            // write a line for each line in the input file
+            double x, y, z;
+            while (infile.readRow(x, y, z))
+            {
+                vector<double> values({units->olength(x), units->olength(y), units->olength(z)});
+                int m = grid->cellIndex(Position(x, y, z));
+                if (m >= 0)
+                {
+                    const Array& Jv = ms->meanIntensity(m);
+                    for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
+                        values.push_back(units->omeanintensityWavelength(wavelengthGrid->wavelength(ell), Jv[ell]));
+                }
+                else
+                {
+                    for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell) values.push_back(0.);
+                }
+                outfile.writeRow(values);
+            }
+        }
+
+        // if requested, also output the wavelength grid
+        if (writeWavelengthGrid())
+        {
+            InstrumentWavelengthGridProbe::writeWavelengthGrid(this, find<Configuration>()->radiationFieldWLG(),
+                                                               itemName() + "_wavelengths",
+                                                               "wavelengths for mean intensity");
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/RadiationFieldAtPositionsProbe.hpp
+++ b/SKIRT/core/RadiationFieldAtPositionsProbe.hpp
@@ -1,0 +1,62 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef RADIATIONFIELDATPOSITIONSPROBE_HPP
+#define RADIATIONFIELDATPOSITIONSPROBE_HPP
+
+#include "Probe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** RadiationFieldAtPositionsProbe outputs a column text file (named <tt>prefix_probe_J.dat</tt>)
+    listing the mean radiation field intensity at the positions listed in a user-provided input
+    file. This allows, for example, to probe the radiation field at the positions listed in a
+    Particle or VoronoiMesh import file used for defining sources or media by configuring this
+    probe with the same import file (any columns other than the position coordinates will be
+    ignored).
+
+    The probe expects three columns in the input column text file, respectively representing the x,
+    y and z coordinates of a position in the spatial domain of the simulation. In case the input
+    file has no unit specifications, the default units are parsec. Refer to the description of the
+    TextInFile class for more information on overall formatting and on how to include header lines
+    specifying the units for each column.
+
+    The output file contains a line for each (non-empty and non-comment) line in the input file, in
+    the same order. The first three columns repeat the x, y and z coordinates of the position (in
+    the configured output units, which may differ from the input units). Subsequent columns list
+    the mean radiation field intensity for each bin in the wavelength grid returned by the
+    Configuration::radiationFieldWLG() function. The radiation field at positions outside of
+    simulation's spatial grid is assumed to be zero.
+
+    The probe offers an option to output a separate text column file with details on the radiation
+    field wavelength grid. For each wavelength bin, the file lists the characteristic wavelength,
+    the wavelength bin width, and the left and right borders of the bin. */
+class RadiationFieldAtPositionsProbe : public Probe
+{
+    ITEM_CONCRETE(RadiationFieldAtPositionsProbe, Probe, "the mean radiation field intensity at imported positions")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(RadiationFieldAtPositions, "Level2&Medium&SpatialGrid&RadiationField")
+
+        PROPERTY_STRING(filename, "the name of the file listing the positions")
+
+        PROPERTY_STRING(useColumns, "a list of names corresponding to columns in the file to be imported")
+        ATTRIBUTE_DEFAULT_VALUE(useColumns, "")
+        ATTRIBUTE_REQUIRED_IF(useColumns, "false")
+        ATTRIBUTE_DISPLAYED_IF(useColumns, "Level3")
+
+        PROPERTY_BOOL(writeWavelengthGrid, "output a text file with the radiation field wavelength grid")
+        ATTRIBUTE_DEFAULT_VALUE(writeWavelengthGrid, "false")
+
+    ITEM_END()
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function performs probing after all photon packets have been emitted and detected. */
+    void probeRun() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -192,6 +192,7 @@
 #include "PseudoSersicGeometry.hpp"
 #include "QuasarSED.hpp"
 #include "RadialVectorField.hpp"
+#include "RadiationFieldAtPositionsProbe.hpp"
 #include "RadiationFieldPerCellProbe.hpp"
 #include "RadiationFieldWavelengthGridProbe.hpp"
 #include "Random.hpp"
@@ -641,6 +642,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<DefaultRadiationFieldCutsProbe>();
     ItemRegistry::add<PlanarRadiationFieldCutsProbe>();
     ItemRegistry::add<RadiationFieldPerCellProbe>();
+    ItemRegistry::add<RadiationFieldAtPositionsProbe>();
     ItemRegistry::add<RadiationFieldWavelengthGridProbe>();
     ItemRegistry::add<DefaultDustTemperatureCutsProbe>();
     ItemRegistry::add<PlanarDustTemperatureCutsProbe>();


### PR DESCRIPTION
**Description**
Add a probe that outputs the mean radiation field intensity at the positions listed in a user-provided input file. This allows, for example, to probe the radiation field at the positions listed in a Particle or VoronoiMesh import file used for defining sources or media by configuring this new probe with the same import file (any columns other than the position coordinates will be ignored).

**Motivation**
As a first order approximation for handling radiation field (RF)-dependent line emission in SKIRT (for certain lines) we consider a two-step approach: (1) calculate the RF using dust only and (2) redo the simulation including line emission parametrized using info derived from the RF calculated in step 1. In order for this to work, we need to “map” the SKIRT RF output back to the entities used for input, as extracted from the snapshot. This probe helps doing that.

**Tests**
A new functional test has been added. 

