### PR TITLE
Avoid artificial "noise" for extreme HG forward scattering

### DIFF
--- a/SKIRT/core/DustMix.cpp
+++ b/SKIRT/core/DustMix.cpp
@@ -142,7 +142,7 @@ void DustMix::setupSelfAfter()
         log->warning(type() + " extreme forward/backward scattering asymmetry parameter values reduced to "
                      + StringUtils::toString(maxg));
         log->warning("  For some or all wavelengths short of "
-                     + StringUtils::toString(units->owavelength(_lambdav[lastAdjustedEll]), 'g', 3) + " "
+                     + StringUtils::toString(units->owavelength(lambdav[lastAdjustedEll]), 'g', 3) + " "
                      + units->uwavelength());
     }
 

--- a/SKIRT/core/DustMix.cpp
+++ b/SKIRT/core/DustMix.cpp
@@ -121,6 +121,31 @@ void DustMix::setupSelfAfter()
     _mu = getOpticalProperties(lambdav, _thetav, _sigmaabsv, _sigmascav, _asymmparv, _S11vv, _S12vv, _S33vv, _S34vv,
                                _sigmaabsvv, _sigmaabspolvv);
 
+    // ensure that values for the asymmetry parameter g are not too close to 1 or -1
+    // - the HG phase function expression becomes numerically unstable for abs(g) > 1-1e-7
+    // - more annoyingly, HG phase function values (and hence the bias factors for peel-off photon packets)
+    //   become exceedingly large or small for abs(g) > 0.95, causing unacceptable artificial "noise"
+    const double maxg = 0.95;
+    int lastAdjustedEll = -1;  // index of longest wavelength for which adjustment has been made
+    for (int ell = 0; ell != numLambda; ++ell)
+    {
+        if (abs(_asymmparv[ell]) > maxg)
+        {
+            _asymmparv[ell] = std::copysign(maxg, _asymmparv[ell]);
+            lastAdjustedEll = ell;
+        }
+    }
+    if (lastAdjustedEll >= 0)
+    {
+        auto units = find<Units>();
+        auto log = find<Log>();
+        log->warning(type() + " extreme forward/backward scattering asymmetry parameter values reduced to "
+                     + StringUtils::toString(maxg));
+        log->warning("  For some or all wavelengths short of "
+                     + StringUtils::toString(units->owavelength(_lambdav[lastAdjustedEll]), 'g', 3) + " "
+                     + units->uwavelength());
+    }
+
     // calculate derived basic optical properties
     for (int ell = 0; ell != numLambda; ++ell)
     {


### PR DESCRIPTION
**Background and motivation**

Many of the dust models in SKIRT employ Henley-Greenstein (HG) scattering with a phase function parameterized on the asymmetry parameter g where -1 <= g <= 1. For wavelengths in the x-ray range, dust grains exhibit strong forward scattering, and several of the dust models currently built into SKIRT list g values for those wavelengths that are very close to or even equal to 1, indicating extreme or even total forward scattering.

The expression for the HG phase function becomes numerically unstable for abs(g) > 1-1e-7. Clipping g to that maximum magnitude would not alter the physics and thus would represent no problem.

More annoyingly, however, HG phase function values for some scattering angles become exceedingly large or small when abs(g) > 0.95. These values are used as bias factors for peel-off photon packets in SKIRT, causing unacceptable artificial "noise" in the recorded fluxes. The only known solution is to clip g values to abs(g) <= 0.95, effectively changing the modeled physics in a way that may or may not be significant.

**Description**

With the update in this pull request, SKIRT automatically clips any g values to abs(g) <= 0.95 for all dust mixes. This happens during setup just after loading the dust model data. If any of the values within the wavelength range used by the simulation have been clipped, a warning message is issued to alert the user. With the dust models currently built into SKIRT, this only happens if the simulation uses wavelengths shorter than 25 nm.

**Tests**
All functional tests still run and a new test including dust and wavelengths shorter than 25 nm has been added.
