### PR TITLE
Fix a bug in velocity dispersion sampling

### DIFF
--- a/SKIRT/core/ElectronMix.cpp
+++ b/SKIRT/core/ElectronMix.cpp
@@ -165,12 +165,13 @@ namespace
             // for high temperatures the generated velocity can be relativistic or even above the speed of light,
             // in which case our non-relativistic Doppler shift formulas produce negative wavelengths;
             // we thus reject any velocities above c/3
+            constexpr double vmax2 = Constants::c() * Constants::c() / 9.;
             while (true)
             {
-                double vtherm = sqrt(Constants::k() / Constants::Melectron() * T) * random->gauss();
-                if (abs(vtherm) < Constants::c() / 3.)
+                Vec vtherm = sqrt(Constants::k() / Constants::Melectron() * T) * random->maxwell();
+                if (vtherm.norm2() < vmax2)
                 {
-                    pp->setScatteringInfo(vtherm * random->direction());
+                    pp->setScatteringInfo(vtherm);
                     break;
                 }
             }

--- a/SKIRT/core/ImportedSource.cpp
+++ b/SKIRT/core/ImportedSource.cpp
@@ -252,10 +252,7 @@ namespace
     public:
         EntityVelocity() {}
         void setBulkVelocity(Vec bfv) { _bfv = bfv; }
-        void applyVelocityDispersion(Random* random, double sigma)
-        {
-            _bfv += sigma * random->gauss() * random->direction();
-        }
+        void applyVelocityDispersion(Random* random, double sigma) { _bfv += sigma * random->maxwell(); }
         Vec velocity() const override { return _bfv; }
     };
 

--- a/SKIRT/core/LineGasSecondarySource.cpp
+++ b/SKIRT/core/LineGasSecondarySource.cpp
@@ -153,6 +153,9 @@ namespace
 
             // get the average bulk velocity for this cell
             _vbulk = ms->bulkVelocity(m);
+
+            // reset the thermal velocity
+            _vtherm = Vec();
         }
 
         // returns a random line index generated from the discrete spectral distribution
@@ -165,7 +168,7 @@ namespace
         void generateThermalVelocity(Random* random, double T, double M)
         {
             if (T > 0. && M > 0.)
-                _vtherm = sqrt(Constants::k() * T / M) * random->gauss() * random->direction();
+                _vtherm = sqrt(Constants::k() * T / M) * random->maxwell();
             else
                 _vtherm = Vec();
         }

--- a/SKIRT/core/Random.cpp
+++ b/SKIRT/core/Random.cpp
@@ -163,6 +163,16 @@ Position Random::position(const Box& box)
     return Position(box.fracPos(x, y, z));
 }
 
+Vec Random::maxwell()
+{
+    // generate the random numbers in separate statements to guarantee evaluation order
+    // (function arguments are evaluated in different order depending on the compiler)
+    double x = gauss();
+    double y = gauss();
+    double z = gauss();
+    return Vec(x, y, z);
+}
+
 //////////////////////////////////////////////////////////////////////
 
 double Random::cdfLinLin(const Array& xv, const Array& Pv)

--- a/SKIRT/core/Random.hpp
+++ b/SKIRT/core/Random.hpp
@@ -11,6 +11,7 @@
 class Box;
 class Direction;
 class Position;
+class Vec;
 
 //////////////////////////////////////////////////////////////////////
 
@@ -116,6 +117,13 @@ public:
     /** This function generates a uniformly distributed random position in a given box (i.e. a
         cuboid lined up with the coordinate axes). */
     Position position(const Box& box);
+
+    /** This function generates a random velocity from a three-dimensional Maxwell-Boltzmann
+        distribution with velocity dispersion 1, which is equivalent to a Gaussian distribution
+        with mean 0 and standard deviation 1 for each of the Cartesian velocity components. The
+        implementation simply calls the function gauss() to obtain each of these three velocity
+        components. */
+    Vec maxwell();
 
     /** This function generates a random number drawn from an arbitrary probability distribution
         \f$p(x)\,{\text{d}}x\f$ with corresponding cumulative distribution function \f$P(x)\f$. The

--- a/SKIRT/core/Units.cpp
+++ b/SKIRT/core/Units.cpp
@@ -47,6 +47,7 @@ double Units::fromFluxStyle(double lambda, double L, FluxOutputStyle style)
         case FluxOutputStyle::Frequency: return L * c / lambda / lambda;
         case FluxOutputStyle::Energy: return L * hc2 / lambda / lambda / lambda;
     }
+    return L;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -60,6 +61,7 @@ Array Units::fromFluxStyle(const Array& lambdav, const Array& Lv, FluxOutputStyl
         case FluxOutputStyle::Frequency: return Lv * c / lambdav / lambdav;
         case FluxOutputStyle::Energy: return Lv * hc2 / lambdav / lambdav / lambdav;
     }
+    return Lv;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/Units.hpp
+++ b/SKIRT/core/Units.hpp
@@ -95,6 +95,7 @@ public:
             case Style::frequencymonluminosity: return FluxOutputStyle::Frequency;
             case Style::energymonluminosity: return FluxOutputStyle::Energy;
         }
+        return FluxOutputStyle::Wavelength;
     }
 
     //======================== Output Conversion =======================


### PR DESCRIPTION
**Description**
This update fixes a bug in the procedure for drawing a random dispersion velocity from the Maxwell-Boltzmann velocity distribution. The resulting Doppler shift for emitted or interacting photon packets had a sharply peaked profile instead of the expected Gaussian profile.

This issue affected three areas:
- An imported primary source with the "import velocity dispersion" flag turned on.
- Secondary line emission from gas (currently used only in the non-operational spin-flip material mix).
- Thermal dispersion in electron mixes configured with a nonzero temperature (recently added and still being tested).

**Tests**
The Doppler shift profiles for primary and secondary emission dispersion now correctly show a Gaussian profile. The thermal dispersion in electron mixes needs further testing and benchmarking.
