### PR TITLE
Log a warning for insufficient wavelength ranges; force dust cross sections to zero beyond 10 cm

### DIFF
--- a/SKIRT/core/DustMix.cpp
+++ b/SKIRT/core/DustMix.cpp
@@ -11,6 +11,7 @@
 #include "PhotonPacket.hpp"
 #include "Random.hpp"
 #include "StringUtils.hpp"
+#include "Units.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
@@ -198,6 +199,25 @@ size_t DustMix::initializeExtraProperties(const Array& /*lambdav*/)
 
 ////////////////////////////////////////////////////////////////////
 
+void DustMix::informAvailableWavelengthRange(Range available)
+{
+    Range required(_lambdav[0], _lambdav[_lambdav.size() - 1]);
+    if (available.max() < required.max() || available.min() > required.min())
+    {
+        auto units = find<Units>();
+        auto outstring = [units](double wavelength) {
+            return StringUtils::toString(units->owavelength(wavelength), 'g', 4) + " " + units->uwavelength();
+        };
+
+        auto log = find<Log>();
+        log->warning(type() + " dust properties are not available for full simulation wavelength range");
+        log->warning("Required: " + outstring(required.min()) + " - " + outstring(required.max()));
+        log->warning("Available: " + outstring(available.min()) + " - " + outstring(available.max()));
+    }
+}
+
+////////////////////////////////////////////////////////////////////
+
 int DustMix::indexForLambda(double lambda) const
 {
     return NR::locateClip(_lambdav, lambda);
@@ -307,7 +327,7 @@ namespace
 ////////////////////////////////////////////////////////////////////
 
 void DustMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
-                                Direction bfky, const MaterialState* /*state*/, PhotonPacket* pp) const
+                                Direction bfky, const MaterialState* /*state*/, const PhotonPacket* pp) const
 {
     switch (scatteringMode())
     {

--- a/SKIRT/core/DustMix.cpp
+++ b/SKIRT/core/DustMix.cpp
@@ -178,9 +178,9 @@ void DustMix::setupSelfAfter()
     // by setting the last value to zero (we now that the last wavelength in the list is the cutoff wavelength)
     if (radioCutoff)
     {
-        _sigmaabsv[numLambda-1] = 0.;
-        _sigmascav[numLambda-1] = 0.;
-        _sigmaextv[numLambda-1] = 0.;
+        _sigmaabsv[numLambda - 1] = 0.;
+        _sigmascav[numLambda - 1] = 0.;
+        _sigmaextv[numLambda - 1] = 0.;
     }
 
     // give the subclass a chance to obtain additional precalculated information

--- a/SKIRT/core/DustMix.cpp
+++ b/SKIRT/core/DustMix.cpp
@@ -65,7 +65,7 @@ void DustMix::setupSelfAfter()
     {
         wavelengths.resize(NR::locate(wavelengths, dm) + 1);
         if (wavelengths.empty() || wavelengths.back() != dm) wavelengths.push_back(dm);
-        wavelengths.push_back(dm * 1.001); // add a dummy border value which is never used
+        wavelengths.push_back(dm * 1.001);  // add a dummy border value which is never used
     }
 
     // remember the wavelength range
@@ -232,8 +232,8 @@ void DustMix::informAvailableWavelengthRange(Range available)
 
         auto log = find<Log>();
         log->warning(type() + " dust properties are not available for full simulation wavelength range");
-        log->warning("Required: " + outstring(_required.min()) + " - " + outstring(_required.max()));
-        log->warning("Available: " + outstring(available.min()) + " - " + outstring(available.max()));
+        log->warning("  Required: " + outstring(_required.min()) + " - " + outstring(_required.max()));
+        log->warning("  Available: " + outstring(available.min()) + " - " + outstring(available.max()));
     }
 }
 

--- a/SKIRT/core/DustMix.cpp
+++ b/SKIRT/core/DustMix.cpp
@@ -65,6 +65,7 @@ void DustMix::setupSelfAfter()
     {
         wavelengths.resize(NR::locate(wavelengths, dm) + 1);
         if (wavelengths.empty() || wavelengths.back() != dm) wavelengths.push_back(dm);
+        wavelengths.push_back(dm * 1.001); // add a dummy border value which is never used
     }
 
     // remember the wavelength range
@@ -175,12 +176,12 @@ void DustMix::setupSelfAfter()
     }
 
     // if the wavelength range was cut off, suppress all cross sections beyond the cutoff wavelength
-    // by setting the last value to zero (we now that the last wavelength in the list is the cutoff wavelength)
+    // by setting the last two values to zero (the penultimate item is for the cutoff wavelength)
     if (radioCutoff)
     {
-        _sigmaabsv[numLambda - 1] = 0.;
-        _sigmascav[numLambda - 1] = 0.;
-        _sigmaextv[numLambda - 1] = 0.;
+        _sigmaabsv[numLambda - 2] = _sigmaabsv[numLambda - 1] = 0.;
+        _sigmascav[numLambda - 2] = _sigmascav[numLambda - 1] = 0.;
+        _sigmaextv[numLambda - 2] = _sigmaextv[numLambda - 1] = 0.;
     }
 
     // give the subclass a chance to obtain additional precalculated information
@@ -226,7 +227,7 @@ void DustMix::informAvailableWavelengthRange(Range available)
     {
         auto units = find<Units>();
         auto outstring = [units](double wavelength) {
-            return StringUtils::toString(units->owavelength(wavelength), 'g', 4) + " " + units->uwavelength();
+            return StringUtils::toString(units->owavelength(wavelength), 'g', 3) + " " + units->uwavelength();
         };
 
         auto log = find<Log>();

--- a/SKIRT/core/DustMix.hpp
+++ b/SKIRT/core/DustMix.hpp
@@ -9,6 +9,7 @@
 #include "ArrayTable.hpp"
 #include "EquilibriumDustEmissionCalculator.hpp"
 #include "MaterialMix.hpp"
+#include "Range.hpp"
 #include "Table.hpp"
 
 ////////////////////////////////////////////////////////////////////
@@ -110,6 +111,11 @@ protected:
         returns zero. */
     virtual size_t initializeExtraProperties(const Array& lambdav);
 
+    /** This function logs a warning message if the given range is smaller than the simulation
+        wavelength range. It can (but does not have to) be called from subclasses that support dust
+        properties for a limited wavelength range. */
+    void informAvailableWavelengthRange(Range available);
+
     //======== Private support functions =======
 
 private:
@@ -172,6 +178,7 @@ public:
 
     //======== High-level photon life cycle =======
 
+public:
     /** This function returns the absorption opacity \f$k^\text{abs}=n\varsigma^\text{abs}\f$ for
         the given wavelength and material state. The photon properties are not used. */
     double opacityAbs(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
@@ -207,7 +214,7 @@ public:
         components, the relative opacity weighting factor applies not just to the luminosity but
         also to the other components of the Stokes vector. */
     void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
-                           Direction bfky, const MaterialState* state, PhotonPacket* pp) const override;
+                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state and the receiving

--- a/SKIRT/core/DustMix.hpp
+++ b/SKIRT/core/DustMix.hpp
@@ -445,7 +445,8 @@ private:
     // all data members are precalculated in setupSelfAfter()
 
     // wavelength grid (shifted to the left of the actually sampled points to approximate rounding)
-    Array _lambdav;  // indexed on ell
+    Array _lambdav;   // indexed on ell
+    Range _required;  // the required wavelength range, i.e. the range of _lambdav before it was shifted
 
     // scattering angle grid
     Array _thetav;  // indexed on t

--- a/SKIRT/core/DustMix.hpp
+++ b/SKIRT/core/DustMix.hpp
@@ -64,6 +64,12 @@ protected:
         scattering cross sections, the scattering asymmetry parameter, and/or the Mueller matrix
         coefficients as required by the implemented scattering mode.
 
+        If the simulation wavelength range extends beyond 10 cm, it is cut off at that value and
+        any dust cross sections beyond 10 cm are forced to zero. None of the currently provided
+        dust mixes offers optical properties beyond 10 cm, and historically any values outside the
+        supported range are clamped to the nearest available value. This leads to substantially
+        overestimated dust extinction in the radio wavelength range. Hence this "hack".
+
         Furthermore, if the simulation tracks the radiation field, this function precalculates the
         Planck-integrated absorption cross sections on an appropriate temperature grid. This
         information is used to obtain the equilibrium temperature of the material mix (or rather,

--- a/SKIRT/core/ElectronMix.cpp
+++ b/SKIRT/core/ElectronMix.cpp
@@ -92,7 +92,7 @@ double ElectronMix::opacityExt(double /*lambda*/, const MaterialState* state, co
 
 void ElectronMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& /*lambda*/, double w,
                                     Direction bfkobs, Direction bfky, const MaterialState* /*state*/,
-                                    PhotonPacket* pp) const
+                                    const PhotonPacket* pp) const
 {
     _dpf.peeloffScattering(I, Q, U, V, w, pp->direction(), bfkobs, bfky, pp);
 }

--- a/SKIRT/core/ElectronMix.hpp
+++ b/SKIRT/core/ElectronMix.hpp
@@ -107,7 +107,7 @@ public:
         with support for polarization depending on the user-configured \em includePolarization
         property. */
     void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
-                           Direction bfky, const MaterialState* state, PhotonPacket* pp) const override;
+                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state and the receiving

--- a/SKIRT/core/FragmentDustMixDecorator.cpp
+++ b/SKIRT/core/FragmentDustMixDecorator.cpp
@@ -206,7 +206,7 @@ double FragmentDustMixDecorator::opacityExt(double lambda, const MaterialState* 
 
 void FragmentDustMixDecorator::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w,
                                                  Direction bfkobs, Direction bfky, const MaterialState* state,
-                                                 PhotonPacket* pp) const
+                                                 const PhotonPacket* pp) const
 {
     // calculate the weights corresponding to the scattering opacities for each fragment and their sum
     Array wv(_numFrags);

--- a/SKIRT/core/FragmentDustMixDecorator.hpp
+++ b/SKIRT/core/FragmentDustMixDecorator.hpp
@@ -177,7 +177,7 @@ public:
         weight of each fragment's contribution is adjusted by the relative scattering opacity of
         the fragment. */
     void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
-                           Direction bfky, const MaterialState* state, PhotonPacket* pp) const override;
+                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state. Specifically, it

--- a/SKIRT/core/ImportedSource.cpp
+++ b/SKIRT/core/ImportedSource.cpp
@@ -36,6 +36,9 @@ void ImportedSource::setupSelfAfter()
     auto config = find<Configuration>();
     _oligochromatic = config->oligochromatic();
 
+    // warn the user if this source's intrinsic wavelength range does not fully cover the configured wavelength range
+    informAvailableWavelengthRange(_sedFamily->intrinsicWavelengthRange(), _sedFamily->type());
+
     // determine the wavelength range for this soource
     _wavelengthRange = config->sourceWavelengthRange();
     _wavelengthRange.intersect(_sedFamily->intrinsicWavelengthRange());

--- a/SKIRT/core/LyaNeutralHydrogenGasMix.cpp
+++ b/SKIRT/core/LyaNeutralHydrogenGasMix.cpp
@@ -127,14 +127,15 @@ double LyaNeutralHydrogenGasMix::opacityExt(double lambda, const MaterialState* 
 
 void LyaNeutralHydrogenGasMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w,
                                                  Direction bfkobs, Direction bfky, const MaterialState* state,
-                                                 PhotonPacket* pp) const
+                                                 const PhotonPacket* pp) const
 {
     // draw a random atom velocity & phase function, unless a previous peel-off stored this already
     if (!pp->hasLyaScatteringInfo())
     {
         double T = state->temperature();
         double nH = state->numberDensity();
-        pp->setLyaScatteringInfo(LyaUtils::sampleAtomVelocity(lambda, T, nH, pp->direction(), config(), random()));
+        const_cast<PhotonPacket*>(pp)->setLyaScatteringInfo(
+            LyaUtils::sampleAtomVelocity(lambda, T, nH, pp->direction(), config(), random()));
     }
 
     // add the contribution to the Stokes vector components depending on scattering type

--- a/SKIRT/core/LyaNeutralHydrogenGasMix.hpp
+++ b/SKIRT/core/LyaNeutralHydrogenGasMix.hpp
@@ -139,7 +139,7 @@ public:
         with support for polarization depending on the user-configured \em includePolarization
         property. */
     void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
-                           Direction bfky, const MaterialState* state, PhotonPacket* pp) const override;
+                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state and the receiving

--- a/SKIRT/core/MaterialMix.hpp
+++ b/SKIRT/core/MaterialMix.hpp
@@ -345,7 +345,7 @@ public:
         relative opacity weight for the current component is specified as argument \em w. */
     virtual void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w,
                                    Direction bfkobs, Direction bfky, const MaterialState* state,
-                                   PhotonPacket* pp) const = 0;
+                                   const PhotonPacket* pp) const = 0;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state and the receiving

--- a/SKIRT/core/NormalizedSource.cpp
+++ b/SKIRT/core/NormalizedSource.cpp
@@ -37,6 +37,16 @@ void NormalizedSource::setupSelfBefore()
 
 //////////////////////////////////////////////////////////////////////
 
+void NormalizedSource::setupSelfAfter()
+{
+    Source::setupSelfAfter();
+
+    // warn the user if this source's intrinsic wavelength range does not fully cover the configured wavelength range
+    informAvailableWavelengthRange(_sed->intrinsicWavelengthRange(), _sed->type());
+}
+
+//////////////////////////////////////////////////////////////////////
+
 Range NormalizedSource::wavelengthRange() const
 {
     return _sed->normalizationWavelengthRange();

--- a/SKIRT/core/NormalizedSource.hpp
+++ b/SKIRT/core/NormalizedSource.hpp
@@ -39,6 +39,10 @@ protected:
     /** This function caches some wavelength information. */
     void setupSelfBefore() override;
 
+    /** This function warns the user if this source's intrinsic wavelength range does not fully
+        cover the configured wavelength range. */
+    void setupSelfAfter() override;
+
     //======================== Other Functions =======================
 
 public:

--- a/SKIRT/core/SingleGrainDustMix.cpp
+++ b/SKIRT/core/SingleGrainDustMix.cpp
@@ -19,6 +19,9 @@ double SingleGrainDustMix::getOpticalProperties(const Array& lambdav, const Arra
     StoredTable<1> sigmasca(this, opticalPropsName, "lambda(m)", "sigmasca(m2/H)");
     StoredTable<1> asymmpar(this, opticalPropsName, "lambda(m)", "g(1)");
 
+    // log warning if the simulation wavelength range extends beyond the optical property range
+    informAvailableWavelengthRange(sigmaabs.axisRange<0>());
+
     // retrieve the optical properties on the requested wavelength grid
     int numLambda = lambdav.size();
     for (int ell = 0; ell != numLambda; ++ell)

--- a/SKIRT/core/Source.cpp
+++ b/SKIRT/core/Source.cpp
@@ -4,7 +4,11 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "Source.hpp"
+#include "Configuration.hpp"
+#include "Log.hpp"
 #include "Random.hpp"
+#include "StringUtils.hpp"
+#include "Units.hpp"
 
 //////////////////////////////////////////////////////////////////////
 
@@ -13,6 +17,26 @@ void Source::setupSelfBefore()
     SimulationItem::setupSelfBefore();
 
     _random = find<Random>();
+}
+
+//////////////////////////////////////////////////////////////////////
+
+void Source::informAvailableWavelengthRange(Range available, string itemType)
+{
+    auto configured = find<Configuration>()->sourceWavelengthRange();
+    const double fuzzy = 0.01;  // 1%
+    if (!available.containsFuzzy(configured.min(), fuzzy) || !available.containsFuzzy(configured.max(), fuzzy))
+    {
+        auto units = find<Units>();
+        auto outstring = [units](double wavelength) {
+            return StringUtils::toString(units->owavelength(wavelength), 'g', 3) + " " + units->uwavelength();
+        };
+
+        auto log = find<Log>();
+        log->warning(itemType + " available spectrum does not fully cover the configured source wavelength range");
+        log->warning("  Configured: " + outstring(configured.min()) + " - " + outstring(configured.max()));
+        log->warning("  Available: " + outstring(available.min()) + " - " + outstring(available.max()));
+    }
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/Source.hpp
+++ b/SKIRT/core/Source.hpp
@@ -86,6 +86,11 @@ protected:
     /** This function caches the simulation's random generator for use by subclasses. */
     void setupSelfBefore() override;
 
+    /** This function logs a warning message if the given range is smaller than the configured
+        source wavelength range. The second argument specifies the type of the simulation item to
+        be included in the message. This function can be called from subclasses. */
+    void informAvailableWavelengthRange(Range available, string itemType);
+
     //======================== Other Functions =======================
 
 public:


### PR DESCRIPTION
**Log messages**

With this update SKIRT issues a warning to the simulation log in the following cases:
- The wavelength range of an SED or SED family does not fully cover the wavelength range configured for the source system (so that the specific luminosity will be zero outside the supported range).
- The optical properties for a dust mix are not available for all wavelengths (potentially) used in the simulation. The values outside of the supported wavelength range are clamped to the nearest available value (except in radio range; see next section).

These extra log messages help the user discover/understand limitations that might otherwise go unnoticed. For example:
- The spectrum for the Bruzual-Charlot SED family "ends" at 160 micron. While this is not a problem for regular applications, in some test simulations it might produce a strange kink in the output spectrum.
- Recent dust mixes tabulate the optical properties up to 10 cm (e.g., all dust mixes based on DustEM tables, including DrainLi and THEMIS), but many older dust mixes have an upper limit of only 1 mm (e.g., the tables supplied by Draine and Min). This means that dust extinction should not be trusted at those longer wavelengths. Again, this is not a problem for most applications.

**Dust properties at radio wavelengths**

If the simulation wavelength range extends beyond 10 cm, any dust cross sections beyond this wavelength are now forced to zero. None of the currently provided dust mixes offers optical properties beyond 10 cm, and historically any values outside the supported range are clamped to the nearest available value. This would lead to substantially overestimated dust extinction in the radio wavelength range. This "hack" avoids this issue.

For reasons of upwards compatibility, with dust mixes that support a shorter wavelength range, the cross sections between the supported upper wavelength limit and 10 cm are still clamped to the nearest available value (i.e. the value at the supported upper wavelength limit).

**Tests**
All functional tests still run.
