### PR TITLE
Instruments output transparent flux from secondary sources

### DIFF
--- a/SKIRT/core/FluxRecorder.cpp
+++ b/SKIRT/core/FluxRecorder.cpp
@@ -27,6 +27,7 @@ namespace
         Transparent,
         PrimaryDirect,
         PrimaryScattered,
+        SecondaryTransparent,
         SecondaryDirect,
         SecondaryScattered,
         TotalQ,
@@ -166,6 +167,8 @@ void FluxRecorder::finalizeConfiguration()
         }
         if (_hasMediumEmission)
         {
+            _sed[SecondaryTransparent].resize(lenSED);
+            _ifu[SecondaryTransparent].resize(lenIFU);
             _sed[SecondaryDirect].resize(lenSED);
             _ifu[SecondaryDirect].resize(lenIFU);
             _sed[SecondaryScattered].resize(lenSED);
@@ -273,9 +276,14 @@ void FluxRecorder::detect(PhotonPacket* pp, int l, double distance)
                 else
                 {
                     if (numScatt == 0)
+                    {
+                        LockFree::add(_sed[SecondaryTransparent][ell], L);
                         LockFree::add(_sed[SecondaryDirect][ell], Lext);
+                    }
                     else
+                    {
                         LockFree::add(_sed[SecondaryScattered][ell], Lext);
+                    }
                 }
             }
             if (_recordPolarization)
@@ -314,9 +322,14 @@ void FluxRecorder::detect(PhotonPacket* pp, int l, double distance)
                 else
                 {
                     if (numScatt == 0)
+                    {
+                        LockFree::add(_ifu[SecondaryTransparent][lell], L);
                         LockFree::add(_ifu[SecondaryDirect][lell], Lext);
+                    }
                     else
+                    {
                         LockFree::add(_ifu[SecondaryScattered][lell], Lext);
+                    }
                 }
             }
             if (_recordPolarization)
@@ -430,9 +443,9 @@ void FluxRecorder::calibrateAndWrite()
 
             // add the actual components of the total flux
             sedNames.insert(sedNames.end(), {"direct primary flux", "scattered primary flux", "direct secondary flux",
-                                             "scattered secondary flux"});
+                                             "scattered secondary flux", "transparent secondary flux"});
             sedArrays.insert(sedArrays.end(), {&_sed[PrimaryDirect], &_sed[PrimaryScattered], &_sed[SecondaryDirect],
-                                               &_sed[SecondaryScattered]});
+                                               &_sed[SecondaryScattered], &_sed[SecondaryTransparent]});
         }
 
         // add the polarization components, if requested
@@ -520,10 +533,11 @@ void FluxRecorder::calibrateAndWrite()
                 ifuArrays.push_back(&_ifu[Transparent]);
             }
             // add the actual components of the total flux (empty arrays will be ignored later on)
-            ifuNames.insert(ifuNames.end(),
-                            {"primarydirect", "primaryscattered", "secondarydirect", "secondaryscattered"});
-            ifuArrays.insert(ifuArrays.end(), {&_ifu[PrimaryDirect], &_ifu[PrimaryScattered], &_ifu[SecondaryDirect],
-                                               &_ifu[SecondaryScattered]});
+            ifuNames.insert(ifuNames.end(), {"primarydirect", "primaryscattered", "secondarytransparent",
+                                             "secondarydirect", "secondaryscattered"});
+            ifuArrays.insert(ifuArrays.end(),
+                             {&_ifu[PrimaryDirect], &_ifu[PrimaryScattered], &_ifu[SecondaryTransparent],
+                              &_ifu[SecondaryDirect], &_ifu[SecondaryScattered]});
         }
 
         // add the polarization components, if requested

--- a/SKIRT/core/FluxRecorder.hpp
+++ b/SKIRT/core/FluxRecorder.hpp
@@ -63,10 +63,11 @@ class WavelengthGrid;
     IFU file name          | Description | Configured by
     -----------------------|-------------|--------------
     total                  | Total attenuated flux | always on
-    transparent            | Transparent flux, as if there were no attenuating media | \em recordComponents = true
+    transparent            | Transparent flux from primary sources | \em recordComponents = true
     primarydirect          | Direct, unscattered flux from primary sources | \em recordComponents = true
     primaryscattered       | Indirect, scattered flux from primary sources | \em recordComponents = true
     primaryscatteredN      | Flux from primary sources that has scattered N times | .. & \em numScatteringLevels > 0
+    secondarytransparent   | Transparent flux emitted by media | \em recordComponents = true
     secondarydirect        | Direct, unscattered flux emitted by media | \em recordComponents = true
     secondaryscattered     | Indirect, scattered flux emitted by media | \em recordComponents = true
     stokesQ                | Stokes vector element Q for total flux | \em recordPolarization = true
@@ -85,7 +86,7 @@ class WavelengthGrid;
     Block                                  | Configured by
     ---------------------------------------|--------------
     Total flux                             | always on
-    Transparent flux and 4 flux components | \em recordComponents = true
+    Transparent fluxes and flux components | \em recordComponents = true
     Stokes vector elements                 | \em recordPolarization = true
     N-times scattered primary flux         | \em recordComponents = true & \em numScatteringLevels > 0
 


### PR DESCRIPTION
**Description**
With this update, instruments configured with `recordComponents="true"` also record and output the transparent flux from secondary sources (i.e. media). The transparent flux is defined as the flux that would be received by the instrument if there were no attenuating media in the configuration.

**Compatibility**
The are no compatibility issues for the frames or cubes in FITS files. The instrument simply generates an extra output file, with a name ending in `_secondarytransparent.fits`. All other files retain the same name, including the `_transparent.fits` file providing the transparent flux from primary sources.

However, the **_extra column in SED output files_** does cause an incompatibility in certain cases. The `transparent secondary flux` column is added **_after_** the `scattered secondary flux` column. For example:

    # column 1: wavelength; lambda (micron)
    # column 2: total flux; F_nu (Jy)
    # column 3: transparent flux; F_nu (Jy)
    # column 4: direct primary flux; F_nu (Jy)
    # column 5: scattered primary flux; F_nu (Jy)
    # column 6: direct secondary flux; F_nu (Jy)
    # column 7: scattered secondary flux; F_nu (Jy)
    # column 8: transparent secondary flux; F_nu (Jy)
    # column 9: 1-times scattered primary flux; F_nu (Jy)
    # column 10: 2-times scattered primary flux; F_nu (Jy)

As long as the instrument is configured with `numScatteringLevels="0"` and  `recordPolarization="false"`, the extra column is at the end of the list and should not cause any problems. However, if the number of scattering levels being recorded is nonzero, or if the Stokes vector components are being recorded, then those column indices will shift (as in the example above).

**Motivation**
Having access to the transparent or "intrinsic" flux allows explicitly calculating the attenuation in a simulated model. This was already possible for primary sources, and now it is also possible for secondary sources.

**Tests**
Functional tests have been adjusted to allow for the extra column.
