### PR TITLE
Add aperture info to FullInstrument documentation

### DIFF
--- a/SKIRT/core/FrameInstrument.hpp
+++ b/SKIRT/core/FrameInstrument.hpp
@@ -12,7 +12,10 @@
 
 /** A FrameInstrument object represents a distant instrument that records the surface brightness in
     every pixel of a given frame for each wavelength, and outputs an IFU data cube in a FITS file.
-    */
+
+    The instrument allows configuring the field of view and number of pixels in both directions of
+    the observer plane. Photon packets arriving from a point that parallel projects outside of the
+    field of view are ignored. */
 class FrameInstrument : public DistantInstrument
 {
     ITEM_CONCRETE(FrameInstrument, DistantInstrument,

--- a/SKIRT/core/FullInstrument.hpp
+++ b/SKIRT/core/FullInstrument.hpp
@@ -13,7 +13,15 @@
 /** A FullInstrument object represents a distant instrument that records and outputs both the
     spatially integrated flux density for each wavelength (as an %SED text column file) and the
     surface brightness in every pixel of a given frame for each wavelength (as an IFU data cube in
-    a FITS file). */
+    a FITS file).
+
+    This instrument acts as a combination of an SEDInstrument with infinite aperture radius and a
+    FrameInstrument with a configurable field of view. Photon packets arriving from a point that
+    parallel projects outside of this field of view are ignored for the purposes of the embedded
+    FrameInstrument, but are still included in the results of the embedded SEDInstrument.
+    Therefore, when interpreting the instrument output for a particular wavelength, spatially
+    integrating the surface brightness recorded by the embedded FrameInstrument might produce a
+    lower flux density value than the one recorded by the embedded SEDInstrument. */
 class FullInstrument : public FrameInstrument
 {
     ITEM_CONCRETE(FullInstrument, FrameInstrument,


### PR DESCRIPTION
**Description**
Augment the documentation of the distant instruments (`SEDInstrument`, `FrameInstrument`, and `FullInstrument`) to explicitly specify the aperture used in all cases. Specifically, the `SEDInstrument` embedded in the `FullInstrument` always uses an infinite aperture radius. Therefore, when interpreting the instrument output for a particular wavelength, spatially integrating the surface brightness recorded by the embedded `FrameInstrument` might produce a lower flux density value than the one recorded by the embedded `SEDInstrument`.

**Motivation**
This (historically inspired) behavior has confused several users because it was not clearly documented.


