### PR TITLE
Fix issue with zero-mass imported Voronoi mesh

### DIFF
--- a/SKIRT/core/VoronoiMeshSpatialGrid.cpp
+++ b/SKIRT/core/VoronoiMeshSpatialGrid.cpp
@@ -138,7 +138,7 @@ void VoronoiMeshSpatialGrid::setupSelfBefore()
 
             // if there is a single medium component, calculate the normalization factor imposed by it;
             // we need this to directly compute cell densities for the DensityInCellInterface
-            if (ms->media().size() == 1) _norm = ms->media()[0]->number() / _mesh->mass();
+            if (ms->media().size() == 1) _norm = _mesh->mass() > 0 ? ms->media()[0]->number() / _mesh->mass() : 0.;
             break;
         }
     }


### PR DESCRIPTION
**Description**
Fix a bug that caused SKIRT to produce NaN densities and hang indefinitely when shooting photon packets in the following special case: import a medium defined on a Voronoi mesh, use the same mesh as a radiative transfer grid, and have zero mass in all cells within the bounding box of the grid, so that the total medium mass is zero.

**Motivation**
Importing a zero-mass medium might be unusual, but it is perfectly valid.

**Tests**
Added a functional test for this special case; all existing tests still work.
