### PR TITLE
Add probes for electron temperature (cuts and per cell)

### DIFF
--- a/SKIRT/core/DefaultElectronTemperatureCutsProbe.cpp
+++ b/SKIRT/core/DefaultElectronTemperatureCutsProbe.cpp
@@ -1,0 +1,32 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "DefaultElectronTemperatureCutsProbe.hpp"
+#include "Configuration.hpp"
+#include "MediumSystem.hpp"
+#include "PlanarElectronTemperatureCutsProbe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void DefaultElectronTemperatureCutsProbe::probeSetup()
+{
+    if (find<Configuration>()->hasMedium() && find<MediumSystem>()->hasElectrons())
+    {
+        // the size in pixels (in each spatial direction) for the default cuts
+        const int Np = 1024;
+
+        // the dimension of the medium system
+        int dimension = find<MediumSystem>()->dimension();
+
+        // output cuts depending on the dimension of the medium system
+        PlanarElectronTemperatureCutsProbe::writeElectronTemperatureCut(this, 1, 1, 0, 0., 0., 0., Np, Np, Np);
+        if (dimension >= 2)
+            PlanarElectronTemperatureCutsProbe::writeElectronTemperatureCut(this, 1, 0, 1, 0., 0., 0., Np, Np, Np);
+        if (dimension == 3)
+            PlanarElectronTemperatureCutsProbe::writeElectronTemperatureCut(this, 0, 1, 1, 0., 0., 0., Np, Np, Np);
+    }
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/DefaultElectronTemperatureCutsProbe.hpp
+++ b/SKIRT/core/DefaultElectronTemperatureCutsProbe.hpp
@@ -1,0 +1,37 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef DEFAULTELECTRONTEMPERATURECUTSPROBE_HPP
+#define DEFAULTELECTRONTEMPERATURECUTSPROBE_HPP
+
+#include "Probe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** DefaultElectronTemperatureCutsProbe outputs FITS files (named
+    <tt>prefix_probe_dust_T_XX.fits</tt>) with cuts through the electron temperature defined by the
+    input model along the coordinate planes. The number of data files written depends on the
+    geometry and material contents of the media system. For spherical symmetry only the
+    intersection with the xy plane is written, for axial symmetry the intersections with the xy and
+    xz planes are written, and for general geometries all three intersections are written. Each of
+    the output files contains a map with 1024 x 1024 pixels, and covers a field of view equal to
+    the total extent of the spatial grid in the simulation. */
+class DefaultElectronTemperatureCutsProbe : public Probe
+{
+    ITEM_CONCRETE(DefaultElectronTemperatureCutsProbe, Probe,
+                  "cuts of the electron temperature along the coordinate planes")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(DefaultElectronTemperatureCutsProbe, "ElectronMix")
+    ITEM_END()
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function performs probing at the end of the setup phase. */
+    void probeSetup() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/ElectronMix.cpp
+++ b/SKIRT/core/ElectronMix.cpp
@@ -245,3 +245,10 @@ void ElectronMix::performScattering(double lambda, const MaterialState* state, P
 }
 
 ////////////////////////////////////////////////////////////////////
+
+double ElectronMix::indicativeTemperature(const MaterialState* state, const Array& /*Jv*/) const
+{
+    return _hasDispersion ? state->temperature() : 0.;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ElectronMix.hpp
+++ b/SKIRT/core/ElectronMix.hpp
@@ -72,7 +72,7 @@ class ElectronMix : public MaterialMix
         ATTRIBUTE_MIN_VALUE(defaultTemperature, "[3")    // temperature must be above local Universe T_CMB
         ATTRIBUTE_MAX_VALUE(defaultTemperature, "1e8]")  // higher temperatures cause relativistic dispersion
         ATTRIBUTE_DEFAULT_VALUE(defaultTemperature, "1e4")
-        ATTRIBUTE_RELEVANT_IF(defaultTemperature, "Panchromatic&includeDispersion")
+        ATTRIBUTE_RELEVANT_IF(defaultTemperature, "Panchromatic&includeThermalDispersion")
         ATTRIBUTE_DISPLAYED_IF(defaultTemperature, "Level2")
 
     ITEM_END()
@@ -180,6 +180,17 @@ public:
         scattering without or with support for polarization depending on the user-configured \em
         includePolarization property. */
     void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const override;
+
+    //======================== Probing ========================
+
+    /** This function returns an indicative temperature of the material mix when it would be
+        embedded in a given radiation field. The implementation in this class ignores the radiation
+        field and returns the temperature driving the thermal velocity dispersion for the medium
+        component in the relevant spatial cell, or zero if thermal velocity dispersion is not
+        enabled for this material mix. Because nothing in the simulation changes the electron
+        temperature, this value corresponds to the temperature defined by the input model at the
+        start of the simulation. */
+    double indicativeTemperature(const MaterialState* state, const Array& Jv) const override;
 
     //======================== Data Members ========================
 

--- a/SKIRT/core/ElectronTemperaturePerCellProbe.cpp
+++ b/SKIRT/core/ElectronTemperaturePerCellProbe.cpp
@@ -1,0 +1,39 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "ElectronTemperaturePerCellProbe.hpp"
+#include "Configuration.hpp"
+#include "MediumSystem.hpp"
+#include "TextOutFile.hpp"
+#include "Units.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void ElectronTemperaturePerCellProbe::probeSetup()
+{
+    if (find<Configuration>()->hasMedium() && find<MediumSystem>()->hasElectrons())
+    {
+        // locate the medium system
+        auto ms = find<MediumSystem>();
+        auto units = find<Units>();
+
+        // create a text file
+        TextOutFile file(this, itemName() + "_T", "electron temperature per cell");
+
+        // write the header
+        file.writeLine("# Electron temperature per spatial cell");
+        file.addColumn("spatial cell index", "", 'd');
+        file.addColumn("electron temperature", units->utemperature(), 'g');
+
+        // write a line for each cell
+        int numCells = ms->numCells();
+        for (int m = 0; m != numCells; ++m)
+        {
+            file.writeRow(m, units->otemperature(ms->indicativeElectronTemperature(m)));
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ElectronTemperaturePerCellProbe.hpp
+++ b/SKIRT/core/ElectronTemperaturePerCellProbe.hpp
@@ -1,0 +1,33 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef ELECTRONTEMPERATUREPERCELLPROBE_HPP
+#define ELECTRONTEMPERATUREPERCELLPROBE_HPP
+
+#include "Probe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** ElectronTemperaturePerCellProbe outputs a column text file (named <tt>prefix_probe_T.dat</tt>)
+    listing the electron temperature defined by the input model for each cell in the spatial grid
+    of the simulation. Specifically, the output file contains a line for each cell in the spatial
+    grid of the simulation. The first column specifies the cell index, and the second column lists
+    the electron temperature. */
+class ElectronTemperaturePerCellProbe : public Probe
+{
+    ITEM_CONCRETE(ElectronTemperaturePerCellProbe, Probe, "the electron temperature for each spatial cell")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(ElectronTemperaturePerCellProbe, "ElectronMix")
+    ITEM_END()
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function performs probing at the end of the setup phase. */
+    void probeSetup() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -863,6 +863,13 @@ double MediumSystem::indicativeDustTemperature(int m) const
 
 ////////////////////////////////////////////////////////////////////
 
+double MediumSystem::indicativeElectronTemperature(int m) const
+{
+    return indicativeTemperature(m, MaterialMix::MaterialType::Electrons);
+}
+
+////////////////////////////////////////////////////////////////////
+
 double MediumSystem::indicativeGasTemperature(int m) const
 {
     return indicativeTemperature(m, MaterialMix::MaterialType::Gas);

--- a/SKIRT/core/MediumSystem.hpp
+++ b/SKIRT/core/MediumSystem.hpp
@@ -561,6 +561,13 @@ public:
         interpretation. */
     double indicativeDustTemperature(int m) const;
 
+    /** This function returns an indicative electron temperature in the spatial cell with index
+        \f$m\f$. This temperature is obtained by averaging the temperature over the electron medium
+        components present in the spatial cell, weighed by relative mass in each component. If no
+        medium component specifies an electron temperature, this function returns zero. Also see
+        the indicativeTemperature() function for more information. */
+    double indicativeElectronTemperature(int m) const;
+
     /** This function returns an indicative gas temperature in the spatial cell with index \f$m\f$.
         This temperature is obtained by averaging the temperature over the gas medium components
         present in the spatial cell, weighed by relative mass in each component. If no medium

--- a/SKIRT/core/PlanarElectronTemperatureCutsProbe.cpp
+++ b/SKIRT/core/PlanarElectronTemperatureCutsProbe.cpp
@@ -1,0 +1,92 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "PlanarElectronTemperatureCutsProbe.hpp"
+#include "Array.hpp"
+#include "Configuration.hpp"
+#include "FITSInOut.hpp"
+#include "MediumSystem.hpp"
+#include "Parallel.hpp"
+#include "ParallelFactory.hpp"
+#include "Units.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void PlanarElectronTemperatureCutsProbe::writeElectronTemperatureCut(Probe* probe, bool xd, bool yd, bool zd, double xc,
+                                                                     double yc, double zc, int Nx, int Ny, int Nz)
+{
+    // locate relevant simulation items
+    auto units = probe->find<Units>();
+    auto ms = probe->find<MediumSystem>();
+    auto grid = ms->grid();
+
+    // determine spatial configuration (regardless of cut direction)
+    Box box = grid->boundingBox();
+    double xpsize = box.xwidth() / Nx;
+    double ypsize = box.ywidth() / Ny;
+    double zpsize = box.zwidth() / Nz;
+    double xbase = box.xmin() + 0.5 * xpsize;
+    double ybase = box.ymin() + 0.5 * ypsize;
+    double zbase = box.zmin() + 0.5 * zpsize;
+    double xcenter = box.center().x();
+    double ycenter = box.center().y();
+    double zcenter = box.center().z();
+
+    // determine index configuration: i->colums, j->rows
+    int Ni = xd ? Nx : Ny;
+    int Nj = zd ? Nz : Ny;
+
+    // allocate result array with the appropriate size
+    Array Tv(Ni * Nj);
+
+    // calculate the results in parallel; perform only at the root processs
+    auto parallel = probe->find<ParallelFactory>()->parallelRootOnly();
+    parallel->call(Nj, [&Tv, ms, grid, units, xpsize, ypsize, zpsize, xbase, ybase, zbase, xd, yd, zd, xc, yc, zc,
+                        Ni](size_t firstIndex, size_t numIndices) {
+        for (size_t j = firstIndex; j != firstIndex + numIndices; ++j)
+        {
+            double z = zd ? (zbase + j * zpsize) : zc;
+            for (int i = 0; i < Ni; i++)
+            {
+                double x = xd ? (xbase + i * xpsize) : xc;
+                double y = yd ? (ybase + (zd ? i : j) * ypsize) : yc;
+                int l = i + Ni * j;
+
+                int m = grid->cellIndex(Position(x, y, z));
+                if (m >= 0) Tv[l] = units->otemperature(ms->indicativeElectronTemperature(m));
+            }
+        }
+    });
+
+    // get the name of the coordinate plane (xy, xz, or yz)
+    string plane;
+    if (xd) plane += "x";
+    if (yd) plane += "y";
+    if (zd) plane += "z";
+
+    // write the results to a FITS file with an appropriate name
+    string description = "electron temperatures in the " + plane + " plane";
+    string filename = probe->itemName() + "_elec_T_" + plane;
+    FITSInOut::write(probe, description, filename, Tv, units->utemperature(), Ni, Nj,
+                     units->olength(xd ? xpsize : ypsize), units->olength(zd ? zpsize : ypsize),
+                     units->olength(xd ? xcenter : ycenter), units->olength(zd ? zcenter : ycenter), units->ulength());
+}
+
+////////////////////////////////////////////////////////////////////
+
+void PlanarElectronTemperatureCutsProbe::probeSetup()
+{
+    if (find<Configuration>()->hasMedium() && find<MediumSystem>()->hasElectrons())
+    {
+        writeElectronTemperatureCut(this, 1, 1, 0, positionX(), positionY(), positionZ(), numPixelsX(), numPixelsY(),
+                                    numPixelsZ());
+        writeElectronTemperatureCut(this, 1, 0, 1, positionX(), positionY(), positionZ(), numPixelsX(), numPixelsY(),
+                                    numPixelsZ());
+        writeElectronTemperatureCut(this, 0, 1, 1, positionX(), positionY(), positionZ(), numPixelsX(), numPixelsY(),
+                                    numPixelsZ());
+    }
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/PlanarElectronTemperatureCutsProbe.hpp
+++ b/SKIRT/core/PlanarElectronTemperatureCutsProbe.hpp
@@ -1,0 +1,44 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef PLANARELECTRONTEMPERATURECUTSPROBE_HPP
+#define PLANARELECTRONTEMPERATURECUTSPROBE_HPP
+
+#include "AbstractPlanarCutsProbe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** PlanarElectronTemperatureCutsProbe outputs FITS files (named
+    <tt>prefix_probe_elec_T_XX.fits</tt>) with cuts through the electron temperature defined by the
+    input model along three planes parallel to the coordinate planes. The offset of each cut plane
+    from the corresponding coordinate plane can be configured by the user (and is zero by default).
+    The field of view of each cut covers the extent of the spatial grid in the simulation in the
+    relevant directions. The number of pixels in each direction can be configured by the user as
+    well. */
+class PlanarElectronTemperatureCutsProbe : public AbstractPlanarCutsProbe
+{
+    ITEM_CONCRETE(PlanarElectronTemperatureCutsProbe, AbstractPlanarCutsProbe,
+                  "cuts of the electron temperature along planes parallel to the coordinate planes")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(PlanarElectronTemperatureCutsProbe, "ElectronMix")
+    ITEM_END()
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function performs probing at the end of the setup phase. */
+    void probeSetup() override;
+
+    /** This function outputs a FITS file with an electron temperature cut in a plane parallel to
+        the coordinate plane indicated by the boolean "direction" arguments \em xd, \em yd, and \em
+        zd, exactly two of which must be true. The arguments \em xc, \em yc, and \em zc specify the
+        position of the cuts, and the arguments \em Nx, \em Ny, and \em Nz specify the number of
+        pixels in each direction. */
+    static void writeElectronTemperatureCut(Probe* probe, bool xd, bool yd, bool zd, double xc, double yc, double zc,
+                                            int Nx, int Ny, int Nz);
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -48,6 +48,7 @@
 #include "CylindricalVectorField.hpp"
 #include "DefaultCustomStateCutsProbe.hpp"
 #include "DefaultDustTemperatureCutsProbe.hpp"
+#include "DefaultElectronTemperatureCutsProbe.hpp"
 #include "DefaultGasTemperatureCutsProbe.hpp"
 #include "DefaultMagneticFieldCutsProbe.hpp"
 #include "DefaultMediaDensityCutsProbe.hpp"
@@ -73,6 +74,7 @@
 #include "DynamicStateOptions.hpp"
 #include "EinastoGeometry.hpp"
 #include "ElectronMix.hpp"
+#include "ElectronTemperaturePerCellProbe.hpp"
 #include "ExpDiskGeometry.hpp"
 #include "ExtinctionOnlyOptions.hpp"
 #include "ExtragalacticUnits.hpp"
@@ -179,6 +181,7 @@
 #include "PhotonPacketOptions.hpp"
 #include "PlanarCustomStateCutsProbe.hpp"
 #include "PlanarDustTemperatureCutsProbe.hpp"
+#include "PlanarElectronTemperatureCutsProbe.hpp"
 #include "PlanarGasTemperatureCutsProbe.hpp"
 #include "PlanarMagneticFieldCutsProbe.hpp"
 #include "PlanarMediaDensityCutsProbe.hpp"
@@ -664,6 +667,9 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     //ItemRegistry::add<DefaultMetallicityCutsProbe>();
     //ItemRegistry::add<PlanarMetallicityCutsProbe>();
     //ItemRegistry::add<MetallicityPerCellProbe>();
+    ItemRegistry::add<DefaultElectronTemperatureCutsProbe>();
+    ItemRegistry::add<PlanarElectronTemperatureCutsProbe>();
+    ItemRegistry::add<ElectronTemperaturePerCellProbe>();
     ItemRegistry::add<DefaultGasTemperatureCutsProbe>();
     ItemRegistry::add<PlanarGasTemperatureCutsProbe>();
     ItemRegistry::add<GasTemperaturePerCellProbe>();


### PR DESCRIPTION
**Description**
This update adds probes for the electron temperature for each spatial cell or along planar cuts.

**Motivation**
These probes are relevant in conjunction with the recently added thermal velocity dispersion option for electrons.
