### PR TITLE
Fix spatially variable material mix support for imported mesh media

### DIFF
--- a/SKIRT/core/GeometricMedium.cpp
+++ b/SKIRT/core/GeometricMedium.cpp
@@ -34,6 +34,13 @@ const MaterialMix* GeometricMedium::mix(Position /*bfr*/) const
 
 ////////////////////////////////////////////////////////////////////
 
+const MaterialMix* GeometricMedium::mix() const
+{
+    return materialMix();
+}
+
+////////////////////////////////////////////////////////////////////
+
 bool GeometricMedium::hasVariableMix() const
 {
     return false;

--- a/SKIRT/core/GeometricMedium.hpp
+++ b/SKIRT/core/GeometricMedium.hpp
@@ -77,6 +77,10 @@ protected:
         medium. The same object is returned regardless of position. */
     const MaterialMix* mix(Position bfr) const override;
 
+    /** This function returns the MaterialMix object defining the material properties for the
+        medium. */
+    const MaterialMix* mix() const override;
+
     /** This function always returns false because a geometric medium has the same dust mix
         throughout its spatial domain. */
     bool hasVariableMix() const override;

--- a/SKIRT/core/ImportedMedium.cpp
+++ b/SKIRT/core/ImportedMedium.cpp
@@ -64,12 +64,20 @@ const MaterialMix* ImportedMedium::mix(Position bfr) const
     if (_importVariableMixParams)
     {
         Array params;
-        // this function is called by the Configuration object before setup() has been performed on the medium;
-        // so if the snapshot has not yet been created, just return a default material mix
-        if (_snapshot)
-            _snapshot->parameters(bfr, params);
-        else
-            params.resize(_materialMixFamily->parameterInfo().size());
+        _snapshot->parameters(bfr, params);
+        return _materialMixFamily->mix(params);
+    }
+    else
+        return _materialMix;
+}
+
+//////////////////////////////////////////////////////////////////////
+
+const MaterialMix* ImportedMedium::mix() const
+{
+    if (_importVariableMixParams)
+    {
+        Array params(_materialMixFamily->parameterInfo().size());
         return _materialMixFamily->mix(params);
     }
     else

--- a/SKIRT/core/ImportedMedium.hpp
+++ b/SKIRT/core/ImportedMedium.hpp
@@ -103,14 +103,21 @@ public:
     int dimension() const override;
 
     /** This function returns the MaterialMix object defining the material properties for the
-        medium at the specified position. If the position argument is omitted, the function returns
-        the material mix for the model coordinate origin as a default value.
+        medium at the specified position.
 
         If the \em importVariableMixParams flag is enabled, the appropriate material mix is
         selected from the configured material mix family based on the value of the imported
         parameters for the specified position. If the flag is disabled, the fixed configured
         material mix is returned regardless of position. */
-    const MaterialMix* mix(Position bfr = Position()) const override;
+    const MaterialMix* mix(Position bfr) const override;
+
+    /** This function returns a default MaterialMix object representative of the material
+        properties of the medium.
+
+        If the \em importVariableMixParams flag is enabled, a default material mix is selected from
+        the configured material mix family using the appropriate number of parameters with a value
+        of zero. If the flag is disabled, the fixed configured material mix is returned. */
+    const MaterialMix* mix() const override;
 
     /** This function returns the configured value of the \em importVariableMixParams flag. If
         true, this medium may return a different MaterialMix object depending on the specified

--- a/SKIRT/core/Medium.hpp
+++ b/SKIRT/core/Medium.hpp
@@ -73,12 +73,16 @@ public:
         with location, the material type and the level of support for various physical processes
         (such as, e.g., polarization) must be the same for all positions. An object of the
         appropriate type must be returned even if the density of the material happens to be zero at
-        the specified position. As a result of this rule, one can call this function with an
-        arbitrary location (or a missing argument to substitute the default) to obtain a MaterialMix
-        object with a type and level of support representative for this medium. */
-    virtual const MaterialMix* mix(Position bfr = Position()) const = 0;
+        the specified position. */
+    virtual const MaterialMix* mix(Position bfr) const = 0;
 
-    /** This function returns true if the mix() function for this medium may return a different
+    /** This function returns (a pointer to) a default MaterialMix object representative of the
+        material properties of this medium. In other words, it returns an arbitrary material mix
+        with the same material type and level of support for various physical processes as any of
+        the material mixes that may be returned by the mix(bfr) function. */
+    virtual const MaterialMix* mix() const = 0;
+
+    /** This function returns true if the mix(bfr) function for this medium may return a different
         MaterialMix object depending on the specified position, or false when the same object is
         always returned. */
     virtual bool hasVariableMix() const = 0;


### PR DESCRIPTION
**Description**
Fix support for spatially variable material mixes with imported mesh media (including Voronoi and AMR meshes). The mechanism worked with particle media but caused a crash when used with mesh media.

**Motivation**
Fix a crashing bug.

**Tests**
All existing functional tests work. New tests have been added for these use cases.

