### PR TITLE
Fix incorrect treatment of photon packets originating outside of Cylinder 2D grid

### DIFF
--- a/SKIRT/core/Cylinder2DSpatialGrid.cpp
+++ b/SKIRT/core/Cylinder2DSpatialGrid.cpp
@@ -136,9 +136,9 @@ public:
                 return false;
             else
             {
-                double qmax = sqrt((Rmax - _p) * (Rmax + _p));
-                double ds = (qmax - _q) / _kq;
-                _q = qmax;
+                double qmin = -sqrt((Rmax - _p) * (Rmax + _p));
+                double ds = (qmin - _q) / _kq;
+                _q = qmin;
                 _R = Rmax - 1e-8 * (_grid->_Rv[_grid->_NR] - _grid->_Rv[_grid->_NR - 1]);
                 _z += _kz * ds;
                 cumds += ds;


### PR DESCRIPTION
**Description**
This update fixes the incorrect treatment of photon packets originating outside of the domain of an axially symmetric grid implemented by `Cylinder2DSpatialGrid`. In other words, in 2D SKIRT models using the `Cylinder2DSpatialGrid`, the paths for photon packets emitted from sources outside of the cylindrical grid boundaries were calculated incorrectly. For example, consider a simple model with a dusty Plummer sphere illuminated by a thin ring surrounding it in the equatorial plane. Viewing this configuration at an inclination of 85 degrees, the correct result (as can be easily verified by using, for example, a 3D Cartesian grid) would be:

<img width="250" alt="Correct" src="https://user-images.githubusercontent.com/7975955/133595734-28b48151-2091-4309-ab89-5e8f22ec0a57.png">

The `Cylinder2DSpatialGrid`, however, when configured with a radial boundary smaller than the source ring, yielded the following incorrect result:

<img width="250" alt="Incorrect" src="https://user-images.githubusercontent.com/7975955/133596076-a17e6736-b9a1-42e8-b70d-7d4e5cffac74.png">

**Impact on previous work**

This bug was already present in SKIRT version 7. In principle, any SKIRT configurations using the `Cylinder2DSpatialGrid` to discretize the transfer medium and including sources located outside of the domain of the grid yielded incorrect results. For example, an exponential disk without radial cutoff has infinite support and will always emit at least some radiation outside of any finite grid. However, with a realistic configuration, the fraction of this "outside" radiation is very small and thus the impact on the result would be negligible. In fact, the bug has escaped detection for so many years precisely because virtually all SKIRT models indeed have no or very little radiation originating outside of the domain of the spatial grid discretizing the medium. 

**Motivation**
Fixing a nasty bug!

**Tests**
A new functional test has been added (the outside ring shown above) and the affected existing tests have been updated.
