### PR TITLE
Add composite wavelength grid defined by aggregating a list of "child" wavelength grids

### DIFF
--- a/SKIRT/core/CompositeWavelengthGrid.cpp
+++ b/SKIRT/core/CompositeWavelengthGrid.cpp
@@ -6,7 +6,6 @@
 #include "CompositeWavelengthGrid.hpp"
 #include "FatalError.hpp"
 #include "NR.hpp"
-#include <iostream>
 
 ////////////////////////////////////////////////////////////////////
 
@@ -25,20 +24,96 @@ namespace
         border point is positive infinity. Both these border points have an associated
         characteristic wavelength of zero, indicating that the corresponding segments lie outside
         of the grid.
-
-        The algorithm uses a special (negative) "invalid" value for characteristic wavelengths that
-        need to be calculated at a later stage. */
+    */
     class SegmentedGrid
     {
     private:
+        // log or linear scale, set by constructor
+        bool _logScale{false};
+
         // initialize the grid to a single segment covering the full possible wavelength range
         vector<double> _borderv = {0., std::numeric_limits<double>::infinity()};
         vector<double> _characv = {0., 0.};
 
+        // relative tolerances
+        constexpr static double TOLMIN = 1. - 1e-9;
+        constexpr static double TOLMAX = 1. + 1e-9;
+
+        // return the characteristic wavelength for given border wavelengths
+        double characteristic(double b1, double b2)
+        {
+            if (_logScale)
+                return sqrt(b1 * b2);
+            else
+                return 0.5 * (b1 + b2);
+        }
+
     public:
+        // construct "empty" grid with given scale
+        SegmentedGrid(bool logScale) : _logScale{logScale} {}
+
         // return constant references to our grid data
         const vector<double>& borderv() { return _borderv; }
         const vector<double>& characv() { return _characv; }
+
+        // returns true if the given wavelength is at a segment border within a small tolerance, and false otherwise
+        bool isBorder(double wave) const
+        {
+            int index = NR::locate(_borderv, wave);
+            if (wave < _borderv[index] * TOLMAX) return true;
+            if (wave > _borderv[index + 1] * TOLMIN) return true;
+            return false;
+        }
+
+        // returns the index of the segment containing the given wavelength, or if the given wavelength
+        // is at a segment border within a small tolerance, the index of that border
+        int getIndex(double wave) const
+        {
+            int index = NR::locate(_borderv, wave);
+            if (wave > _borderv[index + 1] * TOLMIN) return index + 1;
+            return index;
+        }
+
+        // splits the segment containing the given wavelength at that wavelength
+        // unless the given wavelength already is at a border
+        void splitSegment(double split)
+        {
+            // only split the segment if the split point is not at a border
+            if (!isBorder(split))
+            {
+                // get the index of the segment to be split
+                int index = getIndex(split);
+
+                // determine the characteristic wavelengths for the new segments
+                double leftcharac = 0.;
+                double rightcharac = 0.;
+                double old = _characv[index];
+                if (old > 0.)
+                {
+                    leftcharac = (old < split * TOLMIN) ? old : characteristic(_borderv[index], split);
+                    rightcharac = (old > split * TOLMAX) ? old : characteristic(split, _borderv[index + 1]);
+                }
+
+                // insert a new segment at the given wavelength
+                _characv[index] = leftcharac;
+                _borderv.insert(begin(_borderv) + index + 1, split);
+                _characv.insert(begin(_characv) + index + 1, rightcharac);
+            }
+        }
+
+        // replace any segments within the range of the new bin by the new bin;
+        // this function assumes that the borders of the new bin are already present
+        void replaceSegments(double left, double charac, double right)
+        {
+            int leftIndex = getIndex(left);
+            int rightIndex = getIndex(right);
+            if (rightIndex > leftIndex)
+            {
+                _borderv.erase(begin(_borderv) + leftIndex + 1, begin(_borderv) + rightIndex);
+                _characv.erase(begin(_characv) + leftIndex + 1, begin(_characv) + rightIndex);
+                _characv[leftIndex] = charac;
+            }
+        }
 
         // composite the given wavelength grid into the receiving segmented grid
         void add(const DisjointWavelengthGrid* wlg)
@@ -47,30 +122,18 @@ namespace
             int numBins = wlg->numBins();
             for (int ell = 0; ell != numBins; ++ell)
             {
-                double chr = wlg->wavelength(ell);
-                double lef = wlg->leftBorder(ell);
-                double rig = wlg->rightBorder(ell);
+                double charac = wlg->wavelength(ell);
+                double left = wlg->leftBorder(ell);
+                double right = wlg->rightBorder(ell);
 
-                // get the segment indices for the left and right borders
-                int indexLef = NR::locate(_borderv, lef);
-                int indexRig = NR::locate(_borderv, rig);
+                // if the bin borders are not already present in the grid,
+                // insert them by splitting the containing segment
+                splitSegment(left);
+                splitSegment(right);
 
-                // if both are fully inside the same empty segment, insert the input bin into that segment
-                if (indexLef == indexRig && !_characv[indexLef])
-                {
-                    _borderv.insert(begin(_borderv) + indexLef + 1, rig);
-                    _borderv.insert(begin(_borderv) + indexLef + 1, lef);
-                    _characv.insert(begin(_characv) + indexLef + 1, 0.);
-                    _characv.insert(begin(_characv) + indexLef + 1, chr);
-                }
+                // replace any segments within range by the new bin
+                replaceSegments(left, charac, right);
             }
-        }
-
-        void print()
-        {
-            for (size_t k = 0; k != _borderv.size(); ++k)
-                std::cout << _borderv[k] * 1e6 << ':' << _characv[k] * 1e6 << "  ";
-            std::cout << std::endl;
         }
     };
 }
@@ -80,13 +143,12 @@ namespace
 void CompositeWavelengthGrid::setupSelfAfter()
 {
     // initialize the result grid to an empty grid
-    SegmentedGrid grid;
+    SegmentedGrid grid(log());
 
     // composite the child grids into the result grid, in order of occurrence
     for (auto wlg : _wavelengthGrids)
     {
         grid.add(wlg);
-        grid.print();
     }
 
     // pass the result grid to the base class

--- a/SKIRT/core/CompositeWavelengthGrid.cpp
+++ b/SKIRT/core/CompositeWavelengthGrid.cpp
@@ -1,0 +1,99 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "CompositeWavelengthGrid.hpp"
+#include "FatalError.hpp"
+#include "NR.hpp"
+#include <iostream>
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    /*  SegmentedGrid is a helper class for compositing wavelength grids.
+
+        The wavelength grid being handled is represented by a list of bin border points and a
+        corresponding list of characteristic wavelengths. A zero characteristic wavelength
+        indicates a segment that is not part of the grid, i.e. that lies between two non-adjacent
+        bins or beyond the outer grid borders. The two lists always have the same size. The borders
+        are listed in strictly increasing order of wavelength (i.e. there are no duplicates) and
+        all nonzero characteristic wavelengths lie within their corresponding bin.
+
+        To facilitate the compositing algorithm, the first border point is always zero and the last
+        border point is positive infinity. Both these border points have an associated
+        characteristic wavelength of zero, indicating that the corresponding segments lie outside
+        of the grid.
+
+        The algorithm uses a special (negative) "invalid" value for characteristic wavelengths that
+        need to be calculated at a later stage. */
+    class SegmentedGrid
+    {
+    private:
+        // initialize the grid to a single segment covering the full possible wavelength range
+        vector<double> _borderv = {0., std::numeric_limits<double>::infinity()};
+        vector<double> _characv = {0., 0.};
+
+    public:
+        // return constant references to our grid data
+        const vector<double>& borderv() { return _borderv; }
+        const vector<double>& characv() { return _characv; }
+
+        // composite the given wavelength grid into the receiving segmented grid
+        void add(const DisjointWavelengthGrid* wlg)
+        {
+            // loop over the bins of the incoming grid
+            int numBins = wlg->numBins();
+            for (int ell = 0; ell != numBins; ++ell)
+            {
+                double chr = wlg->wavelength(ell);
+                double lef = wlg->leftBorder(ell);
+                double rig = wlg->rightBorder(ell);
+
+                // get the segment indices for the left and right borders
+                int indexLef = NR::locate(_borderv, lef);
+                int indexRig = NR::locate(_borderv, rig);
+
+                // if both are fully inside the same empty segment, insert the input bin into that segment
+                if (indexLef == indexRig && !_characv[indexLef])
+                {
+                    _borderv.insert(begin(_borderv) + indexLef + 1, rig);
+                    _borderv.insert(begin(_borderv) + indexLef + 1, lef);
+                    _characv.insert(begin(_characv) + indexLef + 1, 0.);
+                    _characv.insert(begin(_characv) + indexLef + 1, chr);
+                }
+            }
+        }
+
+        void print()
+        {
+            for (size_t k = 0; k != _borderv.size(); ++k)
+                std::cout << _borderv[k] * 1e6 << ':' << _characv[k] * 1e6 << "  ";
+            std::cout << std::endl;
+        }
+    };
+}
+
+////////////////////////////////////////////////////////////////////
+
+void CompositeWavelengthGrid::setupSelfAfter()
+{
+    // initialize the result grid to an empty grid
+    SegmentedGrid grid;
+
+    // composite the child grids into the result grid, in order of occurrence
+    for (auto wlg : _wavelengthGrids)
+    {
+        grid.add(wlg);
+        grid.print();
+    }
+
+    // pass the result grid to the base class
+    setWavelengthSegments(grid.borderv(), grid.characv());
+
+    // invoke base class at the end because it verifies that the wavelength grid has been initialized
+    DisjointWavelengthGrid::setupSelfAfter();
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/CompositeWavelengthGrid.hpp
+++ b/SKIRT/core/CompositeWavelengthGrid.hpp
@@ -1,0 +1,39 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef COMPOSITEWAVELENGTHGRID_HPP
+#define COMPOSITEWAVELENGTHGRID_HPP
+
+#include "DisjointWavelengthGrid.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** CompositeWavelengthGrid is a subclass of the DisjointWavelengthGrid class representing
+    wavelength grids composited from a list of disjoint wavelength grids. */
+class CompositeWavelengthGrid : public DisjointWavelengthGrid
+{
+    ITEM_CONCRETE(CompositeWavelengthGrid, DisjointWavelengthGrid,
+                  "a wavelength grid composited from a list of wavelength grids")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(CompositeWavelengthGrid, "Level2")
+
+        PROPERTY_ITEM_LIST(wavelengthGrids, DisjointWavelengthGrid, "the wavelength grids to be composited")
+        ATTRIBUTE_DEFAULT_VALUE(wavelengthGrids, "LogWavelengthGrid")
+
+        PROPERTY_BOOL(log, "use logarithmic scale")
+        ATTRIBUTE_DEFAULT_VALUE(log, "true")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function constructs the composite wavelength grid from the configured list of
+        wavelength grids. */
+    void setupSelfAfter() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/CompositeWavelengthGrid.hpp
+++ b/SKIRT/core/CompositeWavelengthGrid.hpp
@@ -10,8 +10,42 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** CompositeWavelengthGrid is a subclass of the DisjointWavelengthGrid class representing
-    wavelength grids composited from a list of disjoint wavelength grids. */
+/** The CompositeWavelengthGrid class aggregates a number of "child" wavelength grids configured by
+    the user into a single, composite wavelength grid. All involved wavelength grids (i.e. all
+    child grids and the composited grid) are disjoint wavelength grids, i.e. they inherit from the
+    DisjointWavelengthGrid class. These grids have non-overlapping but possibly adjacent wavelength
+    bins with constant maximum transmission within the bins and zero transmission outside of the
+    bins. Refer to the DisjointWavelengthGrid class description for a more formal definition. Many
+    of the wavelength grids frequently used in SKIRT have these properties. Refer to the list of
+    DisjointWavelengthGrid subclasses for more information.
+
+    The \em wavelengthGrids property specifies a nonempty list of disjoint wavelength grids of any
+    type and with arbitrary configuration options. To construct a single combined grid, each of the
+    child grids is processed one by one in order of occurrence in the user configuration. After
+    initializing the result buffer to an empty grid, the procedure composites each child grid in
+    turn into the current contents of the result buffer. Specifically, the procedure replaces any
+    bins in the result buffer that are overlapped by child bins by those child bins, splitting
+    partially overlapped bins where needed. The characteristic wavelengths of the bins are
+    preserved where possible. If needed, a new characteristic wavelength is calculated for a
+    shortened (partially overlapped) bin from the new bin borders using linear or logarithmic
+    interpolation as indicated by the \em log configuration option.
+
+    It is worth noting the following:
+
+    - If there is just one child, the composite wavelength grid is merely a copy of that child.
+
+    - As long as all child wavelength ranges are mutually disjoint, the order in which the children
+    are specified is irrelevant because the wavelength bins will be automatically sorted by the
+    compositing process. As soon as there is overlap, however, the ordering of the children
+    determines which child’s wavelength bins will be preserved in the composite wavelength grid
+    for the overlapping ranges. It is therefore usually preferable to sort the child wavelength
+    grids from lower to higher resolution.
+
+    - It is possible to nest a composite wavelength grid inside another composite wavelength grid.
+    This allows joining multiple groups of child wavelength grids each with a different setting of
+    the \em log option. However, this seems useful only in pathetic cases.
+
+    */
 class CompositeWavelengthGrid : public DisjointWavelengthGrid
 {
     ITEM_CONCRETE(CompositeWavelengthGrid, DisjointWavelengthGrid,

--- a/SKIRT/core/DisjointWavelengthGrid.hpp
+++ b/SKIRT/core/DisjointWavelengthGrid.hpp
@@ -47,12 +47,11 @@ protected:
     void setupSelfAfter() override;
 
     /** This function initializes the wavelength grid to a consecutive range of adjacent wavelength
-        bins given a list of characteric wavelengths. This function or one of its alternatives
-        should be called from the setupSelfBefore() function in each subclass. The subclass
-        determines a list of characteric wavelengths according to some predefined scheme, and the
-        bin borders and bin widths are automatically determined from that list by this function. If
-        the specified wavelength list is empty, or if there are duplicate values (which would lead
-        to empty bins), the function throws a fatal error.
+        bins given a list of characteric wavelengths. The subclass determines a list of characteric
+        wavelengths according to some predefined scheme, and the bin borders and bin widths are
+        automatically determined from that list by this function. If the specified wavelength list
+        is empty, or if there are duplicate values (which would lead to empty bins), the function
+        throws a fatal error.
 
         The function first sorts the specified characteristic wavelengths in ascending order and
         then calculates the bin borders assuming linear or logarithmic scaling depending on the
@@ -81,13 +80,11 @@ protected:
     void setWavelengthRange(const Array& lambdav, bool logScale);
 
     /** This function initializes the wavelength grid to a set of distinct, nonadjacent wavelength
-        bins given a list of characteric wavelengths and a relative half bin width. This function
-        or one of its alternatives should be called from the setupSelfBefore() function in each
-        subclass. The subclass determines a list of characteric wavelengths and a relative half bin
-        width, and the bin borders and bin widths are automatically calculated from that
-        information by this function. If the specified wavelength list is empty, or if the relative
-        half bin width is not positive, or if the calculated bins overlap, the function throws a
-        fatal error.
+        bins given a list of characteric wavelengths and a relative half bin width. The subclass
+        determines a list of characteric wavelengths and a relative half bin width, and the bin
+        borders and bin widths are automatically calculated from that information by this function.
+        If the specified wavelength list is empty, or if the relative half bin width is not
+        positive, or if the calculated bins overlap, the function throws a fatal error.
 
         Specifically, the function first sorts the specified characteristic wavelengths in
         ascending order and then calculates the bin borders using \f$\lambda^\mathrm{left}_\ell =
@@ -99,17 +96,29 @@ protected:
     void setWavelengthBins(const Array& lambdav, double relativeHalfWidth, bool constantWidth = false);
 
     /** This function initializes the wavelength grid to a consecutive range of \f$N>0\f$ adjacent
-        wavelength bins given a list of \f$N+1\f$ wavelength bin borders. This function or one of
-        its alternatives should be called from the setupSelfBefore() function in each subclass. The
-        subclass determines a list of bin borders according to some predefined scheme, and the
-        characteristic wavelengths and bin widths are automatically determined from that list by
-        this function. If the specified list has fewer than two bin borders, or if there are
-        duplicate values (which would lead to empty bins), the function throws a fatal error.
+        wavelength bins given a list of \f$N+1\f$ wavelength bin borders. The subclass determines a
+        list of bin borders according to some predefined scheme, and the characteristic wavelengths
+        and bin widths are automatically determined from that list by this function. If the
+        specified list has fewer than two bin borders, or if there are duplicate values (which
+        would lead to empty bins), the function throws a fatal error.
 
         The function first sorts the specified wavelength bin borders in ascending order and then
         calculates the characteristic wavelengths assuming linear scaling (arithmetic mean) or
         logarithmic scaling (geometric mean) depending on the value of the \em logScale flag. */
     void setWavelengthBorders(const Array& borderv, bool logScale);
+
+    /** This function initializes the wavelength grid from a list of bin border points and a
+        corresponding list of characteristic wavelengths. A zero characteristic wavelength
+        indicates a segment that is not part of the grid, i.e. that lies between two non-adjacent
+        bins or beyond the outer grid borders. In other words, the subclass has full control over
+        the placement of bin borders and characteristic wavelengths.
+
+        The two lists must have the same size. The borders must be listed in strictly increasing
+        order of wavelength (i.e. there cannot be any duplicates), all nonzero characteristic
+        wavelengths must lie within their corresponding bin, the last characteristic wavelength
+        must be zero, and there must be at least one nonzero characteristic wavelength. If these
+        requirements are violated, the behavior of this function is undefined. */
+    void setWavelengthSegments(const vector<double>& borderv, const vector<double>& characv);
 
     //================= Functions implementing virtual base class functions ===================
 
@@ -188,7 +197,6 @@ private:
     Array _lambdarightv;  // N right wavelength bin widths
     Array _borderv;       // K=N+1 or K=N*2 ordered border points (depending on whether bins are adjacent)
     vector<int> _ellv;    // K+1 indices of the wavelength bins defined by the border points, or -1 if out of range
-    bool _isConsecutive{false};
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/FileBorderWavelengthGrid.hpp
+++ b/SKIRT/core/FileBorderWavelengthGrid.hpp
@@ -29,7 +29,7 @@ class FileBorderWavelengthGrid : public DisjointWavelengthGrid
 
         PROPERTY_STRING(filename, "the name of the file with the wavelength bin borders")
 
-        PROPERTY_BOOL(log, "logarithmic scale")
+        PROPERTY_BOOL(log, "use logarithmic scale")
         ATTRIBUTE_DEFAULT_VALUE(log, "true")
 
     ITEM_END()

--- a/SKIRT/core/FileWavelengthGrid.hpp
+++ b/SKIRT/core/FileWavelengthGrid.hpp
@@ -40,7 +40,7 @@ class FileWavelengthGrid : public DisjointWavelengthGrid
         ATTRIBUTE_MAX_VALUE(relativeHalfWidth, "1[")
         ATTRIBUTE_DEFAULT_VALUE(relativeHalfWidth, "0")
 
-        PROPERTY_BOOL(log, "logarithmic scale")
+        PROPERTY_BOOL(log, "use logarithmic scale")
         ATTRIBUTE_DEFAULT_VALUE(log, "true")
         ATTRIBUTE_RELEVANT_IF(log, "!relativeHalfWidth")
 

--- a/SKIRT/core/ListBorderWavelengthGrid.hpp
+++ b/SKIRT/core/ListBorderWavelengthGrid.hpp
@@ -31,7 +31,7 @@ class ListBorderWavelengthGrid : public DisjointWavelengthGrid
         ATTRIBUTE_MIN_VALUE(wavelengths, "1 pm")
         ATTRIBUTE_MAX_VALUE(wavelengths, "1 m")
 
-        PROPERTY_BOOL(log, "logarithmic scale")
+        PROPERTY_BOOL(log, "use logarithmic scale")
         ATTRIBUTE_DEFAULT_VALUE(log, "true")
 
     ITEM_END()

--- a/SKIRT/core/ListWavelengthGrid.hpp
+++ b/SKIRT/core/ListWavelengthGrid.hpp
@@ -43,7 +43,7 @@ class ListWavelengthGrid : public DisjointWavelengthGrid
         ATTRIBUTE_MAX_VALUE(relativeHalfWidth, "1[")
         ATTRIBUTE_DEFAULT_VALUE(relativeHalfWidth, "0")
 
-        PROPERTY_BOOL(log, "logarithmic scale")
+        PROPERTY_BOOL(log, "use logarithmic scale")
         ATTRIBUTE_DEFAULT_VALUE(log, "true")
         ATTRIBUTE_RELEVANT_IF(log, "!relativeHalfWidth")
 

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -34,6 +34,7 @@
 #include "ClearDensityRecipe.hpp"
 #include "ClumpyGeometryDecorator.hpp"
 #include "CombineGeometryDecorator.hpp"
+#include "CompositeWavelengthGrid.hpp"
 #include "ConfigurableBandWavelengthGrid.hpp"
 #include "ConfigurableDustMix.hpp"
 #include "ConicalAngularDistribution.hpp"
@@ -607,6 +608,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<ResolutionBorderWavelengthGrid>();
     ItemRegistry::add<FileBorderWavelengthGrid>();
     ItemRegistry::add<ListBorderWavelengthGrid>();
+    ItemRegistry::add<CompositeWavelengthGrid>();
     ItemRegistry::add<BandWavelengthGrid>();
     ItemRegistry::add<PredefinedBandWavelengthGrid>();
     ItemRegistry::add<ConfigurableBandWavelengthGrid>();


### PR DESCRIPTION
**Description**
The `CompositeWavelengthGrid` class aggregates a number of "child" wavelength grids configured by the user into a single, composite wavelength grid. All involved wavelength grids (i.e. all child grids and the composited grid) are disjoint wavelength grids, i.e. they inherit from the `DisjointWavelengthGrid` class. This essentially excludes grids based on broadband filters. 

The compositing procedure processes each child grid in order of occurrence, replacing any overlapped bins and splitting partially overlapped bins where needed. As long as all child wavelength ranges are mutually disjoint, the order in which the children are specified is irrelevant because the wavelength bins will be automatically sorted by the compositing process. As soon as there is overlap, however, the ordering of the children determines which child’s wavelength bins will be preserved in the composite wavelength grid for the overlapping ranges. It is therefore usually preferable to sort the child wavelength grids from lower to higher resolution.

**Motivation**
This new class allows building arbitrarily complex wavelength grids, for example including multiple ranges with a different spectral resolution (similar to but more general than the `NestedLogWavelengthGrid`), or including disjoint ranges (e.g. one range covering optical wavelengths and another one covering radio wavelengths).

**Tests**
New functional tests were added.
