### PR TITLE
Compton scattering and thermal velocity dispersion for electrons

### DIFF
--- a/SKIRT/core/ComptonPhaseFunction.cpp
+++ b/SKIRT/core/ComptonPhaseFunction.cpp
@@ -4,7 +4,22 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "ComptonPhaseFunction.hpp"
+#include "Constants.hpp"
 #include "Random.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // returns the photon energy scaled to the electron rest energy: h nu / m_e c^2
+    double scaledEnergy(double lambda) { return (Constants::h() / Constants::Melectron() / Constants::c()) / lambda; }
+
+    // returns the inverse Compton factor for a given scaled energy and scattering angle cosine
+    double inverseComptonfactor(double x, double costheta) { return 1 + x * (1 - costheta); }
+
+    // returns the Compton factor for a given scaled energy and scattering angle cosine
+    ///double straightComptonfactor(double x, double costheta) { return 1. / inverseComptonfactor(x, costheta); }
+}
 
 ////////////////////////////////////////////////////////////////////
 
@@ -16,21 +31,26 @@ void ComptonPhaseFunction::initialize(Random* random)
 
 ////////////////////////////////////////////////////////////////////
 
-double ComptonPhaseFunction::sectionSca(double /*lambda*/) const
+double ComptonPhaseFunction::sectionSca(double lambda) const
 {
-    return 1.;
+    double x = scaledEnergy(lambda);
+    double x2 = x * x;
+    double x3 = x2 * x;
+    double x1 = 1. + x;
+    double x12 = 1. + 2. * x;
+    return 0.75 * (x1 / (x12 * x12) + 2. / x2 + (1. / (2. * x) - x1 / x3) * log(x12));
 }
 
 ////////////////////////////////////////////////////////////////////
 
-double ComptonPhaseFunction::phaseFunctionValueForCosine(double costheta) const
+double ComptonPhaseFunction::phaseFunctionValueForCosine(double /*x*/, double costheta) const
 {
     return 0.75 * (costheta * costheta + 1.);
 }
 
 ////////////////////////////////////////////////////////////////////
 
-double ComptonPhaseFunction::generateCosineFromPhaseFunction() const
+double ComptonPhaseFunction::generateCosineFromPhaseFunction(double /*x*/) const
 {
     double X = _random->uniform();
     double p = cbrt(4. * X - 2. + sqrt(16. * X * (X - 1.) + 5.));
@@ -39,23 +59,32 @@ double ComptonPhaseFunction::generateCosineFromPhaseFunction() const
 
 ////////////////////////////////////////////////////////////////////
 
-void ComptonPhaseFunction::peeloffScattering(double& I, double& /*lambda*/, double w, Direction bfk,
-                                             Direction bfkobs) const
+void ComptonPhaseFunction::peeloffScattering(double& I, double& lambda, double w, Direction bfk, Direction bfkobs) const
 {
-    // calculate the value of the material-specific phase function
+    double x = scaledEnergy(lambda);
+
+    // calculate the value of the phase function
     double costheta = Vec::dot(bfk, bfkobs);
-    double value = phaseFunctionValueForCosine(costheta);
+    double value = phaseFunctionValueForCosine(x, costheta);
 
     // accumulate the weighted sum in the intensity
     I += w * value;
+
+    // adjust the wavelength
+    lambda *= inverseComptonfactor(x, costheta);
 }
 
 ////////////////////////////////////////////////////////////////////
 
-Direction ComptonPhaseFunction::performScattering(double& /*lambda*/, Direction bfk) const
+Direction ComptonPhaseFunction::performScattering(double& lambda, Direction bfk) const
 {
-    // sample a scattering angle from the dipole phase function
-    double costheta = generateCosineFromPhaseFunction();
+    double x = scaledEnergy(lambda);
+
+    // sample a scattering angle from the phase function
+    double costheta = generateCosineFromPhaseFunction(x);
+
+    // adjust the wavelength
+    lambda *= inverseComptonfactor(x, costheta);
 
     // determine the new propagation direction
     return _random->direction(bfk, costheta);

--- a/SKIRT/core/ComptonPhaseFunction.cpp
+++ b/SKIRT/core/ComptonPhaseFunction.cpp
@@ -1,0 +1,64 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "ComptonPhaseFunction.hpp"
+#include "Random.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void ComptonPhaseFunction::initialize(Random* random)
+{
+    // cache random number generator
+    _random = random;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double ComptonPhaseFunction::sectionSca(double /*lambda*/) const
+{
+    return 1.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double ComptonPhaseFunction::phaseFunctionValueForCosine(double costheta) const
+{
+    return 0.75 * (costheta * costheta + 1.);
+}
+
+////////////////////////////////////////////////////////////////////
+
+double ComptonPhaseFunction::generateCosineFromPhaseFunction() const
+{
+    double X = _random->uniform();
+    double p = cbrt(4. * X - 2. + sqrt(16. * X * (X - 1.) + 5.));
+    return p - 1. / p;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void ComptonPhaseFunction::peeloffScattering(double& I, double& /*lambda*/, double w, Direction bfk,
+                                             Direction bfkobs) const
+{
+    // calculate the value of the material-specific phase function
+    double costheta = Vec::dot(bfk, bfkobs);
+    double value = phaseFunctionValueForCosine(costheta);
+
+    // accumulate the weighted sum in the intensity
+    I += w * value;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Direction ComptonPhaseFunction::performScattering(double& /*lambda*/, Direction bfk) const
+{
+    // sample a scattering angle from the dipole phase function
+    double costheta = generateCosineFromPhaseFunction();
+
+    // determine the new propagation direction
+    return _random->direction(bfk, costheta);
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ComptonPhaseFunction.cpp
+++ b/SKIRT/core/ComptonPhaseFunction.cpp
@@ -5,20 +5,36 @@
 
 #include "ComptonPhaseFunction.hpp"
 #include "Constants.hpp"
+#include "NR.hpp"
 #include "Random.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
 namespace
 {
+    // discretization of the phase function over scattering angle: theta from 0 to pi, index t
+    constexpr int numTheta = 361;
+    constexpr int maxTheta = numTheta - 1;
+    constexpr double deltaTheta = M_PI / maxTheta;
+
     // returns the photon energy scaled to the electron rest energy: h nu / m_e c^2
     double scaledEnergy(double lambda) { return (Constants::h() / Constants::Melectron() / Constants::c()) / lambda; }
+
+    // returns the Compton scattering cross section for a given scaled energy
+    double comptonSection(double x)
+    {
+        double x2 = x * x;
+        double x3 = x2 * x;
+        double x1 = 1. + x;
+        double x12 = 1. + 2. * x;
+        return 0.75 * (x1 / (x12 * x12) + 2. / x2 + (1. / (2. * x) - x1 / x3) * log(x12));
+    }
 
     // returns the inverse Compton factor for a given scaled energy and scattering angle cosine
     double inverseComptonfactor(double x, double costheta) { return 1 + x * (1 - costheta); }
 
     // returns the Compton factor for a given scaled energy and scattering angle cosine
-    ///double straightComptonfactor(double x, double costheta) { return 1. / inverseComptonfactor(x, costheta); }
+    double comptonFactor(double x, double costheta) { return 1. / inverseComptonfactor(x, costheta); }
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -27,6 +43,19 @@ void ComptonPhaseFunction::initialize(Random* random)
 {
     // cache random number generator
     _random = random;
+
+    // construct a theta grid and precalculate values used in generateCosineFromPhaseFunction()
+    // to accelerate construction of the cumulative phase function distribution
+    _costhetav.resize(numTheta);
+    _sinthetav.resize(numTheta);
+    _sin2thetav.resize(numTheta);
+    for (int t = 0; t != numTheta; ++t)
+    {
+        double theta = t * deltaTheta;
+        _costhetav[t] = cos(theta);
+        _sinthetav[t] = sin(theta);
+        _sin2thetav[t] = _sinthetav[t] * _sinthetav[t];
+    }
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -34,27 +63,34 @@ void ComptonPhaseFunction::initialize(Random* random)
 double ComptonPhaseFunction::sectionSca(double lambda) const
 {
     double x = scaledEnergy(lambda);
-    double x2 = x * x;
-    double x3 = x2 * x;
-    double x1 = 1. + x;
-    double x12 = 1. + 2. * x;
-    return 0.75 * (x1 / (x12 * x12) + 2. / x2 + (1. / (2. * x) - x1 / x3) * log(x12));
+    return comptonSection(x);
 }
 
 ////////////////////////////////////////////////////////////////////
 
-double ComptonPhaseFunction::phaseFunctionValueForCosine(double /*x*/, double costheta) const
+double ComptonPhaseFunction::phaseFunctionValueForCosine(double x, double costheta) const
 {
-    return 0.75 * (costheta * costheta + 1.);
+    double C = comptonFactor(x, costheta);
+    double sin2theta = (1 - costheta) * (1 + costheta);
+    double phase = C * C * C + C - C * C * sin2theta;
+    return 0.75 / comptonSection(x) * phase;
 }
 
 ////////////////////////////////////////////////////////////////////
 
-double ComptonPhaseFunction::generateCosineFromPhaseFunction(double /*x*/) const
+double ComptonPhaseFunction::generateCosineFromPhaseFunction(double x) const
 {
-    double X = _random->uniform();
-    double p = cbrt(4. * X - 2. + sqrt(16. * X * (X - 1.) + 5.));
-    return p - 1. / p;
+    // construct the normalized cumulative phase function distribution for this x
+    Array thetaXv;
+    NR::cdf(thetaXv, maxTheta, [this, x](int t) {
+        t += 1;
+        double C = comptonFactor(x, _costhetav[t]);
+        double phase = C * C * C + C - C * C * _sin2thetav[t];
+        return phase * _sinthetav[t];
+    });
+
+    // draw a random cosine from this distribution
+    return _random->cdfLinLin(_costhetav, thetaXv);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ComptonPhaseFunction.hpp
+++ b/SKIRT/core/ComptonPhaseFunction.hpp
@@ -12,8 +12,26 @@ class Random;
 
 ////////////////////////////////////////////////////////////////////
 
-/** The ComptonPhaseFunction helper class represents the Compton scattering process. The current
-    implementation does not support polarization. */
+/** The ComptonPhaseFunction helper class represents Compton scattering of photons by free
+    electrons. The current implementation does not support polarization.
+
+    Compton scattering forms the extension of Thomson scattering into the high-photon-energy
+    domain. The scattering event is elastic (i.e. the photon wavelength is changed by the
+    interaction) and its cross section and phase function depend on the wavelength of the incoming
+    photon. Compared to Thomson scattering, the total cross section is reduced at higher energies.
+    With \f$x = (h\nu)/(m_e c^2)\f$ the incoming photon energy scaled to the electron rest energy,
+    the ratio of the total Compton scattering cross section \f$\sigma_\mathrm{C}(x)\f$ over the
+    (constant) total Thomson cross section \f$\sigma_\mathrm{T}\f$ is given by:
+
+    \f[ \frac{\sigma_\mathrm{C}(x)}{\sigma_\mathrm{T}} = \frac{3}{4} \bigg( \frac{1+x}{(1+2x)^2} +
+    \frac{2}{x^2} + \Big(\frac{1}{2x}-\frac{1+x}{x^3}\Big) \cdot \ln(1+2x) \bigg). \f]
+
+    For an interaction with incoming photon energy \f$x\f$ and scattering angle \f$\theta\f$, the
+    energy change \f$E_\mathrm{out}/E_\mathrm{in}\f$ is given by the Compton factor \f$C(x, \theta)
+    = \big(1+x(1-\cos \theta)\big)^{-1}\f$. Equivalently, the wavelength change is given by
+    \f$\lambda_\mathrm{out} / \lambda_\mathrm{in} = \big(1+x(1-\cos \theta)\big)\f$.
+
+    */
 class ComptonPhaseFunction
 {
     //============= Construction - Setup - Destruction =============
@@ -33,14 +51,15 @@ public:
     //======== Scattering =======
 
 private:
-    /** This function returns the value of the scattering phase function \f$\Phi(\cos\theta)\f$ for
-        the specified scattering angle cosine \f$\cos\theta\f$, where the phase function is
-        normalized as \f[\int_{-1}^1 \Phi(\cos\theta) \,\mathrm{d}\cos\theta =2.\f] */
-    double phaseFunctionValueForCosine(double costheta) const;
+    /** This function returns the value of the scattering phase function \f$\Phi(x, \cos\theta)\f$
+        for the specified incoming photon energy \f$x\f$ and scattering angle cosine
+        \f$\cos\theta\f$, where the phase function is normalized for all \f$x\f$ as \f[\int_{-1}^1
+        \Phi(x, \cos\theta) \,\mathrm{d}\cos\theta =2.\f] */
+    double phaseFunctionValueForCosine(double x, double costheta) const;
 
     /** This function generates a random scattering angle cosine sampled from the phase function
-        \f$\Phi(\cos\theta)\f$. */
-    double generateCosineFromPhaseFunction() const;
+        \f$\Phi(x, \cos\theta)\f$ for the specified incoming photon energy \f$x\f$. */
+    double generateCosineFromPhaseFunction(double x) const;
 
 public:
     /** This function calculates the contribution of a Compton scattering event to the peel-off

--- a/SKIRT/core/ComptonPhaseFunction.hpp
+++ b/SKIRT/core/ComptonPhaseFunction.hpp
@@ -1,0 +1,72 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef COMPTONPHASEFUNCTION
+#define COMPTONPHASEFUNCTION
+
+#include "Array.hpp"
+#include "Direction.hpp"
+class Random;
+
+////////////////////////////////////////////////////////////////////
+
+/** The ComptonPhaseFunction helper class represents the Compton scattering process. The current
+    implementation does not support polarization. */
+class ComptonPhaseFunction
+{
+    //============= Construction - Setup - Destruction =============
+
+public:
+    /** This function caches a pointer to the simulation's random number generator and
+        pre-calculates some data used for sampling from the relevant phase function. The function
+        must be called during setup (i.e. in single-thread mode). */
+    void initialize(Random* random);
+
+    //======== Absorption =======
+
+    /** This function calculates and returns the Compton scattering cross section for the given
+        wavelength, normalized to the (constant) Thomson cross section. */
+    double sectionSca(double lambda) const;
+
+    //======== Scattering =======
+
+private:
+    /** This function returns the value of the scattering phase function \f$\Phi(\cos\theta)\f$ for
+        the specified scattering angle cosine \f$\cos\theta\f$, where the phase function is
+        normalized as \f[\int_{-1}^1 \Phi(\cos\theta) \,\mathrm{d}\cos\theta =2.\f] */
+    double phaseFunctionValueForCosine(double costheta) const;
+
+    /** This function generates a random scattering angle cosine sampled from the phase function
+        \f$\Phi(\cos\theta)\f$. */
+    double generateCosineFromPhaseFunction() const;
+
+public:
+    /** This function calculates the contribution of a Compton scattering event to the peel-off
+        photon luminosity for the given geometry and wavelength, and determines the adjusted
+        wavelength of the outgoing photon packet. The luminosity contribution is added to the
+        incoming value of the \em I argument, and the adjusted wavelength is stored in the \em
+        lambda argument. The \em w argument specifies the relative opacity weighting factor for
+        this medium component. See the description of the MaterialMix::peeloffScattering() function
+        for more information. */
+    void peeloffScattering(double& I, double& lambda, double w, Direction bfk, Direction bfkobs) const;
+
+    /** Given the incoming photon packet wavelength and direction this function calculates a
+        randomly sampled new propagation direction for a Compton scattering event, and determines
+        the adjusted wavelength of the outgoing photon packet. The adjusted wavelength is stored in
+        the \em lambda argument, and the direction is returned. */
+    Direction performScattering(double& lambda, Direction bfk) const;
+
+    //======================== Data Members ========================
+
+private:
+    // the simulation's random number generator - initialized during construction
+    Random* _random{nullptr};
+
+    // precalculated discretizations - initialized during construction
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/ComptonPhaseFunction.hpp
+++ b/SKIRT/core/ComptonPhaseFunction.hpp
@@ -31,6 +31,15 @@ class Random;
     = \big(1+x(1-\cos \theta)\big)^{-1}\f$. Equivalently, the wavelength change is given by
     \f$\lambda_\mathrm{out} / \lambda_\mathrm{in} = \big(1+x(1-\cos \theta)\big)\f$.
 
+    The normalized phase function for an interaction with incoming photon energy \f$x\f$ is given
+    by:
+
+    \f[ \Phi(x, \theta) = \frac{\sigma_\mathrm{T}}{\sigma_\mathrm{C}(x)} \, \frac{3}{4}
+    \left[ C^3(x, \theta) + C(x, \theta) -C^2(x, \theta)\sin^2\theta \right], \f]
+
+    where \f$\theta\f$ is the scattering angle and \f$C(x, \theta)\f$ is the Compton factor defined
+    earlier.
+
     */
 class ComptonPhaseFunction
 {
@@ -80,10 +89,13 @@ public:
     //======================== Data Members ========================
 
 private:
-    // the simulation's random number generator - initialized during construction
+    // the simulation's random number generator - initialized by initialize()
     Random* _random{nullptr};
 
-    // precalculated discretizations - initialized during construction
+    // precalculated discretizations - initialized by initialize()
+    Array _costhetav;
+    Array _sinthetav;
+    Array _sin2thetav;
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/Configuration.cpp
+++ b/SKIRT/core/Configuration.cpp
@@ -320,8 +320,16 @@ void Configuration::setupSelfAfter()
     if (_hasPolarization) log->info("  Including support for polarization");
     if (_hasMovingMedia) log->info("  Including support for kinematics");
 
+    // check for scattering dispersion
+    bool hasDispersion = false;
+    if (_hasMedium)
+    {
+        for (auto medium : find<MediumSystem>(false)->media())
+            if (medium->mix()->hasScatteringDispersion()) hasDispersion = true;
+    }
+
     // disable path length stretching if the wavelength of a photon packet can change during its lifetime
-    if ((_hasMovingMedia || _hubbleExpansionRate || _hasLymanAlpha) && _pathLengthBias > 0.)
+    if ((_hasMovingMedia || hasDispersion || _hubbleExpansionRate || _hasLymanAlpha) && _pathLengthBias > 0.)
     {
         log->warning("  Disabling path length stretching to allow Doppler shifts to be properly sampled");
         _pathLengthBias = 0.;

--- a/SKIRT/core/ElectronMix.cpp
+++ b/SKIRT/core/ElectronMix.cpp
@@ -60,6 +60,25 @@ bool ElectronMix::hasPolarizedScattering() const
 
 ////////////////////////////////////////////////////////////////////
 
+bool ElectronMix::hasScatteringDispersion() const
+{
+    // this function may be called before setup() has been invoked, so we need to figure out the result ourselves
+
+    // determine whether velocity dispersion is enabled
+    bool hasDispersion = includeThermalDispersion() && !find<Configuration>()->oligochromatic();
+
+    // determine whether we need Compton scattering because the simulation may have short wavelengths
+    if (!hasDispersion && !includePolarization())
+    {
+        auto range = find<Configuration>()->simulationWavelengthRange();
+        hasDispersion = range.min() < comptonWL;
+    }
+
+    return hasDispersion;
+}
+
+////////////////////////////////////////////////////////////////////
+
 vector<StateVariable> ElectronMix::specificStateVariableInfo() const
 {
     vector<StateVariable> result{StateVariable::numberDensity()};

--- a/SKIRT/core/ElectronMix.cpp
+++ b/SKIRT/core/ElectronMix.cpp
@@ -4,10 +4,20 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "ElectronMix.hpp"
+#include "Configuration.hpp"
 #include "Constants.hpp"
+#include "Log.hpp"
 #include "MaterialState.hpp"
 #include "PhotonPacket.hpp"
 #include "Random.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // transition wavelength from Compton to Thomson scattering
+    const double comptonWL = 10e-9;  // 10 nm
+}
 
 ////////////////////////////////////////////////////////////////////
 
@@ -15,7 +25,20 @@ void ElectronMix::setupSelfBefore()
 {
     MaterialMix::setupSelfBefore();
 
+    // determine whether we need Compton scattering because the simulation may have short wavelengths
+    auto range = find<Configuration>()->simulationWavelengthRange();
+    _hasCompton = range.min() < comptonWL;
+
+    // disable Compton scattering if polarization is requested
+    if (_hasCompton && includePolarization())
+    {
+        _hasCompton = false;
+        find<Log>()->warning("Compton scattering disabled because the implementation does not support polarization");
+    }
+
+    // initialize our phase function helpers
     _dpf.initialize(random(), includePolarization());
+    if (_hasCompton) _cpf.initialize(random());
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -55,16 +78,18 @@ double ElectronMix::sectionAbs(double /*lambda*/) const
 
 ////////////////////////////////////////////////////////////////////
 
-double ElectronMix::sectionSca(double /*lambda*/) const
+double ElectronMix::sectionSca(double lambda) const
 {
-    return Constants::sigmaThomson();
+    double sigma = Constants::sigmaThomson();
+    if (_hasCompton && lambda < comptonWL) sigma *= _cpf.sectionSca(lambda);
+    return sigma;
 }
 
 ////////////////////////////////////////////////////////////////////
 
-double ElectronMix::sectionExt(double /*lambda*/) const
+double ElectronMix::sectionExt(double lambda) const
 {
-    return Constants::sigmaThomson();
+    return sectionSca(lambda);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -76,33 +101,38 @@ double ElectronMix::opacityAbs(double /*lambda*/, const MaterialState* /*state*/
 
 ////////////////////////////////////////////////////////////////////
 
-double ElectronMix::opacitySca(double /*lambda*/, const MaterialState* state, const PhotonPacket* /*pp*/) const
+double ElectronMix::opacitySca(double lambda, const MaterialState* state, const PhotonPacket* /*pp*/) const
 {
-    return state->numberDensity() * Constants::sigmaThomson();
+    return state->numberDensity() * sectionSca(lambda);
 }
 
 ////////////////////////////////////////////////////////////////////
 
-double ElectronMix::opacityExt(double /*lambda*/, const MaterialState* state, const PhotonPacket* /*pp*/) const
+double ElectronMix::opacityExt(double lambda, const MaterialState* state, const PhotonPacket* /*pp*/) const
 {
-    return state->numberDensity() * Constants::sigmaThomson();
+    return state->numberDensity() * sectionSca(lambda);
 }
 
 ////////////////////////////////////////////////////////////////////
 
-void ElectronMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& /*lambda*/, double w,
+void ElectronMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w,
                                     Direction bfkobs, Direction bfky, const MaterialState* /*state*/,
                                     const PhotonPacket* pp) const
 {
-    _dpf.peeloffScattering(I, Q, U, V, w, pp->direction(), bfkobs, bfky, pp);
+    if (_hasCompton && lambda < comptonWL)
+        _cpf.peeloffScattering(I, lambda, w, pp->direction(), bfkobs);
+    else
+        _dpf.peeloffScattering(I, Q, U, V, w, pp->direction(), bfkobs, bfky, pp);
 }
 
 ////////////////////////////////////////////////////////////////////
 
 void ElectronMix::performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const
 {
-    // determine the new propagation direction, and if required, update the polarization state of the photon packet
-    Direction bfknew = _dpf.performScattering(pp->direction(), pp);
+    // determine the new propagation direction, and if required,
+    // update the wavelength or the polarization state of the photon packet
+    Direction bfknew = (_hasCompton && lambda < comptonWL) ? _cpf.performScattering(lambda, pp->direction())
+                                                           : _dpf.performScattering(pp->direction(), pp);
 
     // execute the scattering event in the photon packet
     pp->scatter(bfknew, state->bulkVelocity(), lambda);

--- a/SKIRT/core/ElectronMix.hpp
+++ b/SKIRT/core/ElectronMix.hpp
@@ -94,6 +94,13 @@ public:
         material mix supports polarization during scattering events or not. */
     bool hasPolarizedScattering() const override;
 
+    /** This function returns true when thermal dispersion is enabled and/or support for Compton
+        scattering has been turned on (based on the simulation's wavelength range), indicating that
+        in those cases a scattering interaction for the electron mix may (and usually does) adjust
+        the wavelength of the interacting photon packet. If both thermal dispersion and support for
+        Compton scattering are disabled, the function returns false. */
+    bool hasScatteringDispersion() const override;
+
     //======== Medium state setup =======
 
 public:

--- a/SKIRT/core/ElectronMix.hpp
+++ b/SKIRT/core/ElectronMix.hpp
@@ -69,8 +69,8 @@ class ElectronMix : public MaterialMix
 
         PROPERTY_DOUBLE(defaultTemperature, "the default temperature of the electron population")
         ATTRIBUTE_QUANTITY(defaultTemperature, "temperature")
-        ATTRIBUTE_MIN_VALUE(defaultTemperature, "[3")  // temperature must be above local Universe T_CMB
-        ATTRIBUTE_MAX_VALUE(defaultTemperature, "1e10]")
+        ATTRIBUTE_MIN_VALUE(defaultTemperature, "[3")    // temperature must be above local Universe T_CMB
+        ATTRIBUTE_MAX_VALUE(defaultTemperature, "1e8]")  // higher temperatures cause relativistic dispersion
         ATTRIBUTE_DEFAULT_VALUE(defaultTemperature, "1e4")
         ATTRIBUTE_RELEVANT_IF(defaultTemperature, "Panchromatic&includeDispersion")
         ATTRIBUTE_DISPLAYED_IF(defaultTemperature, "Level2")

--- a/SKIRT/core/ElectronMix.hpp
+++ b/SKIRT/core/ElectronMix.hpp
@@ -70,7 +70,7 @@ class ElectronMix : public MaterialMix
         PROPERTY_DOUBLE(defaultTemperature, "the default temperature of the electron population")
         ATTRIBUTE_QUANTITY(defaultTemperature, "temperature")
         ATTRIBUTE_MIN_VALUE(defaultTemperature, "[3")  // temperature must be above local Universe T_CMB
-        ATTRIBUTE_MAX_VALUE(defaultTemperature, "1e6]")
+        ATTRIBUTE_MAX_VALUE(defaultTemperature, "1e10]")
         ATTRIBUTE_DEFAULT_VALUE(defaultTemperature, "1e4")
         ATTRIBUTE_RELEVANT_IF(defaultTemperature, "Panchromatic&includeDispersion")
         ATTRIBUTE_DISPLAYED_IF(defaultTemperature, "Level2")

--- a/SKIRT/core/LyaNeutralHydrogenGasMix.cpp
+++ b/SKIRT/core/LyaNeutralHydrogenGasMix.cpp
@@ -130,16 +130,16 @@ void LyaNeutralHydrogenGasMix::peeloffScattering(double& I, double& Q, double& U
                                                  const PhotonPacket* pp) const
 {
     // draw a random atom velocity & phase function, unless a previous peel-off stored this already
-    if (!pp->hasLyaScatteringInfo())
+    if (!pp->hasScatteringInfo())
     {
         double T = state->temperature();
         double nH = state->numberDensity();
-        const_cast<PhotonPacket*>(pp)->setLyaScatteringInfo(
+        const_cast<PhotonPacket*>(pp)->setScatteringInfo(
             LyaUtils::sampleAtomVelocity(lambda, T, nH, pp->direction(), config(), random()));
     }
 
     // add the contribution to the Stokes vector components depending on scattering type
-    if (pp->lyaDipole())
+    if (pp->dipole())
     {
         // contribution of dipole scattering with or without polarization
         _dpf.peeloffScattering(I, Q, U, V, w, pp->direction(), bfkobs, bfky, pp);
@@ -154,7 +154,7 @@ void LyaNeutralHydrogenGasMix::peeloffScattering(double& I, double& Q, double& U
     // for a random fraction of the events governed by the relative Lya contribution,
     // Doppler-shift the photon packet wavelength into and out of the atom frame
     if (random()->uniform() <= w)
-        lambda = LyaUtils::shiftWavelength(lambda, pp->lyaAtomVelocity(), pp->direction(), bfkobs);
+        lambda = LyaUtils::shiftWavelength(lambda, pp->particleVelocity(), pp->direction(), bfkobs);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -162,17 +162,17 @@ void LyaNeutralHydrogenGasMix::peeloffScattering(double& I, double& Q, double& U
 void LyaNeutralHydrogenGasMix::performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const
 {
     // draw a random atom velocity & phase function, unless a peel-off stored this already
-    if (!pp->hasLyaScatteringInfo())
+    if (!pp->hasScatteringInfo())
     {
         double T = state->temperature();
         double nH = state->numberDensity();
-        pp->setLyaScatteringInfo(LyaUtils::sampleAtomVelocity(lambda, T, nH, pp->direction(), config(), random()));
+        pp->setScatteringInfo(LyaUtils::sampleAtomVelocity(lambda, T, nH, pp->direction(), config(), random()));
     }
 
     // draw the outgoing direction from the dipole or the isotropic phase function
     // and, if required, update the polarization state of the photon packet
     Direction bfknew;
-    if (pp->lyaDipole())
+    if (pp->dipole())
     {
         bfknew = _dpf.performScattering(pp->direction(), pp);
     }
@@ -183,7 +183,7 @@ void LyaNeutralHydrogenGasMix::performScattering(double lambda, const MaterialSt
     }
 
     // Doppler-shift the photon packet wavelength into and out of the atom frame
-    lambda = LyaUtils::shiftWavelength(lambda, pp->lyaAtomVelocity(), pp->direction(), bfknew);
+    lambda = LyaUtils::shiftWavelength(lambda, pp->particleVelocity(), pp->direction(), bfknew);
 
     // execute the scattering event in the photon packet
     pp->scatter(bfknew, state->bulkVelocity(), lambda);

--- a/SKIRT/core/LyaNeutralHydrogenGasMix.cpp
+++ b/SKIRT/core/LyaNeutralHydrogenGasMix.cpp
@@ -50,6 +50,13 @@ bool LyaNeutralHydrogenGasMix::hasExtraSpecificState() const
 
 ////////////////////////////////////////////////////////////////////
 
+bool LyaNeutralHydrogenGasMix::hasScatteringDispersion() const
+{
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////
+
 vector<StateVariable> LyaNeutralHydrogenGasMix::specificStateVariableInfo() const
 {
     return vector<StateVariable>{StateVariable::numberDensity(), StateVariable::temperature()};

--- a/SKIRT/core/LyaNeutralHydrogenGasMix.hpp
+++ b/SKIRT/core/LyaNeutralHydrogenGasMix.hpp
@@ -38,7 +38,7 @@ class LyaNeutralHydrogenGasMix : public MaterialMix
         PROPERTY_DOUBLE(defaultTemperature, "the default temperature of the neutral hydrogen gas")
         ATTRIBUTE_QUANTITY(defaultTemperature, "temperature")
         ATTRIBUTE_MIN_VALUE(defaultTemperature, "[3")  // gas temperature must be above local Universe T_CMB
-        ATTRIBUTE_MAX_VALUE(defaultTemperature, "1e6]")
+        ATTRIBUTE_MAX_VALUE(defaultTemperature, "1e9]")
         ATTRIBUTE_DEFAULT_VALUE(defaultTemperature, "1e4")
         ATTRIBUTE_DISPLAYED_IF(defaultTemperature, "Level2")
 

--- a/SKIRT/core/LyaNeutralHydrogenGasMix.hpp
+++ b/SKIRT/core/LyaNeutralHydrogenGasMix.hpp
@@ -73,6 +73,10 @@ public:
         case the temperature. */
     bool hasExtraSpecificState() const override;
 
+    /** This function returns true, indicating that a scattering interaction for this material mix
+        may (and usually does) adjust the wavelength of the interacting photon packet. */
+    bool hasScatteringDispersion() const override;
+
     //======== Medium state setup =======
 
 public:

--- a/SKIRT/core/MaterialMix.cpp
+++ b/SKIRT/core/MaterialMix.cpp
@@ -62,6 +62,13 @@ bool MaterialMix::hasExtraSpecificState() const
 
 ////////////////////////////////////////////////////////////////////
 
+bool MaterialMix::hasScatteringDispersion() const
+{
+    return false;
+}
+
+////////////////////////////////////////////////////////////////////
+
 vector<SnapshotParameter> MaterialMix::parameterInfo() const
 {
     return vector<SnapshotParameter>();

--- a/SKIRT/core/MaterialMix.hpp
+++ b/SKIRT/core/MaterialMix.hpp
@@ -243,6 +243,11 @@ public:
         otherwise. The default implementation in this base class returns false. */
     virtual bool hasExtraSpecificState() const;
 
+    /** This function returns true if a scattering interaction for this material mix may adjust the
+        wavelength of the interacting photon packet, and false otherwise. The default
+        implementation in this base class returns false. */
+    virtual bool hasScatteringDispersion() const;
+
     //======== Medium state setup =======
 
     /** This function returns the number and type of import parameters required by this particular

--- a/SKIRT/core/RangeWavelengthDistribution.hpp
+++ b/SKIRT/core/RangeWavelengthDistribution.hpp
@@ -29,7 +29,7 @@ class RangeWavelengthDistribution : public WavelengthDistribution
         ATTRIBUTE_QUANTITY(minWavelength, "wavelength")
         ATTRIBUTE_MIN_VALUE(minWavelength, "1 pm")
         ATTRIBUTE_MAX_VALUE(minWavelength, "1 m")
-        ATTRIBUTE_DEFAULT_VALUE(minWavelength, "1 Angstrom")
+        ATTRIBUTE_DEFAULT_VALUE(minWavelength, "1 pm")
 
         PROPERTY_DOUBLE(maxWavelength, "the longest wavelength of the wavelength probability distribution")
         ATTRIBUTE_QUANTITY(maxWavelength, "wavelength")

--- a/SKIRT/core/SpinFlipHydrogenGasMix.hpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.hpp
@@ -33,7 +33,7 @@ class SpinFlipHydrogenGasMix : public MaterialMix
         PROPERTY_DOUBLE(defaultTemperature, "the default temperature of the gas")
         ATTRIBUTE_QUANTITY(defaultTemperature, "temperature")
         ATTRIBUTE_MIN_VALUE(defaultTemperature, "[3")  // gas temperature must be above local Universe T_CMB
-        ATTRIBUTE_MAX_VALUE(defaultTemperature, "1e6]")
+        ATTRIBUTE_MAX_VALUE(defaultTemperature, "1e9]")
         ATTRIBUTE_DEFAULT_VALUE(defaultTemperature, "1e4")
         ATTRIBUTE_DISPLAYED_IF(defaultTemperature, "Level2")
 

--- a/SKIRT/utils/PhotonPacket.cpp
+++ b/SKIRT/utils/PhotonPacket.cpp
@@ -35,7 +35,7 @@ void PhotonPacket::launch(size_t historyIndex, double lambda, double L, Position
     else
         setUnpolarized();
     _hasObservedOpticalDepth = false;
-    _hasLyaScatteringInfo = false;
+    _hasScatteringInfo = false;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -71,7 +71,7 @@ void PhotonPacket::launchEmissionPeelOff(const PhotonPacket* pp, Direction bfk)
     else
         setUnpolarized();
     _hasObservedOpticalDepth = false;
-    _hasLyaScatteringInfo = false;
+    _hasScatteringInfo = false;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -88,7 +88,7 @@ void PhotonPacket::launchScatteringPeelOff(const PhotonPacket* pp, Direction bfk
     setDirection(bfk);
     setUnpolarized();
     _hasObservedOpticalDepth = false;
-    _hasLyaScatteringInfo = false;
+    _hasScatteringInfo = false;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -106,7 +106,7 @@ void PhotonPacket::scatter(Direction bfk, Vec bfv, double lambda)
     setDirection(bfk);
     _lambda = bfv.isNull() ? lambda : shiftedEmissionWavelength(lambda, bfk, bfv);
     _hasObservedOpticalDepth = false;
-    _hasLyaScatteringInfo = false;
+    _hasScatteringInfo = false;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/PhotonPacket.hpp
+++ b/SKIRT/utils/PhotonPacket.hpp
@@ -214,7 +214,7 @@ public:
         \frac{{\bf{k}}_\text{ph} \cdot {\bf{v}}_\text{rec} + \Delta v_\mathrm{h}}{c} \right)
         \right. \f] where \f$c\f$ is the speed of light in vacuum. */
     static double shiftedReceptionWavelength(double photonWavelength, Direction photonDirection, Vec receiverVelocity,
-                                             double expansionVelocity);
+                                             double expansionVelocity = 0.);
 
     /** This function returns the Doppler-shifted wavelength perceived for this photon packet by a
         moving receiver (with non-relativistic velocity). The arguments specify the velocity of the

--- a/SKIRT/utils/PhotonPacket.hpp
+++ b/SKIRT/utils/PhotonPacket.hpp
@@ -51,7 +51,15 @@ class VelocityInterface;
     SpatialGridPath class and the StokesVector class. For performance reasons, a PhotonPacket object
     is usually constructed once at the start of a loop and then reused in the loop body for many
     consecutive launches; this allows the vectors with path information to remain allocated. Also,
-    some trivial functions are implemented inline in the header. */
+    several trivial functions are implemented inline in the header.
+
+    The PhotonPacket class offers auxiliary facilities for caching "technical" information related
+    to a photon packet's state during its lifecycle. This optional information is managed by the
+    clients invoking the corresponding store and retrieve functions. Examples include the observed
+    optical depth, used to avoid recalculating the optical depth for consecutive instruments with
+    the same viewing direction, and extra scattering information, used by some material mixes to
+    ensure that peel-off and random-walk operations for a given scattering interaction are treated
+    consistently. */
 class PhotonPacket : public SpatialGridPath, public StokesVector
 {
     // ------- Construction, launch and lifecycle events -------
@@ -242,36 +250,47 @@ public:
         direction can avoid recalculating the optical depth. */
     double observedOpticalDepth() const { return _observedOpticalDepth; }
 
-    // ------- Caching Lya scattering info -------
+    // ------- Caching scattering info -------
 
 public:
-    /** This function stores externally calculated information on the Lyman-alpha scattering event
-        currently being processed in data members. This capability is offered so that the actual
-        scattering event and all its peel-offs can use the same atom velocity and phase function.
-        */
-    void setLyaScatteringInfo(const std::pair<Vec, bool>& scattInfo)
+    /** This function stores externally calculated information on a scattering event currently
+        being processed in data members. The single argument is a pair specifying the interacting
+        particle velocity and whether to use a dipole phase function (true) or isotropic scattering
+        (false). This capability is offered so that the actual scattering event and all its
+        peel-offs can use the same random particle velocity and phase function. */
+    void setScatteringInfo(const std::pair<Vec, bool>& scattInfo)
     {
-        std::tie(_lyaAtomVelocity, _lyaDipole) = scattInfo;
-        _hasLyaScatteringInfo = true;
+        std::tie(_particleVelocity, _dipole) = scattInfo;
+        _hasScatteringInfo = true;
     }
 
-    /** This function returns true if valid Lyman-alpha scattering information has been stored
-        since the latest photon packet launch or scattering event. Otherwise the function returns
-        false. */
-    bool hasLyaScatteringInfo() const { return _hasLyaScatteringInfo; }
+    /** This function stores externally calculated information on a scattering event currently
+        being processed in data members. The single argument specifies the interacting particle
+        velocity. The phase function flag is always set to isotropic (false). This capability is
+        offered so that the actual scattering event and all its peel-offs can use the same random
+        particle velocity. */
+    void setScatteringInfo(Vec particleVelocity)
+    {
+        _particleVelocity = particleVelocity;
+        _dipole = false;
+        _hasScatteringInfo = true;
+    }
 
-    /** If hasLyaScatteringInfo() returns true, this function returns the most recently stored
-        velocity vector of the scattering atom relative to the local gas frame. Otherwise, it
-        returns some meaningless value. This capability is offered so that the actual Lyman-alpha
-        scattering event and all its peel-offs can use the same atom velocity. */
-    Vec lyaAtomVelocity() const { return _lyaAtomVelocity; }
+    /** This function returns true if valid scattering information has been stored since the latest
+        photon packet launch or scattering event. Otherwise the function returns false. */
+    bool hasScatteringInfo() const { return _hasScatteringInfo; }
 
-    /** If hasLyaScatteringInfo() returns true, this function returns the most recently stored
-        phase function choice, i.e., true if scattering as a dipole, false if scattering
-        isotropically. Otherwise, the function returns some meaningless value. This capability is
-        offered so that the actual Lyman-alpha scattering event and all its peel-offs can use the
-        same phase function. */
-    bool lyaDipole() const { return _lyaDipole; }
+    /** If hasScatteringInfo() returns true, this function returns the most recently stored
+        velocity vector of the scattering particle relative to the local frame. Otherwise, it
+        returns some meaningless value. This capability is offered so that the actual scattering
+        event and all its peel-offs can use the same particle velocity. */
+    Vec particleVelocity() const { return _particleVelocity; }
+
+    /** If hasScatteringInfo() returns true, this function returns the most recently stored phase
+        function choice, i.e., true if scattering as a dipole, false if scattering isotropically.
+        Otherwise, the function returns some meaningless value. This capability is offered so that
+        the actual scattering event and all its peel-offs can use the same phase function. */
+    bool dipole() const { return _dipole; }
 
     // ------- Data members -------
 
@@ -298,10 +317,10 @@ private:
     double _observedOpticalDepth{0.};      // optical depth calculated for peel-off to an instrument
     bool _hasObservedOpticalDepth{false};  // true if the above field holds a valid value for this packet
 
-    // Lyman-alpha scattering information
-    Vec _lyaAtomVelocity;               // the velocity vector of the scattering atom in the local gas frame
-    bool _lyaDipole{false};             // true if scattering as a dipole, false if scattering isotropically
-    bool _hasLyaScatteringInfo{false};  // true if the above field holds a valid value for this packet
+    // scattering information
+    Vec _particleVelocity;           // the velocity vector of the scattering particle in the local frame
+    bool _dipole{false};             // true if scattering as a dipole, false if scattering isotropically
+    bool _hasScatteringInfo{false};  // true if the above field holds a valid value for this packet
 };
 
 ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
This update introduces new physics for electron populations:
 - For wavelengths shorter than 10 nm, the electron mix switches to Compton scattering. In contrast to Thomson scattering, the scattering cross section and phase function depend on wavelength, and the scattering interaction is inelastic, causing a wavelength shift. The Compton implementation does not support polarization. If support for polarization is requested, Thomson scattering is used even for short wavelengths.
 - The electron mix supports optional thermal velocity dispersion based on the local temperature, which can be provided as a column in an import file or as a constant temperature value for a built-in geometry.

**Motivation**
These processes are relevant in the X-ray wavelength range.

**Tests**
Existing functional tests still work; new tests have been added for the new functionality. More extensive benchmark tests should be performed in the near future.

