### PR TITLE
Fix secondary emission crash when two simulations are performed consecutively in single thread mode

### DIFF
--- a/SKIRT/core/ContGasSecondarySource.cpp
+++ b/SKIRT/core/ContGasSecondarySource.cpp
@@ -108,9 +108,10 @@ namespace
     {
     private:
         // information initialized once, during the first call to calculateIfNeeded()
-        Array _wavelengthGrid;   // the emission wavelength grid
-        Range _wavelengthRange;  // the range of the emission wavelength grid
-        int _numWavelengths{0};  // the number of wavelengths in the emission wavelength grid
+        const EmittingGasMix* _mix{nullptr};  // the gas mix;
+        Array _wavelengthGrid;                // the emission wavelength grid
+        Range _wavelengthRange;               // the range of the emission wavelength grid
+        int _numWavelengths{0};               // the number of wavelengths in the emission wavelength grid
 
         // information on a particular spatial cell, initialized by calculateIfNeeded()
         int _m{-1};                // spatial cell index
@@ -129,17 +130,19 @@ namespace
         //   ms: medium system
         void calculateIfNeeded(int m, int h, const EmittingGasMix* mix, MediumSystem* ms)
         {
-            // if this photon packet is launched from the same cell as the previous one, we don't need to do anything
-            if (m == _m) return;
-
-            // when called for the first time, cache info on the emission wavelength grid
-            if (_m == -1)
+            // when called for the first time for a given gas mix, cache info on the emission wavelength grid
+            if (_mix != mix)
             {
+                _m = -1;
+                _mix = mix;
                 auto wavelengthGrid = mix->emissionWavelengthGrid();
                 _wavelengthGrid = wavelengthGrid->extlambdav();
                 _wavelengthRange = wavelengthGrid->wavelengthRange();
                 _numWavelengths = _wavelengthGrid.size();
             }
+
+            // if this photon packet is launched from the same cell as the previous one, we don't need to do anything
+            if (m == _m) return;
 
             // remember the new cell index
             _m = m;

--- a/SKIRT/core/DustSecondarySource.cpp
+++ b/SKIRT/core/DustSecondarySource.cpp
@@ -187,12 +187,11 @@ namespace
         void calculateIfNeeded(int p, const vector<int>& mv, const vector<int>& nv, MediumSystem* ms,
                                Configuration* config)
         {
-            // if this photon packet is launched from the same cell as the previous one, we don't need to do anything
-            if (p == _p) return;
-
-            // when called for the first time, cache some info
-            if (_p == -1)
+            // when called for the first time for a given simulation, cache some info
+            if (_ms != ms)
             {
+                _p = -1;
+                _n = -1;
                 _ms = ms;
                 auto wavelengthGrid = config->dustEmissionWLG();
                 _wavelengthGrid = wavelengthGrid->extlambdav();
@@ -203,6 +202,9 @@ namespace
                 _numCells = ms->numCells();
                 _evv.resize(ms->numMedia());
             }
+
+            // if this photon packet is launched from the same cell as the previous one, we don't need to do anything
+            if (p == _p) return;
 
             // remember the new cell index and map to the other indices
             _p = p;


### PR DESCRIPTION
**Description**
This update fixes a bug that caused a crash at the start of secondary emission of the second simulation performed consecutively in the same SKIRT run in single thread mode. This issue has gone unnoticed for a long time because SKIRT is not often used in this mode. Usually one performs just one simulation using multiple threads as opposed to multiple consecutive simulations using a single thread.

**Tests**
All functional tests still succeed. Because each functional test is performed in a separate SKIRT run, the bug considered here did not affect the functional tests.
