### PR TITLE
Add probe to output projected surface density (dust) or column density (electrons, gas)

### DIFF
--- a/SKIRT/core/ProjectedMediaDensityProbe.cpp
+++ b/SKIRT/core/ProjectedMediaDensityProbe.cpp
@@ -1,0 +1,156 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "ProjectedMediaDensityProbe.hpp"
+#include "Array.hpp"
+#include "Configuration.hpp"
+#include "FITSInOut.hpp"
+#include "MediumSystem.hpp"
+#include "Parallel.hpp"
+#include "ParallelFactory.hpp"
+#include "PathSegmentGenerator.hpp"
+#include "Units.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void ProjectedMediaDensityProbe::probeSetup()
+{
+    if (probeAfter() == ProbeAfter::Setup) probe();
+}
+
+////////////////////////////////////////////////////////////////////
+
+void ProjectedMediaDensityProbe::probeRun()
+{
+    if (probeAfter() == ProbeAfter::Run) probe();
+}
+
+////////////////////////////////////////////////////////////////////
+
+void ProjectedMediaDensityProbe::probe()
+{
+    if (find<Configuration>()->hasMedium())
+    {
+        // locate relevant simulation items
+        auto units = find<Units>();
+        auto ms = find<MediumSystem>();
+        int numMedia = ms->numMedia();
+        auto grid = ms->grid();
+
+        // get frame configuration
+        int Nxp = numPixelsX();
+        int Nyp = numPixelsY();
+        double xcent = centerX();
+        double ycent = centerY();
+        double xpmin = centerX() - 0.5 * fieldOfViewX();
+        double xpsiz = fieldOfViewX() / numPixelsX();
+        double ypmin = centerY() - 0.5 * fieldOfViewY();
+        double ypsiz = fieldOfViewY() / numPixelsY();
+
+        // determine direction from observer to model
+        Direction bfkobs(inclination(), azimuth());
+        bfkobs = -bfkobs;
+
+        // calculate sines and cosines for the transformation from observer to model coordinates
+        double costheta = cos(inclination());
+        double sintheta = sin(inclination());
+        double cosphi = cos(azimuth());
+        double sinphi = sin(azimuth());
+        double cosomega = cos(roll());
+        double sinomega = sin(roll());
+
+        // allocate result arrays with the appropriate size and initialize contents to zero
+        Array dust_v;
+        Array elec_v;
+        Array gas_v;
+        int size = Nxp * Nyp;
+        if (ms->hasDust()) dust_v.resize(size);
+        if (ms->hasElectrons()) elec_v.resize(size);
+        if (ms->hasGas()) gas_v.resize(size);
+
+        // calculate the results in parallel; perform only at the root processs
+        auto parallel = find<ParallelFactory>()->parallelRootOnly();
+        parallel->call(Nyp, [&dust_v, &elec_v, &gas_v, ms, numMedia, grid, xpmin, xpsiz, ypmin, ypsiz, bfkobs, costheta,
+                             sintheta, cosphi, sinphi, cosomega, sinomega, Nxp](size_t firstIndex, size_t numIndices) {
+            // allocate objects that can be reused for multiple pixels
+            SpatialGridPath path;
+            auto generator = grid->createPathSegmentGenerator();
+
+            // loop over pixels
+            for (size_t j = firstIndex; j != firstIndex + numIndices; ++j)
+            {
+                for (int i = 0; i != Nxp; ++i)
+                {
+                    int l = i + Nxp * j;
+
+                    // transform pixel indices to observer coordinates
+                    double xp = xpmin + (i + 0.5) * xpsiz;
+                    double yp = ypmin + (j + 0.5) * ypsiz;
+                    double zp = 2. * grid->boundingBox().diagonal();  // somewhere outside of the model
+
+                    // transform observer coordinates to model coordinates (inverse transform of frame instrument)
+                    double xpp = sinomega * xp - cosomega * yp;
+                    double ypp = cosomega * xp + sinomega * yp;
+                    double zpp = zp;
+                    double x = cosphi * costheta * xpp - sinphi * ypp + cosphi * sintheta * zpp;
+                    double y = sinphi * costheta * xpp + cosphi * ypp + sinphi * sintheta * zpp;
+                    double z = -sintheta * xpp + costheta * zpp;
+
+                    // initialize a path leaving the pixel through the model
+                    path.setPosition(Position(x, y, z));
+                    path.setDirection(bfkobs);
+
+                    // calculate the column densities for each medium type along the path
+                    generator->start(&path);
+                    while (generator->next())
+                    {
+                        int m = generator->m();
+                        if (m >= 0)
+                        {
+                            for (int h = 0; h != numMedia; ++h)
+                            {
+                                if (ms->isDust(h))
+                                {
+                                    dust_v[l] += ms->massDensity(m, h) * generator->ds();
+                                }
+                                else if (ms->isElectrons(h))
+                                {
+                                    elec_v[l] += ms->numberDensity(m, h) * generator->ds();
+                                }
+                                else if (ms->isGas(h))
+                                {
+                                    gas_v[l] += ms->numberDensity(m, h) * generator->ds();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        // define a function to write a result array to a FITS file
+        auto write = [this, units, xpsiz, ypsiz, xcent, ycent, Nxp, Nyp](Array& v, string label, string prefix,
+                                                                         bool massDensity) {
+            if (v.size())
+            {
+                // convert to output units
+                v *= (massDensity ? units->omasssurfacedensity(1.) : units->onumbersurfacedensity(1.));
+                string densityUnits = massDensity ? units->umasssurfacedensity() : units->unumbersurfacedensity();
+
+                // write file
+                string filename = itemName() + "_" + prefix;
+                FITSInOut::write(this, label, filename, v, densityUnits, Nxp, Nyp, units->olength(xpsiz),
+                                 units->olength(ypsiz), units->olength(xcent), units->olength(ycent), units->ulength());
+            }
+        };
+
+        // write the results for each material type to a FITS file with an appropriate name
+        write(dust_v, "dust surface mass density", "dust", true);
+        write(elec_v, "electron column number density", "elec", false);
+        write(gas_v, "gas column number density", "gas", false);
+    }
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ProjectedMediaDensityProbe.cpp
+++ b/SKIRT/core/ProjectedMediaDensityProbe.cpp
@@ -78,6 +78,9 @@ void ProjectedMediaDensityProbe::probe()
             SpatialGridPath path;
             auto generator = grid->createPathSegmentGenerator();
 
+            // get a distance well outside of the model (but with a similar order of magnitude)
+            double zp = 2. * grid->boundingBox().diagonal();
+
             // loop over pixels
             for (size_t j = firstIndex; j != firstIndex + numIndices; ++j)
             {
@@ -88,7 +91,6 @@ void ProjectedMediaDensityProbe::probe()
                     // transform pixel indices to observer coordinates
                     double xp = xpmin + (i + 0.5) * xpsiz;
                     double yp = ypmin + (j + 0.5) * ypsiz;
-                    double zp = 2. * grid->boundingBox().diagonal();  // somewhere outside of the model
 
                     // transform observer coordinates to model coordinates (inverse transform of frame instrument)
                     double xpp = sinomega * xp - cosomega * yp;

--- a/SKIRT/core/ProjectedMediaDensityProbe.hpp
+++ b/SKIRT/core/ProjectedMediaDensityProbe.hpp
@@ -1,0 +1,109 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef PROJECTEDMEDIADENSITYPROBE_HPP
+#define PROJECTEDMEDIADENSITYPROBE_HPP
+
+#include "Probe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** ProjectedMediaDensityProbe outputs a projection of the grid-discretized media density in the
+    simulation on a plane along a given line of sight. The viewing angle, field of view and pixel
+    resolution are configured in the same way as for a FrameInstrument so that it is easy to obtain
+    a mass density projection matching the position of an instrument.
+
+    A separate FITS file is produced for each material type (dust, electrons, or gas), if present.
+    The file for dust provides the dust surface mass density in units of dust mass per area. The
+    files for electrons and gas provide the electron or hydrogen column number density in units of
+    number per area. Multiple media components containing the same material type are combined,
+    regardless of their ordering in the configuration. */
+class ProjectedMediaDensityProbe : public Probe
+{
+    /** The enumeration type indicating when probing occurs. */
+    ENUM_DEF(ProbeAfter, Setup, Run)
+        ENUM_VAL(ProbeAfter, Setup, "after setup")
+        ENUM_VAL(ProbeAfter, Run, "after the complete simulation run")
+    ENUM_END()
+
+    ITEM_CONCRETE(ProjectedMediaDensityProbe, Probe,
+                  "Parallel-projection of the media density toward an arbitrary line of sight")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(ProjectedMediaDensityProbe, "Level2&Medium&SpatialGrid")
+
+        PROPERTY_DOUBLE(inclination, "the inclination angle θ of the projection")
+        ATTRIBUTE_QUANTITY(inclination, "posangle")
+        ATTRIBUTE_MIN_VALUE(inclination, "0 deg")
+        ATTRIBUTE_MAX_VALUE(inclination, "180 deg")
+        ATTRIBUTE_DEFAULT_VALUE(inclination, "0 deg")
+        ATTRIBUTE_DISPLAYED_IF(inclination, "Dimension2|Dimension3")
+
+        PROPERTY_DOUBLE(azimuth, "the azimuth angle φ of the projection")
+        ATTRIBUTE_QUANTITY(azimuth, "posangle")
+        ATTRIBUTE_MIN_VALUE(azimuth, "-360 deg")
+        ATTRIBUTE_MAX_VALUE(azimuth, "360 deg")
+        ATTRIBUTE_DEFAULT_VALUE(azimuth, "0 deg")
+        ATTRIBUTE_DISPLAYED_IF(azimuth, "Dimension3")
+
+        PROPERTY_DOUBLE(roll, "the roll angle ω of the projection")
+        ATTRIBUTE_QUANTITY(roll, "posangle")
+        ATTRIBUTE_MIN_VALUE(roll, "-360 deg")
+        ATTRIBUTE_MAX_VALUE(roll, "360 deg")
+        ATTRIBUTE_DEFAULT_VALUE(roll, "0 deg")
+        ATTRIBUTE_DISPLAYED_IF(roll, "Level2&(Dimension2|Dimension3)")
+
+        PROPERTY_DOUBLE(fieldOfViewX, "the total field of view in the horizontal direction")
+        ATTRIBUTE_QUANTITY(fieldOfViewX, "length")
+        ATTRIBUTE_MIN_VALUE(fieldOfViewX, "]0")
+
+        PROPERTY_INT(numPixelsX, "the number of pixels in the horizontal direction")
+        ATTRIBUTE_MIN_VALUE(numPixelsX, "1")
+        ATTRIBUTE_MAX_VALUE(numPixelsX, "10000")
+        ATTRIBUTE_DEFAULT_VALUE(numPixelsX, "250")
+
+        PROPERTY_DOUBLE(centerX, "the center of the frame in the horizontal direction")
+        ATTRIBUTE_QUANTITY(centerX, "length")
+        ATTRIBUTE_DEFAULT_VALUE(centerX, "0")
+        ATTRIBUTE_DISPLAYED_IF(centerX, "Level2")
+
+        PROPERTY_DOUBLE(fieldOfViewY, "the total field of view in the vertical direction")
+        ATTRIBUTE_QUANTITY(fieldOfViewY, "length")
+        ATTRIBUTE_MIN_VALUE(fieldOfViewY, "]0")
+
+        PROPERTY_INT(numPixelsY, "the number of pixels in the vertical direction")
+        ATTRIBUTE_MIN_VALUE(numPixelsY, "1")
+        ATTRIBUTE_MAX_VALUE(numPixelsY, "10000")
+        ATTRIBUTE_DEFAULT_VALUE(numPixelsY, "250")
+
+        PROPERTY_DOUBLE(centerY, "the center of the frame in the vertical direction")
+        ATTRIBUTE_QUANTITY(centerY, "length")
+        ATTRIBUTE_DEFAULT_VALUE(centerY, "0")
+        ATTRIBUTE_DISPLAYED_IF(centerY, "Level2")
+
+        PROPERTY_ENUM(probeAfter, ProbeAfter, "when to probe the medium state")
+        ATTRIBUTE_DEFAULT_VALUE(probeAfter, "Setup")
+        ATTRIBUTE_DISPLAYED_IF(probeAfter, "HasDynamicState")
+
+    ITEM_END()
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function performs probing after setup. It produces output only if the \em
+        probeAfter property is set to Setup. */
+    void probeSetup() override;
+
+    /** This function performs probing after all photon packets have been emitted and detected. It
+        produces output only if the \em probeAfter property is set to Run. */
+    void probeRun() override;
+
+private:
+    /** This function performs the probing; it is called from probeSetup() or probeRun() depending
+        on the value of the \em probeAfter property. */
+    void probe();
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -189,6 +189,7 @@
 #include "PowerLawGrainSizeDistribution.hpp"
 #include "PredefinedBandWavelengthGrid.hpp"
 #include "ProbeSystem.hpp"
+#include "ProjectedMediaDensityProbe.hpp"
 #include "PseudoSersicGeometry.hpp"
 #include "QuasarSED.hpp"
 #include "RadialVectorField.hpp"
@@ -622,6 +623,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<TreeSpatialGridTopologyProbe>();
     ItemRegistry::add<DefaultMediaDensityCutsProbe>();
     ItemRegistry::add<PlanarMediaDensityCutsProbe>();
+    ItemRegistry::add<ProjectedMediaDensityProbe>();
     ItemRegistry::add<OpticalDepthMapProbe>();
     ItemRegistry::add<SpatialCellPropertiesProbe>();
     ItemRegistry::add<SpatialGridSourceDensityProbe>();

--- a/SKIRT/utils/Direction.hpp
+++ b/SKIRT/utils/Direction.hpp
@@ -70,6 +70,9 @@ public:
         the formulae \f[ \begin{split} \theta &= \arccos\left(k_z\right), \\ \varphi &=
         \arctan\left(\frac{k_y}{k_x}\right). \end{split} \f] */
     void spherical(double& theta, double& phi) const;
+
+    /** This operator returns the opposite direction (negating each component). */
+    Direction operator-() const { return Direction(-_x, -_y, -_z); }
 };
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
`ProjectedMediaDensityProbe` outputs a projection of the grid-discretized media density in the simulation on a plane along a given line of sight. The viewing angle, field of view and pixel resolution are configured in the same way as for a `FrameInstrument` so that it is easy to obtain a mass density projection matching the position of an instrument.

**Motivation**
This capability was suggested by users a number of times, including most recently by Gayathri Eknath at Cardiff University in Wales.

**Tests**
New functional tests were added.



