### PR TITLE
Support binary stored columns format as a faster alternative for column text files

### DIFF
--- a/SKIRT/core/StoredColumns.cpp
+++ b/SKIRT/core/StoredColumns.cpp
@@ -1,0 +1,82 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "StoredColumns.hpp"
+#include "FatalError.hpp"
+#include "StringUtils.hpp"
+#include "System.hpp"
+#include <cstring>
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // the alternate interpretations for 8-byte items in the stored columns format
+    union ScolItem
+    {
+        double doubleType;
+        size_t sizeType;
+        char stringType[8];
+    };
+    const size_t itemSize = sizeof(ScolItem);
+
+    static_assert((sizeof(size_t) == 8) & (sizeof(double) == 8) & (itemSize == 8),
+                  "Cannot properly declare union for items in stored columns format");
+}
+
+////////////////////////////////////////////////////////////////////
+
+void StoredColumns::open(string filepath)
+{
+    // verify that we don't have an associated map
+    if (!_filePath.empty()) throw FATALERROR("Another column file is already associated with this instance");
+
+    // remember the path for the input file
+    _filePath = filepath;
+
+    // acquire a memory map for the file; the function returns zeros if the memory map cannot be created
+    auto map = System::acquireMemoryMap(_filePath);
+    if (!map.first) throw FATALERROR("Cannot acquire memory map for file: " + _filePath);
+    const ScolItem* currentItem = static_cast<const ScolItem*>(map.first);
+
+    // verify the name tag, the Endianness tag, and the extra zero
+    if (memcmp("SKIRT X\n", currentItem++->stringType, itemSize) || currentItem++->sizeType != 0x010203040A0BFEFF
+        || currentItem++->sizeType != 0)
+        throw FATALERROR("File does not have stored columns file format: " + _filePath);
+
+    // get the number of rows and columns
+    size_t numRows = currentItem++->sizeType;
+    _numColumns = currentItem++->sizeType;
+
+    // get the column names and unit strings
+    for (size_t i = 0; i != _numColumns; ++i)
+        _columnNames.push_back(StringUtils::squeeze(string(currentItem++->stringType, itemSize)));
+    for (size_t i = 0; i != _numColumns; ++i)
+        _columnUnits.push_back(StringUtils::squeeze(string(currentItem++->stringType, itemSize)));
+
+    // initialize the row pointers
+    _nextRow = &currentItem->doubleType;
+    currentItem += _numColumns * numRows;
+    _endRow = &currentItem->doubleType;
+
+    // verify the end-of-file tag
+    if (memcmp("SCOLEND\n", currentItem->stringType, itemSize))
+        throw FATALERROR("End-of-file does not match expected number of values: " + _filePath);
+}
+
+////////////////////////////////////////////////////////////////////
+
+void StoredColumns::close()
+{
+    if (!_filePath.empty()) System::releaseMemoryMap(_filePath);
+    _filePath.clear();
+    _columnNames.clear();
+    _columnUnits.clear();
+    _numColumns = 0;
+    _nextRow = nullptr;
+    _endRow = nullptr;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/StoredColumns.hpp
+++ b/SKIRT/core/StoredColumns.hpp
@@ -1,0 +1,123 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef STOREDCOLUMNS_HPP
+#define STOREDCOLUMNS_HPP
+
+#include "Array.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** An instance of the StoredColumns class provides access to a set of data columns stored in a
+    file using the binary SKIRT stored columns format (which is simular to the SKIRT stored table
+    format implemented by StoredTable). Stored columns files are intended as a much faster
+    replacement for large regular text column data files, without the benefit of being human
+    readable. The format does not support non-leaf rows, so it cannot be used for representing
+    adaptive mesh data.
+
+    Stored columns file format
+    --------------------------
+
+    A stored columns file includes the names and units of the quantities in each column, in
+    addition to the tabulated data values. All values are stored as binary data in the form of
+    64-bit floating-point numbers. More specifically, a stored columns file is essentially a
+    sequence of 8-byte data items. A data item can have one of three types:
+
+        - string: 1 to 8 printable and non-whitespace 7-bit ASCII characters, padded with spaces
+          to fill 8 bytes if needed;
+        - unsigned integer: 64-bit integer in little-endian byte order;
+        - floating point: 64-bit double (IEEE 754) in little-endian byte order.
+
+    The overall layout is as follows:
+        - SKIRT name/version tag
+        - Endianness tag
+        - 0  (to differentiate from stored table format, which stores the nr of axes here)
+        - numRows
+        - numColumns
+        - columnName (x numColumns)
+        - columnUnit (x numColumns)
+        - value (x numColumns x numRows)
+        - end-of-file tag
+
+    The values are ordered so that the column values for a particular row are next to each other.
+
+    The StoredColumns class
+    -----------------------
+
+    The default constructor creates an invalid stored columns instance. The alternate constructor
+    and the open() function associate a particular stored columns file with the stored columns
+    instance. The close() function and the destructor automatically release the file association
+    and any related resources. It is allowed to call open() again after close().
+
+    The columnNames() and columnUnits() functions return informaton about the columns, and the
+    readRow() function returns the rows one by one, from the start to the end of the file.
+*/
+class StoredColumns
+{
+    // ================== Constructing ==================
+
+public:
+    /** The default constructor constructs a closed stored columns instance. The user must call the
+        open() function to associate the instance with a particular stored columns file. */
+    StoredColumns() {}
+
+    /** This alternate constructor constructs a stored columns instance and immediately associates
+        a given stored columns file with it by calling the open() function. Refer to the open()
+        function for more information. */
+    StoredColumns(string filename) { open(filename); }
+
+    /** The destructor releases the association with a stored columns file established by the
+        alternate constructor or the open() function, if there is any. */
+    ~StoredColumns() { close(); }
+
+    /** This function associates a given stored columns input file with the stored columns
+        instance. If such an association already exists, or if the open operations fails, this
+        function throws a fatal error. The \em filename argument specifies the absolute file path
+        of the input file, including the mandatory ".scol" filename extension. */
+    void open(string filepath);
+
+    /** This function releases the association with a stored columns file established by the
+        alternate constructor or the open() function, if there is any. After callig this function,
+        it is allowed to call open() again. */
+    void close();
+
+    // ================== Accessing data ==================
+
+public:
+    /** This function returns the names of the columns in the file. The length of the list
+        corresponds to the number of columns. If no file is open, the list is enpty. */
+    const vector<string>& columnNames() const { return _columnNames; }
+
+    /** This function returns the unit strings for the columns in the file, in the same order as
+        the column names returned by columnNames(). If no file is open, the list is enpty. */
+    const vector<string>& columnUnits() const { return _columnUnits; }
+
+    /** This function returns a pointer to a list of the column values in the next row, or the null
+        pointer if there are no more rows or if no file is open. The returned pointer becomes
+        invalid upon the next invocation of this function, or when the file is closed. The column
+        values are listed in the order corresponding to the list returned by columnNames(). The
+        function returns rows one by one, in the order they are stored in the file. */
+    const double* nextRow()
+    {
+        if (_nextRow == _endRow) return nullptr;
+        auto result = _nextRow;
+        _nextRow += _numColumns;
+        return result;
+    }
+
+    // ================== Data members ==================
+
+private:
+    string _filePath;                 // the canonical path to the associated stored columns file
+    vector<string> _columnNames;      // the column names
+    vector<string> _columnUnits;      // the column unit strings
+    size_t _numColumns{0};            // step size from one row to the next
+    const double* _nextRow{nullptr};  // ptr to the first value in the next row to be returned
+    const double* _endRow{nullptr};   // ptr just beyond the last row in the file
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif


### PR DESCRIPTION
**Motivation**
With the ever increasing resolution of hydro simulations, column text import files representing a galaxy snapshot may easily contain 100 million lines. Reading these large column text files can be very slow (on the order of one minute per ten million lines) and cannot be accelerated through parallelization. Although the time spent reading import files is usually still small compared to the total simulation time, these long setup times are especially annoying while interactively testing or fine-tuning a SKIRT configuration.

It has been suggested, among others by @cbehren and @bwvdnbro, to support a binary format such as HDF5 for SKIRT import. However, this would bring extra complexities. Firstly, we would need to introduce a dependency on the HDF5 library (which, admittedly, could be made optional). Secondly, HDF5 is a very rich data-base-like format. We would need to define exactly how the columns to be imported and the corresponding metadata have to be stored in the file, creating a kind of SKIRT-specific HDF5 format. Feasible but not ideal.

Lastly, there is no hope to import directly from hydro snapshots stored in HDF5 because every type of simulation requires its own post-processing recipe, usually implemented in Python. At the end of the data extraction and processing performed in that step, one can just as well save the SKIRT import files in a SKIRT-specific format, as long as this is easy to do in Python.

**Description**
This pull request introduces the option, in many common use cases, to provide import files in the binary SKIRT _stored columns_ file format. This format is similar to the SKIRT _stored table_ file format used for SKIRT built-in resources, but is intended to represent a set of data columns just like a column text file.

An accompanying PTS pull request is adding a function to save stored columns files, and a command to convert an existing column text file to stored columns format. 

To provide a stored columns file to SKIRT, simply specify a filename with the mandatory `.scol` filename extension anywhere SKIRT expects a column text file (within the limitations described below). Where applicable, the `useColumns` attribute may need to be updated (because column names may need to differ, see below).

**Limitations**
The stored columns file format has the following limitations:
    - being a binary format, the files are not human readable.
    - a (binary) file header with column names and unit strings must always be included.
    - the column names and unit strings have a maximum length of 8 characters each.
    - there is no support for non-leaf rows, so the format cannot be used for representing adaptive mesh data.

**Tests**
Functional tests have been added. The new format has also been tested with some large import files. Reading the stored columns format is about 30 times faster than for the regular text-based format.
