### PR TITLE
Add (poorly tested) implementation of 21 cm line emission and self-absorption 

### DIFF
--- a/SKIRT/core/LineGasSecondarySource.cpp
+++ b/SKIRT/core/LineGasSecondarySource.cpp
@@ -124,9 +124,6 @@ namespace
         Array _pv, _Pv;  // normalized discrete emission spectrum (relative line luminosities)
         Vec _vbulk;      // bulk velocity
 
-        // information on a particular photon packet launch, initialized by generateThermalVelocity()
-        Vec _vtherm;  // random thermal velocity
-
     public:
         // instances of this class are allocated in thread-local storage, which means that the constructor is
         // invoked under the hood for each new execution thread; hence it does trivial initialization only
@@ -161,17 +158,8 @@ namespace
         // returns the normalized line luminosity for the given wavelength
         double luminosity(int index) const { return _pv[index]; }
 
-        // generates and stores a random thermal velocity for the given medium temperature and particle mass
-        void generateThermalVelocity(Random* random, double T, double M)
-        {
-            if (T > 0. && M > 0.)
-                _vtherm = sqrt(Constants::k() * T / M) * random->gauss() * random->direction();
-            else
-                _vtherm = Vec();
-        }
-
-        // returns the sum of the bulk velocity and the random thermal velocity
-        Vec velocity() const override { return _vbulk + _vtherm; }
+        // returns the bulk velocity
+        Vec velocity() const override { return _vbulk; }
     };
 
     // setup an instance of the above class to cache emission information for each parallel execution thread
@@ -217,8 +205,15 @@ void LineGasSecondarySource::launch(PhotonPacket* pp, size_t historyIndex, doubl
         }
     }
 
-    // if a temperature is available, generate a random thermal velocity
-    if (_hasTemperature) t_gascell.generateThermalVelocity(_random, _ms->temperature(m, _h), _masses[index]);
+    // get the central wavelength, and if a temperature is available, adjust it for a random thermal velocity
+    double wavelength = _centers[index];
+    if (_hasTemperature)
+    {
+        double T = _ms->temperature(m, _h);
+        double M = _masses[index];
+        double vtherm = sqrt(Constants::k() * T / M) * _random->gauss();
+        wavelength *=  1 + vtherm / Constants::c();
+    }
 
     // generate a random position in this spatial cell
     Position bfr = _ms->grid()->randomPositionInCell(m);
@@ -227,7 +222,7 @@ void LineGasSecondarySource::launch(PhotonPacket* pp, size_t historyIndex, doubl
     VelocityInterface* bvi = t_gascell.velocity().isNull() ? nullptr : &t_gascell;
 
     // launch the photon packet with isotropic direction
-    pp->launch(historyIndex, _centers[index], L * ws * w, bfr, _random->direction(), bvi);
+    pp->launch(historyIndex, wavelength, L * ws * w, bfr, _random->direction(), bvi);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/LineGasSecondarySource.cpp
+++ b/SKIRT/core/LineGasSecondarySource.cpp
@@ -212,7 +212,7 @@ void LineGasSecondarySource::launch(PhotonPacket* pp, size_t historyIndex, doubl
         double T = _ms->temperature(m, _h);
         double M = _masses[index];
         double vtherm = sqrt(Constants::k() * T / M) * _random->gauss();
-        wavelength *=  1 + vtherm / Constants::c();
+        wavelength *= 1 + vtherm / Constants::c();
     }
 
     // generate a random position in this spatial cell

--- a/SKIRT/core/SpinFlipHydrogenGasMix.cpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.cpp
@@ -15,8 +15,14 @@
 
 namespace
 {
-    const double lambdaUV = 1000e-10;           // 1000 Angstrom
-    const double lambdaSF = 21.10611405413e-2;  // 21 cm
+    constexpr double lambdaUV = 1000e-10;           // 1000 Angstrom
+    constexpr double lambdaSF = 21.10611405413e-2;  // 21 cm
+
+    // reference Milky Way radiation field at 1000 Angstrom
+    // converted from 3.43e-8 photons/cm2/s/Hz to internal units W/m2/m/sr
+    constexpr double c = Constants::c();
+    constexpr double h = Constants::h();
+    constexpr double JMW = 3.43e-8 * 1e4 * (h * c / lambdaUV) * (c / (lambdaUV * lambdaUV)) / (4. * M_PI);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SpinFlipHydrogenGasMix.cpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.cpp
@@ -152,9 +152,6 @@ double SpinFlipHydrogenGasMix::mass() const
 
 ////////////////////////////////////////////////////////////////////
 
-#define M_2_SQRTPI 1.12837916709551257389615890312154517 /* 2/sqrt(pi)     */
-#define M_SQRT2 1.41421356237309504880168872420969808    /* sqrt(2)        */
-
 namespace
 {
     // returns the absorption cross section per neutral hydrogen atom for the given wavelength and gas temperature

--- a/SKIRT/core/SpinFlipHydrogenGasMix.cpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.cpp
@@ -10,6 +10,7 @@
 #include "FatalError.hpp"
 #include "MaterialState.hpp"
 #include "PhotonPacket.hpp"
+#include <iostream>
 
 ////////////////////////////////////////////////////////////////////
 
@@ -19,10 +20,11 @@ namespace
     constexpr double lambdaSF = 21.10611405413e-2;  // 21 cm
 
     // reference Milky Way radiation field at 1000 Angstrom
-    // converted from 3.43e-8 photons/cm2/s/Hz to internal units W/m2/m/sr
+    // converted from 1e6 photons/cm2/s/sr/eV to internal units W/m2/m/sr
     constexpr double c = Constants::c();
     constexpr double h = Constants::h();
-    constexpr double JMW = 3.43e-8 * 1e4 * (h * c / lambdaUV) * (c / (lambdaUV * lambdaUV)) / (4. * M_PI);
+    constexpr double Qel = Constants::Qelectron();
+    constexpr double JMW = 1e6 * 1e4 * (h * c * h * c / (lambdaUV * lambdaUV * lambdaUV)) / Qel;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/Range.hpp
+++ b/SKIRT/utils/Range.hpp
@@ -21,10 +21,10 @@ protected:
 
 public:
     /** This is the default constructor; the minimum and maximum values are initialized to zero. */
-    Range() : _min(0), _max(0) {}
+    constexpr Range() : _min(0), _max(0) {}
 
     /** This constructor initializes the range to the minimum and maximum values provided as arguments. */
-    Range(double min, double max) : _min(min), _max(max) {}
+    constexpr Range(double min, double max) : _min(min), _max(max) {}
 
     /** This function sets the range to the minimum and maximum values provided as arguments. */
     void set(double min, double max)


### PR DESCRIPTION
**Description**
This update adds a full implementation of the `SpinFlipHydrogenGasMix` class, supporting the 21 cm line emission and self-absorption caused by the hyperfine structure "spin-flip" transition of neutral hydrogen atoms. The material mix expects the input model to define the total hydrogen number density, the neutral hydrogen fraction, and the gas metallicity and temperature. These properties and the local UV radiation field calculated by the simulation (taking into account dust extinction) are used to partition the neutral hydrogen in atomic and molecular fractions, and to then calculate the line luminosity en absorption coefficient. 

We employ the atomic/molecular partitioning scheme described by Gnedin and Kravtsov 2011. In contrast to many other observationally inspired partitioning schemes, this scheme relies only on local properties so that it can be applied in a 3D simulation without change. The future will tell whether this scheme can/should be fine-tuned or otherwise augmented to make simulation results match observations.

**Motivation and context**
This update fits in the overall objective to extend SKIRT with the simulation of secondary emission processes other than thermal emission from dust. Specifically, it should enable users to investigate the importance of self-absorption of the 21 cm line in typical astrophysical contexts. It also serves as a test-bed for the recently extended secondary emission framework in the code.

**Tests**
The implementation has been minimally tested to verify that there is "some" emission and "some" absorption.

**Many more sanity checks and comparisons with observation must be undertaken before the feature can and should be used for actual science.**

