### PR TITLE
Introduce configuration option for wavelength output style

### DIFF
--- a/SKIRT/core/DustAbsorptionPerCellProbe.cpp
+++ b/SKIRT/core/DustAbsorptionPerCellProbe.cpp
@@ -32,7 +32,7 @@ void DustAbsorptionPerCellProbe::probeRun()
             file.writeLine("# Spectral luminosity absorbed by dust per spatial cell");
             file.addColumn("spatial cell index", "", 'd');
             for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
-                file.addColumn(units->smonluminosity() + "^abs at lambda = "
+                file.addColumn(units->smonluminosity() + "^abs at " + units->swavelength() + " = "
                                    + StringUtils::toString(units->owavelength(wavelengthGrid->wavelength(ell)), 'g')
                                    + " " + units->uwavelength(),
                                units->umonluminosity());

--- a/SKIRT/core/DustAbsorptionPerCellProbe.cpp
+++ b/SKIRT/core/DustAbsorptionPerCellProbe.cpp
@@ -6,6 +6,7 @@
 #include "DustAbsorptionPerCellProbe.hpp"
 #include "Configuration.hpp"
 #include "DisjointWavelengthGrid.hpp"
+#include "Indices.hpp"
 #include "InstrumentWavelengthGridProbe.hpp"
 #include "MediumSystem.hpp"
 #include "StringUtils.hpp"
@@ -31,7 +32,7 @@ void DustAbsorptionPerCellProbe::probeRun()
             // write the header
             file.writeLine("# Spectral luminosity absorbed by dust per spatial cell");
             file.addColumn("spatial cell index", "", 'd');
-            for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
+            for (int ell : Indices(wavelengthGrid->numBins(), units->rwavelength()))
                 file.addColumn(units->smonluminosity() + "^abs at " + units->swavelength() + " = "
                                    + StringUtils::toString(units->owavelength(wavelengthGrid->wavelength(ell)), 'g')
                                    + " " + units->uwavelength(),
@@ -44,7 +45,7 @@ void DustAbsorptionPerCellProbe::probeRun()
                 vector<double> values({static_cast<double>(m)});
                 const Array& Jv = ms->meanIntensity(m);
                 double factor = 4. * M_PI * ms->volume(m);
-                for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
+                for (int ell : Indices(wavelengthGrid->numBins(), units->rwavelength()))
                 {
                     double lambda = wavelengthGrid->wavelength(ell);
                     double Labs = Jv[ell] * factor * ms->opacityAbs(lambda, m, MaterialMix::MaterialType::Dust);

--- a/SKIRT/core/DustEmissivityProbe.cpp
+++ b/SKIRT/core/DustEmissivityProbe.cpp
@@ -93,7 +93,7 @@ namespace
 
         // write the header
         file.writeLine("# Dust emissivities for input field " + title);
-        file.addColumn("wavelength", units->uwavelength());
+        file.addColumn("wavelength; " + units->swavelength(), units->uwavelength());
         for (int h : hv) file.addColumn("lambda*j_lambda for dust in medium component " + std::to_string(h), "W/sr/H");
 
         // write the emissivity for each dust mix to file

--- a/SKIRT/core/DustEmissivityProbe.cpp
+++ b/SKIRT/core/DustEmissivityProbe.cpp
@@ -7,6 +7,7 @@
 #include "ArrayTable.hpp"
 #include "Configuration.hpp"
 #include "DisjointWavelengthGrid.hpp"
+#include "Indices.hpp"
 #include "InstrumentWavelengthGridProbe.hpp"
 #include "MediumSystem.hpp"
 #include "PlanckFunction.hpp"
@@ -97,7 +98,7 @@ namespace
         for (int h : hv) file.addColumn("lambda*j_lambda for dust in medium component " + std::to_string(h), "W/sr/H");
 
         // write the emissivity for each dust mix to file
-        for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
+        for (int ell : Indices(wavelengthGrid->numBins(), units->rwavelength()))
         {
             double lambda = wavelengthGrid->wavelength(ell);
             vector<double> values({units->owavelength(lambda)});

--- a/SKIRT/core/FluxRecorder.cpp
+++ b/SKIRT/core/FluxRecorder.cpp
@@ -5,6 +5,7 @@
 
 #include "FluxRecorder.hpp"
 #include "FITSInOut.hpp"
+#include "Indices.hpp"
 #include "LockFree.hpp"
 #include "Log.hpp"
 #include "MediumSystem.hpp"
@@ -458,7 +459,7 @@ void FluxRecorder::calibrateAndWrite()
         }
 
         // write the column data
-        for (int ell = 0; ell != numWavelengths; ++ell)
+        for (int ell : Indices(numWavelengths, units->rwavelength()))
         {
             vector<double> values({units->owavelength(_lambdagrid->wavelength(ell))});
             for (const Array* array : sedArrays) values.push_back(array->size() ? (*array)[ell] : 0.);
@@ -479,7 +480,7 @@ void FluxRecorder::calibrateAndWrite()
             statFile.writeLine("# --> w_i is luminosity contribution (in W) from i_th launched photon");
 
             // write the column data
-            for (int ell = 0; ell != numWavelengths; ++ell)
+            for (int ell : Indices(numWavelengths, units->rwavelength()))
             {
                 vector<double> values({units->owavelength(_lambdagrid->wavelength(ell))});
                 for (int k = 0; k <= maxContributionPower; ++k) values.push_back(_wsed[k][ell]);

--- a/SKIRT/core/FluxRecorder.cpp
+++ b/SKIRT/core/FluxRecorder.cpp
@@ -451,7 +451,7 @@ void FluxRecorder::calibrateAndWrite()
 
         // open the file and add the column headers
         TextOutFile sedFile(_parentItem, _instrumentName + "_sed", "SED");
-        sedFile.addColumn("wavelength", units->uwavelength());
+        sedFile.addColumn("wavelength; " + units->swavelength(), units->uwavelength());
         for (const string& name : sedNames)
         {
             sedFile.addColumn(name + "; " + units->sfluxdensity(), units->ufluxdensity());
@@ -471,7 +471,7 @@ void FluxRecorder::calibrateAndWrite()
         {
             // open the file and add the column headers
             TextOutFile statFile(_parentItem, _instrumentName + "_sedstats", "SED statistics");
-            statFile.addColumn("wavelength", units->uwavelength());
+            statFile.addColumn("wavelength; " + units->swavelength(), units->uwavelength());
             for (int k = 0; k <= maxContributionPower; ++k)
             {
                 statFile.addColumn("Sum[w_i**" + std::to_string(k) + "]");

--- a/SKIRT/core/InstrumentWavelengthGridProbe.cpp
+++ b/SKIRT/core/InstrumentWavelengthGridProbe.cpp
@@ -40,10 +40,12 @@ void InstrumentWavelengthGridProbe::writeWavelengthGrid(Probe* item, const Wavel
     // write the rows
     for (int ell : Indices(wavelengthGrid->numBins(), units->rwavelength()))
     {
-        file.writeRow(units->owavelength(wavelengthGrid->wavelength(ell)),
-                      units->owavelength(wavelengthGrid->effectiveWidth(ell)),
-                      units->owavelength(wavelengthGrid->leftBorder(ell)),
-                      units->owavelength(wavelengthGrid->rightBorder(ell)));
+        double chara = units->owavelength(wavelengthGrid->wavelength(ell));
+        double width = units->owavelength(wavelengthGrid->effectiveWidth(ell));
+        double left = units->owavelength(wavelengthGrid->leftBorder(ell));
+        double right = units->owavelength(wavelengthGrid->rightBorder(ell));
+        if (units->rwavelength()) std::swap(left, right);
+        file.writeRow(chara, width, left, right);
     }
 }
 

--- a/SKIRT/core/InstrumentWavelengthGridProbe.cpp
+++ b/SKIRT/core/InstrumentWavelengthGridProbe.cpp
@@ -4,6 +4,7 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "InstrumentWavelengthGridProbe.hpp"
+#include "Indices.hpp"
 #include "Instrument.hpp"
 #include "InstrumentSystem.hpp"
 #include "TextOutFile.hpp"
@@ -37,8 +38,7 @@ void InstrumentWavelengthGridProbe::writeWavelengthGrid(Probe* item, const Wavel
     file.addColumn("right border of wavelength bin; " + units->swavelength(), units->uwavelength());
 
     // write the rows
-    int numWavelengths = wavelengthGrid->numBins();
-    for (int ell = 0; ell != numWavelengths; ++ell)
+    for (int ell : Indices(wavelengthGrid->numBins(), units->rwavelength()))
     {
         file.writeRow(units->owavelength(wavelengthGrid->wavelength(ell)),
                       units->owavelength(wavelengthGrid->effectiveWidth(ell)),

--- a/SKIRT/core/InstrumentWavelengthGridProbe.cpp
+++ b/SKIRT/core/InstrumentWavelengthGridProbe.cpp
@@ -31,10 +31,10 @@ void InstrumentWavelengthGridProbe::writeWavelengthGrid(Probe* item, const Wavel
 
     // create a text file and add the columns
     TextOutFile file(item, filename, description);
-    file.addColumn("characteristic wavelength", units->uwavelength());
-    file.addColumn("effective wavelength bin width", units->uwavelength());
-    file.addColumn("left border of wavelength bin", units->uwavelength());
-    file.addColumn("right border of wavelength bin", units->uwavelength());
+    file.addColumn("characteristic wavelength; " + units->swavelength(), units->uwavelength());
+    file.addColumn("effective wavelength bin width; " + units->swavelength(), units->uwavelength());
+    file.addColumn("left border of wavelength bin; " + units->swavelength(), units->uwavelength());
+    file.addColumn("right border of wavelength bin; " + units->swavelength(), units->uwavelength());
 
     // write the rows
     int numWavelengths = wavelengthGrid->numBins();

--- a/SKIRT/core/LaunchedPacketsProbe.cpp
+++ b/SKIRT/core/LaunchedPacketsProbe.cpp
@@ -51,7 +51,7 @@ void LaunchedPacketsProbe::probeRun()
 
     // create a text file and add the columns
     TextOutFile file(this, itemName() + "_launchedpackets", "photon packets launched by primary sources");
-    file.addColumn("wavelength", units->uwavelength());
+    file.addColumn("wavelength; " + units->swavelength(), units->uwavelength());
     file.addColumn("total nr of photon packets launched in bin");
     for (int h = 0; h != numSources; ++h)
         file.addColumn("nr of photon packets launched in bin by source " + std::to_string(h + 1));

--- a/SKIRT/core/LaunchedPacketsProbe.cpp
+++ b/SKIRT/core/LaunchedPacketsProbe.cpp
@@ -5,6 +5,7 @@
 
 #include "LaunchedPacketsProbe.hpp"
 #include "Configuration.hpp"
+#include "Indices.hpp"
 #include "LockFree.hpp"
 #include "PhotonPacket.hpp"
 #include "SourceSystem.hpp"
@@ -57,7 +58,7 @@ void LaunchedPacketsProbe::probeRun()
         file.addColumn("nr of photon packets launched in bin by source " + std::to_string(h + 1));
 
     // write the rows
-    for (int ell = 0; ell != numWavelengths; ++ell)
+    for (int ell : Indices(numWavelengths, units->rwavelength()))
     {
         double lambda = _probeWavelengthGrid->wavelength(ell);
 

--- a/SKIRT/core/LuminosityProbe.cpp
+++ b/SKIRT/core/LuminosityProbe.cpp
@@ -5,6 +5,7 @@
 
 #include "LuminosityProbe.hpp"
 #include "Configuration.hpp"
+#include "Indices.hpp"
 #include "Parallel.hpp"
 #include "ParallelFactory.hpp"
 #include "ProcessManager.hpp"
@@ -48,7 +49,7 @@ void LuminosityProbe::probeSetup()
     for (int i = 0; i != numSources; ++i) file.addColumn("luminosity fraction for source " + std::to_string(i + 1));
 
     // write the rows
-    for (int ell = 0; ell != numWavelengths; ++ell)
+    for (int ell : Indices(numWavelengths, units->rwavelength()))
     {
         double lambda = probeWavelengthGrid->wavelength(ell);
         double dlambda = probeWavelengthGrid->effectiveWidth(ell);

--- a/SKIRT/core/LuminosityProbe.cpp
+++ b/SKIRT/core/LuminosityProbe.cpp
@@ -42,8 +42,8 @@ void LuminosityProbe::probeSetup()
 
     // create a text file and add the columns
     TextOutFile file(this, itemName() + "_luminosities", "primary source luminosities");
-    file.addColumn("wavelength", units->uwavelength());
-    file.addColumn("specific luminosity", units->umonluminosity());
+    file.addColumn("wavelength; " + units->swavelength(), units->uwavelength());
+    file.addColumn("specific luminosity; " + units->smonluminosity(), units->umonluminosity());
     file.addColumn("luminosity in bin", units->ubolluminosity());
     for (int i = 0; i != numSources; ++i) file.addColumn("luminosity fraction for source " + std::to_string(i + 1));
 

--- a/SKIRT/core/OpticalMaterialPropertiesProbe.cpp
+++ b/SKIRT/core/OpticalMaterialPropertiesProbe.cpp
@@ -5,6 +5,7 @@
 
 #include "OpticalMaterialPropertiesProbe.hpp"
 #include "Configuration.hpp"
+#include "Indices.hpp"
 #include "InstrumentSystem.hpp"
 #include "MaterialMix.hpp"
 #include "Medium.hpp"
@@ -56,7 +57,6 @@ void OpticalMaterialPropertiesProbe::probeSetup()
 
         // select "local" or default wavelength grid
         auto probeWavelengthGrid = find<Configuration>()->wavelengthGrid(wavelengthGrid());
-        int numWavelengths = probeWavelengthGrid->numBins();
 
         // create a seperate file for each medium
         for (int h = 0; h != numMedia; ++h)
@@ -82,7 +82,7 @@ void OpticalMaterialPropertiesProbe::probeSetup()
             out.addColumn("scattering asymmetry parameter");
 
             // write the columns
-            for (int ell = 0; ell != numWavelengths; ++ell)
+            for (int ell : Indices(probeWavelengthGrid->numBins(), units->rwavelength()))
             {
                 double lambda = probeWavelengthGrid->wavelength(ell);
                 double sigmaExt = mix->sectionExt(lambda);

--- a/SKIRT/core/OpticalMaterialPropertiesProbe.cpp
+++ b/SKIRT/core/OpticalMaterialPropertiesProbe.cpp
@@ -71,7 +71,7 @@ void OpticalMaterialPropertiesProbe::probeSetup()
             out.writeLine("# Medium component " + std::to_string(h) + " -- " + materialForType(mix->materialType())
                           + " mass per " + entityForType(mix->materialType()) + ": "
                           + StringUtils::toString(units->obulkmass(mix->mass()), 'e', 9) + " " + units->ubulkmass());
-            out.addColumn("wavelength", units->uwavelength());
+            out.addColumn("wavelength; " + units->swavelength(), units->uwavelength());
             out.addColumn("extinction cross section per " + entityForType(mix->materialType()), units->usection());
             out.addColumn("absorption cross section per " + entityForType(mix->materialType()), units->usection());
             out.addColumn("scattering cross section per " + entityForType(mix->materialType()), units->usection());

--- a/SKIRT/core/PlanarRadiationFieldCutsProbe.cpp
+++ b/SKIRT/core/PlanarRadiationFieldCutsProbe.cpp
@@ -10,6 +10,7 @@
 #include "FITSInOut.hpp"
 #include "InstrumentWavelengthGridProbe.hpp"
 #include "MediumSystem.hpp"
+#include "NR.hpp"
 #include "Parallel.hpp"
 #include "ParallelFactory.hpp"
 #include "Units.hpp"
@@ -77,12 +78,21 @@ void PlanarRadiationFieldCutsProbe::writeRadiationFieldCut(Probe* probe, bool xd
     if (yd) plane += "y";
     if (zd) plane += "z";
 
+    // copy the wavelength grid in output units
+    int numWavelengths = wavelengthGrid->numBins();
+    Array wavegrid(numWavelengths);
+    for (int ell = 0; ell != numWavelengths; ++ell) wavegrid[ell] = units->owavelength(wavelengthGrid->wavelength(ell));
+
+    // reverse the ordering of the wavelength grid and frames if necessary
+    if (units->rwavelength())
+    {
+        NR::reverse(wavegrid);
+        NR::reverse(Jvv, size);
+    }
+
     // write the results to a FITS file with an appropriate name
     string description = "mean intensity in the " + plane + " plane";
     string filename = probe->itemName() + "_J_" + plane;
-    Array wavegrid(wavelengthGrid->numBins());
-    for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
-        wavegrid[ell] = units->owavelength(wavelengthGrid->wavelength(ell));
     FITSInOut::write(probe, description, filename, Jvv, units->umeanintensity(), Ni, Nj,
                      units->olength(xd ? xpsize : ypsize), units->olength(zd ? zpsize : ypsize),
                      units->olength(xd ? xcenter : ycenter), units->olength(zd ? zcenter : ycenter), units->ulength(),

--- a/SKIRT/core/RadiationFieldAtPositionsProbe.cpp
+++ b/SKIRT/core/RadiationFieldAtPositionsProbe.cpp
@@ -6,6 +6,7 @@
 #include "RadiationFieldAtPositionsProbe.hpp"
 #include "Configuration.hpp"
 #include "DisjointWavelengthGrid.hpp"
+#include "Indices.hpp"
 #include "InstrumentWavelengthGridProbe.hpp"
 #include "MediumSystem.hpp"
 #include "StringUtils.hpp"
@@ -41,7 +42,7 @@ void RadiationFieldAtPositionsProbe::probeRun()
             outfile.addColumn("position x", units->ulength());
             outfile.addColumn("position y", units->ulength());
             outfile.addColumn("position z", units->ulength());
-            for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
+            for (int ell : Indices(wavelengthGrid->numBins(), units->rwavelength()))
                 outfile.addColumn(units->smeanintensity() + " at " + units->swavelength() + " = "
                                       + StringUtils::toString(units->owavelength(wavelengthGrid->wavelength(ell)), 'g')
                                       + " " + units->uwavelength(),
@@ -56,7 +57,7 @@ void RadiationFieldAtPositionsProbe::probeRun()
                 if (m >= 0)
                 {
                     const Array& Jv = ms->meanIntensity(m);
-                    for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
+                    for (int ell : Indices(wavelengthGrid->numBins(), units->rwavelength()))
                         values.push_back(units->omeanintensity(wavelengthGrid->wavelength(ell), Jv[ell]));
                 }
                 else

--- a/SKIRT/core/RadiationFieldAtPositionsProbe.cpp
+++ b/SKIRT/core/RadiationFieldAtPositionsProbe.cpp
@@ -42,7 +42,7 @@ void RadiationFieldAtPositionsProbe::probeRun()
             outfile.addColumn("position y", units->ulength());
             outfile.addColumn("position z", units->ulength());
             for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
-                outfile.addColumn(units->smeanintensity() + " at lambda = "
+                outfile.addColumn(units->smeanintensity() + " at " + units->swavelength() + " = "
                                       + StringUtils::toString(units->owavelength(wavelengthGrid->wavelength(ell)), 'g')
                                       + " " + units->uwavelength(),
                                   units->umeanintensity());

--- a/SKIRT/core/RadiationFieldPerCellProbe.cpp
+++ b/SKIRT/core/RadiationFieldPerCellProbe.cpp
@@ -6,6 +6,7 @@
 #include "RadiationFieldPerCellProbe.hpp"
 #include "Configuration.hpp"
 #include "DisjointWavelengthGrid.hpp"
+#include "Indices.hpp"
 #include "InstrumentWavelengthGridProbe.hpp"
 #include "MediumSystem.hpp"
 #include "StringUtils.hpp"
@@ -31,7 +32,7 @@ void RadiationFieldPerCellProbe::probeRun()
             // write the header
             file.writeLine("# Mean radiation field intensities per spatial cell");
             file.addColumn("spatial cell index", "", 'd');
-            for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
+            for (int ell : Indices(wavelengthGrid->numBins(), units->rwavelength()))
                 file.addColumn(units->smeanintensity() + " at " + units->swavelength() + " = "
                                    + StringUtils::toString(units->owavelength(wavelengthGrid->wavelength(ell)), 'g')
                                    + " " + units->uwavelength(),
@@ -43,7 +44,7 @@ void RadiationFieldPerCellProbe::probeRun()
             {
                 vector<double> values({static_cast<double>(m)});
                 const Array& Jv = ms->meanIntensity(m);
-                for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
+                for (int ell : Indices(wavelengthGrid->numBins(), units->rwavelength()))
                 {
                     values.push_back(units->omeanintensity(wavelengthGrid->wavelength(ell), Jv[ell]));
                 }

--- a/SKIRT/core/RadiationFieldPerCellProbe.cpp
+++ b/SKIRT/core/RadiationFieldPerCellProbe.cpp
@@ -32,7 +32,7 @@ void RadiationFieldPerCellProbe::probeRun()
             file.writeLine("# Mean radiation field intensities per spatial cell");
             file.addColumn("spatial cell index", "", 'd');
             for (int ell = 0; ell != wavelengthGrid->numBins(); ++ell)
-                file.addColumn(units->smeanintensity() + " at lambda = "
+                file.addColumn(units->smeanintensity() + " at " + units->swavelength() + " = "
                                    + StringUtils::toString(units->owavelength(wavelengthGrid->wavelength(ell)), 'g')
                                    + " " + units->uwavelength(),
                                units->umeanintensity());

--- a/SKIRT/core/SkirtUnitDef.cpp
+++ b/SKIRT/core/SkirtUnitDef.cpp
@@ -110,6 +110,12 @@ SkirtUnitDef::SkirtUnitDef()
     addUnit("pergrainsize", "1/micron", 1e6);
     addUnit("pergrainsize", "1/nm", 1e9);
     addUnit("pergrainsize", "1/Angstrom", 1e10);
+    addUnit("pergrainsize", "/m", 1.);
+    addUnit("pergrainsize", "/cm", 1e2);
+    addUnit("pergrainsize", "/mm", 1e3);
+    addUnit("pergrainsize", "/micron", 1e6);
+    addUnit("pergrainsize", "/nm", 1e9);
+    addUnit("pergrainsize", "/Angstrom", 1e10);
 
     // cross section
     addUnit("section", "m2", 1.);
@@ -171,12 +177,20 @@ SkirtUnitDef::SkirtUnitDef()
     addUnit("numbersurfacedensity", "1/cm2", 1e4);
     addUnit("numbersurfacedensity", "1/AU2", 1 / pow(AU, 2));
     addUnit("numbersurfacedensity", "1/pc2", 1 / pow(pc, 2));
+    addUnit("numbersurfacedensity", "/m2", 1.);
+    addUnit("numbersurfacedensity", "/cm2", 1e4);
+    addUnit("numbersurfacedensity", "/AU2", 1 / pow(AU, 2));
+    addUnit("numbersurfacedensity", "/pc2", 1 / pow(pc, 2));
 
     // number volume density
     addUnit("numbervolumedensity", "1/m3", 1.);
     addUnit("numbervolumedensity", "1/cm3", 1e6);
     addUnit("numbervolumedensity", "1/AU3", 1 / pow(AU, 3));
     addUnit("numbervolumedensity", "1/pc3", 1 / pow(pc, 3));
+    addUnit("numbervolumedensity", "/m3", 1.);
+    addUnit("numbervolumedensity", "/cm3", 1e6);
+    addUnit("numbervolumedensity", "/AU3", 1 / pow(AU, 3));
+    addUnit("numbervolumedensity", "/pc3", 1 / pow(pc, 3));
 
     // mass coefficient
     addUnit("masscoefficient", "m2/kg", 1.);
@@ -356,12 +370,19 @@ SkirtUnitDef::SkirtUnitDef()
     addUnit("energymonluminosity", "1/s/J", 1.);
     addUnit("energymonluminosity", "1/s/eV", 1. / Qel);
     addUnit("energymonluminosity", "1/s/keV", 1e-3 / Qel);
+    addUnit("energymonluminosity", "/s/J", 1.);
+    addUnit("energymonluminosity", "/s/eV", 1. / Qel);
+    addUnit("energymonluminosity", "/s/keV", 1e-3 / Qel);
 
     // energy flux density (F_E)
     addUnit("energyfluxdensity", "1/s/m2/J", 1.);
     addUnit("energyfluxdensity", "1/s/J/m2", 1.);
     addUnit("energyfluxdensity", "1/s/cm2/keV", 10. / Qel);
     addUnit("energyfluxdensity", "1/s/keV/cm2", 10. / Qel);
+    addUnit("energyfluxdensity", "/s/m2/J", 1.);
+    addUnit("energyfluxdensity", "/s/J/m2", 1.);
+    addUnit("energyfluxdensity", "/s/cm2/keV", 10. / Qel);
+    addUnit("energyfluxdensity", "/s/keV/cm2", 10. / Qel);
 
     // energy surface brightness (f_E)
     addUnit("energysurfacebrightness", "1/s/m2/J/sr", 1.);
@@ -372,6 +393,14 @@ SkirtUnitDef::SkirtUnitDef()
     addUnit("energysurfacebrightness", "1/s/keV/cm2/sr", 10. / Qel);
     addUnit("energysurfacebrightness", "1/s/cm2/keV/arcsec2", 10. / Qel / arcsec2);
     addUnit("energysurfacebrightness", "1/s/keV/cm2/arcsec2", 10. / Qel / arcsec2);
+    addUnit("energysurfacebrightness", "/s/m2/J/sr", 1.);
+    addUnit("energysurfacebrightness", "/s/J/m2/sr", 1.);
+    addUnit("energysurfacebrightness", "/s/m2/J/arcsec2", 1. / arcsec2);
+    addUnit("energysurfacebrightness", "/s/J/m2/arcsec2", 1. / arcsec2);
+    addUnit("energysurfacebrightness", "/s/cm2/keV/sr", 10. / Qel);
+    addUnit("energysurfacebrightness", "/s/keV/cm2/sr", 10. / Qel);
+    addUnit("energysurfacebrightness", "/s/cm2/keV/arcsec2", 10. / Qel / arcsec2);
+    addUnit("energysurfacebrightness", "/s/keV/cm2/arcsec2", 10. / Qel / arcsec2);
 
     // energy mean intensity or spectral radiance (J_E)
     addUnit("energymeanintensity", "1/s/m2/J/sr", 1.);
@@ -382,6 +411,14 @@ SkirtUnitDef::SkirtUnitDef()
     addUnit("energymeanintensity", "1/s/keV/cm2/sr", 10. / Qel);
     addUnit("energymeanintensity", "1/s/cm2/keV/arcsec2", 10. / Qel / arcsec2);
     addUnit("energymeanintensity", "1/s/keV/cm2/arcsec2", 10. / Qel / arcsec2);
+    addUnit("energymeanintensity", "/s/m2/J/sr", 1.);
+    addUnit("energymeanintensity", "/s/J/m2/sr", 1.);
+    addUnit("energymeanintensity", "/s/m2/J/arcsec2", 1. / arcsec2);
+    addUnit("energymeanintensity", "/s/J/m2/arcsec2", 1. / arcsec2);
+    addUnit("energymeanintensity", "/s/cm2/keV/sr", 10. / Qel);
+    addUnit("energymeanintensity", "/s/keV/cm2/sr", 10. / Qel);
+    addUnit("energymeanintensity", "/s/cm2/keV/arcsec2", 10. / Qel / arcsec2);
+    addUnit("energymeanintensity", "/s/keV/cm2/arcsec2", 10. / Qel / arcsec2);
 
     // angular size (for objects in the sky)
     addUnit("angle", "rad", 1.);

--- a/SKIRT/core/SkirtUnitDef.cpp
+++ b/SKIRT/core/SkirtUnitDef.cpp
@@ -227,12 +227,6 @@ SkirtUnitDef::SkirtUnitDef()
     addUnit("bolluminosity", "J/s", 1.);
     addUnit("bolluminosity", "erg/s", 1e-7);
     addUnit("bolluminosity", "Lsun", Lsun);
-    addUnit("bolluminosity", "eV/s", Qel);
-    addUnit("bolluminosity", "meV/s", 1e-3 * Qel);
-    addUnit("bolluminosity", "keV/s", 1e3 * Qel);
-    addUnit("bolluminosity", "MeV/s", 1e6 * Qel);
-    addUnit("bolluminosity", "GeV/s", 1e9 * Qel);
-    addUnit("bolluminosity", "TeV/s", 1e12 * Qel);
 
     // neutral monochromatic luminosity (lambda L_lambda = nu L_nu)
     addUnit("neutralmonluminosity", "W", 1.);

--- a/SKIRT/core/SkirtUnitDef.cpp
+++ b/SKIRT/core/SkirtUnitDef.cpp
@@ -61,11 +61,39 @@ SkirtUnitDef::SkirtUnitDef()
     addUnit("wavelength", "PHz", 1e-15 * c, -1.);
     addUnit("wavelength", "EHz", 1e-18 * c, -1.);
     addUnit("wavelength", "ZHz", 1e-21 * c, -1.);
+    addUnit("wavelength", "J", hc, -1.);
     addUnit("wavelength", "eV", hc / Qel, -1.);
     addUnit("wavelength", "meV", 1e3 * hc / Qel, -1.);
     addUnit("wavelength", "keV", 1e-3 * hc / Qel, -1.);
     addUnit("wavelength", "MeV", 1e-6 * hc / Qel, -1.);
     addUnit("wavelength", "GeV", 1e-9 * hc / Qel, -1.);
+
+    // wavelength-style wavelength
+    addUnit("wavelengthwavelength", "m", 1.);
+    addUnit("wavelengthwavelength", "cm", 1e-2);
+    addUnit("wavelengthwavelength", "mm", 1e-3);
+    addUnit("wavelengthwavelength", "micron", 1e-6);
+    addUnit("wavelengthwavelength", "nm", 1e-9);
+    addUnit("wavelengthwavelength", "Angstrom", 1e-10);
+    addUnit("wavelengthwavelength", "pm", 1e-12);
+
+    // frequency-style wavelength
+    addUnit("frequencywavelength", "Hz", c, -1.);
+    addUnit("frequencywavelength", "kHz", 1e-3 * c, -1.);
+    addUnit("frequencywavelength", "MHz", 1e-6 * c, -1.);
+    addUnit("frequencywavelength", "GHz", 1e-9 * c, -1.);
+    addUnit("frequencywavelength", "THz", 1e-12 * c, -1.);
+    addUnit("frequencywavelength", "PHz", 1e-15 * c, -1.);
+    addUnit("frequencywavelength", "EHz", 1e-18 * c, -1.);
+    addUnit("frequencywavelength", "ZHz", 1e-21 * c, -1.);
+
+    // energy-style wavelength
+    addUnit("energywavelength", "J", hc, -1.);
+    addUnit("energywavelength", "eV", hc / Qel, -1.);
+    addUnit("energywavelength", "meV", 1e3 * hc / Qel, -1.);
+    addUnit("energywavelength", "keV", 1e-3 * hc / Qel, -1.);
+    addUnit("energywavelength", "MeV", 1e-6 * hc / Qel, -1.);
+    addUnit("energywavelength", "GeV", 1e-9 * hc / Qel, -1.);
 
     // grainsize
     addUnit("grainsize", "m", 1.);
@@ -380,6 +408,9 @@ SkirtUnitDef::SkirtUnitDef()
     addDefaultUnit("SIUnits", "length", "m");
     addDefaultUnit("SIUnits", "distance", "m");
     addDefaultUnit("SIUnits", "wavelength", "m");
+    addDefaultUnit("SIUnits", "wavelengthwavelength", "m");
+    addDefaultUnit("SIUnits", "frequencywavelength", "Hz");
+    addDefaultUnit("SIUnits", "energywavelength", "J");
     addDefaultUnit("SIUnits", "grainsize", "m");
     addDefaultUnit("SIUnits", "pergrainsize", "1/m");
     addDefaultUnit("SIUnits", "section", "m2");
@@ -425,6 +456,9 @@ SkirtUnitDef::SkirtUnitDef()
     addDefaultUnit("StellarUnits", "length", "AU");
     addDefaultUnit("StellarUnits", "distance", "pc");
     addDefaultUnit("StellarUnits", "wavelength", "micron");
+    addDefaultUnit("StellarUnits", "wavelengthwavelength", "micron");
+    addDefaultUnit("StellarUnits", "frequencywavelength", "GHz");
+    addDefaultUnit("StellarUnits", "energywavelength", "keV");
     addDefaultUnit("StellarUnits", "grainsize", "micron");
     addDefaultUnit("StellarUnits", "pergrainsize", "1/micron");
     addDefaultUnit("StellarUnits", "section", "m2");
@@ -470,6 +504,9 @@ SkirtUnitDef::SkirtUnitDef()
     addDefaultUnit("ExtragalacticUnits", "length", "pc");
     addDefaultUnit("ExtragalacticUnits", "distance", "Mpc");
     addDefaultUnit("ExtragalacticUnits", "wavelength", "micron");
+    addDefaultUnit("ExtragalacticUnits", "wavelengthwavelength", "micron");
+    addDefaultUnit("ExtragalacticUnits", "frequencywavelength", "GHz");
+    addDefaultUnit("ExtragalacticUnits", "energywavelength", "keV");
     addDefaultUnit("ExtragalacticUnits", "grainsize", "micron");
     addDefaultUnit("ExtragalacticUnits", "pergrainsize", "1/micron");
     addDefaultUnit("ExtragalacticUnits", "section", "m2");

--- a/SKIRT/core/Units.cpp
+++ b/SKIRT/core/Units.cpp
@@ -119,6 +119,19 @@ string Units::swavelength() const
 
 ////////////////////////////////////////////////////////////////////
 
+bool Units::rwavelength() const
+{
+    switch (_wavelengthOutputStyle)
+    {
+        case WavelengthOutputStyle::Wavelength: return false;
+        case WavelengthOutputStyle::Frequency: return true;
+        case WavelengthOutputStyle::Energy: return true;
+    }
+    return false;
+}
+
+////////////////////////////////////////////////////////////////////
+
 string Units::uwavelength() const
 {
     switch (_wavelengthOutputStyle)

--- a/SKIRT/core/Units.cpp
+++ b/SKIRT/core/Units.cpp
@@ -106,16 +106,41 @@ double Units::odistance(double d) const
 
 ////////////////////////////////////////////////////////////////////
 
+string Units::swavelength() const
+{
+    switch (_wavelengthOutputStyle)
+    {
+        case WavelengthOutputStyle::Wavelength: return "lambda";
+        case WavelengthOutputStyle::Frequency: return "nu";
+        case WavelengthOutputStyle::Energy: return "E";
+    }
+    return string();
+}
+
+////////////////////////////////////////////////////////////////////
+
 string Units::uwavelength() const
 {
-    return unit("wavelength");
+    switch (_wavelengthOutputStyle)
+    {
+        case WavelengthOutputStyle::Wavelength: return unit("wavelengthwavelength");
+        case WavelengthOutputStyle::Frequency: return unit("frequencywavelength");
+        case WavelengthOutputStyle::Energy: return unit("energywavelength");
+    }
+    return string();
 }
 
 ////////////////////////////////////////////////////////////////////
 
 double Units::owavelength(double lambda) const
 {
-    return out("wavelength", lambda);
+    switch (_wavelengthOutputStyle)
+    {
+        case WavelengthOutputStyle::Wavelength: return out("wavelengthwavelength", lambda);
+        case WavelengthOutputStyle::Frequency: return out("frequencywavelength", lambda);
+        case WavelengthOutputStyle::Energy: return out("energywavelength", lambda);
+    }
+    return 0.;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/Units.hpp
+++ b/SKIRT/core/Units.hpp
@@ -135,6 +135,12 @@ public:
         program. */
     string swavelength() const;
 
+    /** This function returns true if wavelength values are ordered in reverse in the wavelength
+        output style adopted by the program, and false otherwise. Specifically, it returns false
+        for the output style 'wavelength' and true for the output styles 'frequency' and 'energy'.
+        */
+    bool rwavelength() const;
+
     /** This function returns a string containing the name of the style and unit of wavelength
         adopted by the program for output. */
     string uwavelength() const;

--- a/SKIRT/core/Units.hpp
+++ b/SKIRT/core/Units.hpp
@@ -19,15 +19,23 @@
     Firstly, the Units base class and its derived classes enable the SMILE units mechanism in SKIRT
     parameter files, as described in the documentation of the UnitDef class.
 
-    Secondly, the Units class allows the user to configure the flux output style as an attribute in
-    the SKIRT parameter file.
+    Secondly, the Units class allows the user to configure the wavelength and flux output styles as
+    attributes in the SKIRT parameter file.
 
     Finally, the Units class offers functionality for use by other classes in the simulation item
     hierarchy. It provides functions for converting physical quantities from internal SI units to
     external output units depending on the unit system (determined by the name of the subclass
-    being called) and, where applicable, on the selected flux output style. */
+    being called) and, where applicable, on the selected wavelength and flux output styles. */
 class Units : public SimulationItem
 {
+    /** The enumeration type indicating the output style for spectral values, i.e. as photon
+        wavelength (the internal representation), as photon frequency, or as photon energy. */
+    ENUM_DEF(WavelengthOutputStyle, Wavelength, Frequency, Energy)
+        ENUM_VAL(WavelengthOutputStyle, Wavelength, "as photon wavelength: λ")
+        ENUM_VAL(WavelengthOutputStyle, Frequency, "as photon frequency: ν")
+        ENUM_VAL(WavelengthOutputStyle, Energy, "as photon energy: E")
+    ENUM_END()
+
     /** The enumeration type indicating the output style for flux density and surface brightness.
         Neutral indicates \f$\lambda F_\lambda = \nu F_\nu\f$; Wavelength indicates
         \f$F_\lambda\f$; Frequency indicates \f$F_\nu\f$; and Energy indicates \f$F_E\f$. */
@@ -40,8 +48,11 @@ class Units : public SimulationItem
 
     ITEM_ABSTRACT(Units, SimulationItem, "a units system")
 
+        PROPERTY_ENUM(wavelengthOutputStyle, WavelengthOutputStyle, "the output style for wavelengths")
+        ATTRIBUTE_DEFAULT_VALUE(wavelengthOutputStyle, "Wavelength")
+
         PROPERTY_ENUM(fluxOutputStyle, FluxOutputStyle, "the output style for flux density and surface brightness")
-        ATTRIBUTE_DEFAULT_VALUE(fluxOutputStyle, "Frequency")
+        ATTRIBUTE_DEFAULT_VALUE(fluxOutputStyle, "wavelengthOutputStyleEnergy:Energy;Frequency")
 
     ITEM_END()
 
@@ -120,12 +131,16 @@ public:
         program's output units. */
     double odistance(double d) const;
 
-    /** This function returns a string containing the name of the unit of wavelength adopted by the
-        program for output. */
+    /** This function returns a string describing the wavelength output style adopted by the
+        program. */
+    string swavelength() const;
+
+    /** This function returns a string containing the name of the style and unit of wavelength
+        adopted by the program for output. */
     string uwavelength() const;
 
-    /** This function converts the wavelength \f$\lambda\f$ from the internally used SI units (m)
-        to the program's output units. */
+    /** This function converts the wavelength \f$\lambda\f$ from the internal style (wavelength)
+        and the internally used SI units (m) to the program's adopted output style and units. */
     double owavelength(double lambda) const;
 
     /** This function returns a string containing the name of the unit of dust grain size adopted

--- a/SKIRT/utils/NR.cpp
+++ b/SKIRT/utils/NR.cpp
@@ -8,6 +8,20 @@
 
 ////////////////////////////////////////////////////////////////////
 
+void NR::reverse(Array& xv, size_t blocksize)
+{
+    auto first = begin(xv);
+    auto last = end(xv) - blocksize;
+    while (first < last)
+    {
+        for (size_t i = 0; i != blocksize; ++i) std::iter_swap(first + i, last + i);
+        first += blocksize;
+        last -= blocksize;
+    }
+}
+
+////////////////////////////////////////////////////////////////////
+
 double NR::cdf2(bool loglog, const Array& xv, Array& pv, Array& Pv)
 {
     size_t n = xv.size() - 1;

--- a/SKIRT/utils/NR.hpp
+++ b/SKIRT/utils/NR.hpp
@@ -85,6 +85,11 @@ public:
         xv.resize(n);
     }
 
+    /** This function reverses blocks of values in the specified array. The number of values in the
+        array must be an integer multiple of the specified block size. If not, the behavior is
+        undefined. */
+    static void reverse(Array& xv, size_t blocksize = 1);
+
     //======================== Searching =======================
 
 public:

--- a/SMILE/fundamentals/Indices.hpp
+++ b/SMILE/fundamentals/Indices.hpp
@@ -1,0 +1,76 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef INDICES_HPP
+#define INDICES_HPP
+
+#include "Basics.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** The Indices class can be used to iterate over zero-based indices of type int
+    in forward or backward order based on a run-time flag. For example:
+
+    \code
+    for (int index : Indices(4)) {  }         // loops over 0,1,2,3
+    for (int index : Indices(4, true)) {  }   // loops over 3,2,1,0
+    \endcode
+
+    It is also possible to specify any container that implements size():
+
+    \code
+    vector xv(4);
+    for (int index : Indices(xv)) {  }        // loops over 0,1,2,3
+    for (int index : Indices(xv, true)) {  }  // loops over 3,2,1,0
+    \endcode
+
+    */
+class Indices
+{
+private:
+    /** Instances of this helper class are returned as index iterators. */
+    class Iterator
+    {
+    public:
+        Iterator(int value, int step) : _value(value), _step(step) {}
+        bool operator!=(Iterator const& other) const { return _value != other._value; }
+        int operator*() const { return _value; }
+        Iterator& operator++()
+        {
+            _value += _step;
+            return *this;
+        }
+
+    private:
+        int _value;
+        int _step;
+    };
+
+public:
+    /** This constructor intializes an index range with the specified number of zero-based indices.
+        The second argument indicates iteration direction: false (or missing) for forward
+        iteration; true for backward iteration. */
+    Indices(int range, bool reverse = false) : _range(range), _reverse(reverse) {}
+
+    /** This constructor intializes an index range with a number of zero-based indices
+        corresponding to the size of the specified container. The container class must implement
+        the size() function. The second argument indicates iteration direction: false (or missing)
+        for forward iteration; true for backward iteration. */
+    template<class C> Indices(C cont, bool reverse = false) : _range(cont.size()), _reverse(reverse) {}
+
+    /** This function returns the begin iterator corresponding to the iteration direction. */
+    Iterator begin() const { return _reverse ? Iterator(_range - 1, -1) : Iterator(0, 1); }
+
+    /** This function returns the end iterator corresponding to the iteration direction. */
+    Iterator end() const { return _reverse ? Iterator(-1, -1) : Iterator(_range, 1); }
+
+private:
+    int _range;
+    bool _reverse;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SMILE/schema/ItemInfo.hpp
+++ b/SMILE/schema/ItemInfo.hpp
@@ -181,10 +181,10 @@ private: \
     third argument provides a human readable description for the enumeration value (as a quoted
     string). */
 #define ENUM_VAL(enumtype, enumvalue, title) \
-        ii_loadEnumInfo_##enumtype_##enumvalue(); \
+        ii_loadEnumInfo_##enumtype##_##enumvalue(); \
     } \
     /** \enum enumtype enumvalue : title. */ \
-    static void ii_loadEnumInfo_##enumtype_##enumvalue() \
+    static void ii_loadEnumInfo_##enumtype##_##enumvalue() \
     { \
         ItemRegistry::addEnum(static_cast<int>(enumtype::enumvalue), #enumvalue, title);
 


### PR DESCRIPTION
**Description**
This pull request introduces a user configuration option on the units system for selecting a wavelength output style in addition to a flux output style. This new option determines how the internal wavelength quantity is represented in output files: as a wavelength (e.g., in micron), as a frequency (e.g., in GHz), or as a photon energy (e.g., in keV).

In the output of instruments and probes, wavelength-iterated rows, columns, and data frames are always sorted in increasing order of the spectral quantity being used. For example, if the energy wavelength output style is selected, the rows of an SED output file are in increasing energy order, corresponding to decreasing wavelength order.

**Motivation**
In conjunction with the previously introduced energy units for fluxes, this new capability allows outputting SEDs and data cubes in a form expected by x-ray astronomers. 

**Incompatibility**

All text column file headers generated by SKIRT now explicitly include the wavelength and flux styles being used. This was previously not always the case (although one could deduce the flux style from the listed output units). **This change may break procedures that rely on the exact contents of the SKIRT output text file headers.**

 For example, with energy wavelength style, the header for a wavelength column might read:

     # column 1: wavelength; E (keV)

For the default wavelength style, compared to the previous SKIRT output, this change adds the word lambda to the column header:

    # column 1: wavelength; lambda (micron)

**Tests**
Some existing functional tests were slightly adjusted for the column header changes and new tests were added.
