### PR TITLE
Verify workflows after severing ties with external dependencies

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -7,7 +7,7 @@
 # Source files with other extensions (including .h, .c, .hh, .cc) are NOT tested
 # to allow for differently formatted third-party code.
 #
-name: Check source code formatting
+name: Check formatting
 
 # workflow event triggers
 on: [pull_request, workflow_dispatch]


### PR DESCRIPTION
**Description**
This pull request serves to verify that the recently updated pull-request workflows still work after actually severing the ties with the external dependencies: the previously used action repository has been removed and the Travis CI integration has been disabled for the SKIRT repository.

Also, the name of the format checking workflow has been shortened to improve readability in the GitHub user interface.