### PR TITLE
Add power-law behavior to radial and rotational vector fields

### DIFF
--- a/SKIRT/core/CylindricalVectorField.cpp
+++ b/SKIRT/core/CylindricalVectorField.cpp
@@ -16,9 +16,23 @@ int CylindricalVectorField::dimension() const
 
 Vec CylindricalVectorField::vector(Position bfr) const
 {
-    Vec result(-bfr.y(), bfr.x(), 0.);
-    double norm = result.norm();
-    return norm > 0. ? result / norm : Vec();
+    // get the radial distance and a unit vector in the rotation direction
+    // except that, if at the z-axis, always immediately return a null vector
+    Vec u(-bfr.y(), bfr.x(), 0.);
+    double r = u.norm();
+    if (r == 0) return Vec();
+    u /= r;
+
+    // set the magnitude to a default value of unity and update if needed
+    double v = 1.;
+    if (unityRadius() > 0.)
+    {
+        if ((exponent() > 0. && r < unityRadius()) || (exponent() < 0. && r > unityRadius()))
+            v = pow(r / unityRadius(), exponent());
+    }
+
+    // return a vector with proper magnitude and direction
+    return v * u;
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/CylindricalVectorField.hpp
+++ b/SKIRT/core/CylindricalVectorField.hpp
@@ -10,14 +10,50 @@
 
 //////////////////////////////////////////////////////////////////////
 
-/** CylindricalVectorField represents a vector field with unit vectors rotating around the z-axis
-    in a plane parallel to the xy-plane. The orientation is clockwise when looking along with the
+/** CylindricalVectorField represents a vector field with vectors rotating around the z-axis in a
+    plane parallel to the xy-plane. The orientation is clockwise when looking along with the
     positive z-axis, and counterclockwise when looking down from the positive z-axis towards the
-    xy-plane. */
+    xy-plane.
+
+    The magnitude of the vectors varies with radial distance from the z-axis. The class has two
+    configuration properties: the distance at which the vector magnitude becomes unity and a power
+    law exponent. If the exponent is positive, the magnitude ramps up from zero at the z-axis to
+    unity at the specified distance, and remains unity from there on. If the power law index is
+    negative, the magnitude is unity from the z-axis to the specified distance, and then ramps down
+    from there to zero at infinity.
+
+    Given the user-configurable unity radius \f$R_1\ge 0\f$ and power-law exponent \f$\alpha\f$,
+    the magnitude \f$v(R)\f$ of the vectors as a function of radial distance \f$R=\sqrt{x^2+y^2}\f$
+    is given by
+
+    \f[ R_1=0 \lor \alpha=0 \qquad v(R) = \begin{cases} 0 & \mathrm{for}\;R=0 \\ 1 &
+    \mathrm{for}\;R>0 \end{cases} \f]
+
+    \f[ R_1>0 \land \alpha>0 \qquad v(R) = \begin{cases} 0 & \mathrm{for}\;R=0 \\ (R/R_1)^\alpha &
+    \mathrm{for}\;0<R<R_1 \\ 1 & \mathrm{for}\;R\ge R_1 \end{cases} \f]
+
+    \f[ R_1>0 \land \alpha<0 \qquad v(R) = \begin{cases} 0 & \mathrm{for}\;R=0 \\ 1 &
+    \mathrm{for}\;0<R<R_1 \\ (R/R_1)^\alpha & \mathrm{for}\;R \ge R_1 \end{cases} \f]
+
+    The first equation defines the vector field for the special values \f$R_1=0\f$ and/or
+    \f$\alpha=0\f$ to consist solely of unit vectors except at the z-axis, where the direction of
+    the vector is undefined. The default value of \f$R_1=0\f$ causes this behavior. If the unity
+    radius is set to a value \f$R_1>0\f$, the default value of \f$\alpha=1\f$ specifies linear
+    behavior: the vector magnitude scales linearly from zero at the z-axis to unity at \f$R=R_1\f$,
+    and stays at unity for larger radii. */
 class CylindricalVectorField : public VectorField
 {
     ITEM_CONCRETE(CylindricalVectorField, VectorField, "a vector field rotating clockwise around the z-axis")
         ATTRIBUTE_TYPE_INSERT(CylindricalVectorField, "Dimension3")
+
+        PROPERTY_DOUBLE(unityRadius, "the radius where the magnitude of the vectors is unity")
+        ATTRIBUTE_QUANTITY(unityRadius, "length")
+        ATTRIBUTE_MIN_VALUE(unityRadius, "[0")
+        ATTRIBUTE_DEFAULT_VALUE(unityRadius, "0")
+
+        PROPERTY_DOUBLE(exponent, "the power-law exponent governing the radial dependence of the magnitude")
+        ATTRIBUTE_DEFAULT_VALUE(exponent, "1")
+
     ITEM_END()
 
     //======================== Other Functions =======================
@@ -27,11 +63,9 @@ public:
         indicating no symmetries (the vectors point in a different direction at each position). */
     int dimension() const override;
 
-    /** This function returns a unit vector that is parallel with the xy-plane and orthogonal to
-        the cylindrical radius component of the given position \f$\bf{r}\f$ with counterclockwise
-        orientation in the xy-plane. Specifically, if \f$\bf{r}=(x,y,z)\f$, the function returns a
-        normalized version of \f$(-y,x,0)\f$ unless \f$x=y=0\f$ in which case it returns the null
-        vector. */
+    /** This function returns a vector that is parallel with the xy-plane and orthogonal to the
+        cylindrical radius component of the given position \f$\bf{r}\f$ according to the
+        definitions given in the class header. */
     Vec vector(Position bfr) const override;
 };
 

--- a/SKIRT/core/MediumVelocityPerCellProbe.cpp
+++ b/SKIRT/core/MediumVelocityPerCellProbe.cpp
@@ -36,7 +36,7 @@ void MediumVelocityPerCellProbe::probeSetup()
         for (int m = 0; m != numCells; ++m)
         {
             Vec v = ms->bulkVelocity(m);
-            file.writeRow(m, units->omagneticfield(v.x()), units->omagneticfield(v.y()), units->omagneticfield(v.z()));
+            file.writeRow(m, units->ovelocity(v.x()), units->ovelocity(v.y()), units->ovelocity(v.z()));
         }
     }
 }

--- a/SKIRT/core/RadialVectorField.cpp
+++ b/SKIRT/core/RadialVectorField.cpp
@@ -16,10 +16,22 @@ int RadialVectorField::dimension() const
 
 Vec RadialVectorField::vector(Position bfr) const
 {
+    // get the radial distance and a unit vector in the radial direction
+    // except that, if at the origin, always immediately return a null vector
     double r = bfr.norm();
-    double s = r < unityRadius() ? r / unityRadius() : 1.;
-    Vec u = r > 0. ? bfr / r : Vec();
-    return s * u;
+    if (r == 0) return Vec();
+    Vec u = bfr / r;
+
+    // set the magnitude to a default value of unity and update if needed
+    double v = 1.;
+    if (unityRadius() > 0.)
+    {
+        if ((exponent() > 0. && r < unityRadius()) || (exponent() < 0. && r > unityRadius()))
+            v = pow(r / unityRadius(), exponent());
+    }
+
+    // return a vector with proper magnitude and direction
+    return v * u;
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/RadialVectorField.hpp
+++ b/SKIRT/core/RadialVectorField.hpp
@@ -18,7 +18,7 @@
     magnitude is unity from the origin to the specified distance, and then ramps down from there to
     zero at infinity.
 
-    Given the user-configurable scale radius \f$r_1\ge 0\f$ and power-law exponent \f$\alpha\f$,
+    Given the user-configurable unity radius \f$r_1\ge 0\f$ and power-law exponent \f$\alpha\f$,
     the magnitude \f$v(r)\f$ of the vectors as a function of radial distance \f$r\f$ is given by
 
     \f[ r_1=0 \lor \alpha=0 \qquad v(r) = \begin{cases} 0 & \mathrm{for}\;r=0 \\ 1 &
@@ -58,9 +58,8 @@ public:
         indicating no symmetries (the vectors point in a different direction at each position). */
     int dimension() const override;
 
-    /** This function returns a unit vector pointing away from the origin at the given position
-        \f$\bf{r}\f$. Specifically, it returns \f$\bf{r}/||\bf{r}||\f$ unless \f$||\bf{r}||=0\f$ in
-        which case it returns the null vector. */
+    /** This function returns a vector pointing away from the origin at the given position
+        \f$\bf{r}\f$ according to the definitions given in the class header. */
     Vec vector(Position bfr) const override;
 };
 

--- a/SKIRT/core/RadialVectorField.hpp
+++ b/SKIRT/core/RadialVectorField.hpp
@@ -10,14 +10,32 @@
 
 //////////////////////////////////////////////////////////////////////
 
-/** RadialVectorField represents a vector field with vectors pointing away from the origin with
-    lengths that depend on the spatial location and on a scale radius \f$r_1\f$ specified by the
-    user as a property. Specifically, the magnitude \f$v\f$ of the vectors is given by \f[ v =
-    \begin{cases} r/r_1 & \mathrm{for}\;0\le r<r_1 \\ 1 & \mathrm{for}\;r\ge r_1 \end{cases} \f] or
-    by \f$v=1\f$ if \f$r_1=0\f$ (the default value). In other words, for the default transition
-    radius of zero, the field consists of unit vectors. For other transition radii, the vector
-    magnitude scales from zero at \f$r=0\f$ to unity at \f$r=r_1\f$, and stays at unity for
-    \f$r>r_1\f$. */
+/** RadialVectorField represents a vector field with vectors pointing away from the origin and with
+    a magnitude that varies with radial distance from the origin. The class has two configuration
+    properties: the distance at which the vector magnitude becomes unity and a power law exponent.
+    If the exponent is positive, the magnitude ramps up from zero at the origin to unity at the
+    specified distance, and remains unity from there on. If the power law index is negative, the
+    magnitude is unity from the origin to the specified distance, and then ramps down from there to
+    zero at infinity.
+
+    Given the user-configurable scale radius \f$r_1\ge 0\f$ and power-law exponent \f$\alpha\f$,
+    the magnitude \f$v(r)\f$ of the vectors as a function of radial distance \f$r\f$ is given by
+
+    \f[ r_1=0 \lor \alpha=0 \qquad v(r) = \begin{cases} 0 & \mathrm{for}\;r=0 \\ 1 &
+    \mathrm{for}\;r>0 \end{cases} \f]
+
+    \f[ r_1>0 \land \alpha>0 \qquad v(r) = \begin{cases} 0 & \mathrm{for}\;r=0 \\ (r/r_1)^\alpha &
+    \mathrm{for}\;0<r<r_1 \\ 1 & \mathrm{for}\;r\ge r_1 \end{cases} \f]
+
+    \f[ r_1>0 \land \alpha<0 \qquad v(r) = \begin{cases} 0 & \mathrm{for}\;r=0 \\ 1 &
+    \mathrm{for}\;0<r<r_1 \\ (r/r_1)^\alpha & \mathrm{for}\;r \ge r_1 \end{cases} \f]
+
+    The first equation defines the vector field for the special values \f$r_1=0\f$ and/or
+    \f$\alpha=0\f$ to consist solely of unit vectors except at the origin, where the direction of
+    the vector is undefined. The default value of \f$r_1=0\f$ causes this behavior. If the unity
+    radius is set to a value \f$r_1>0\f$, the default value of \f$\alpha=1\f$ specifies linear
+    behavior: the vector magnitude scales linearly from zero at the origin to unity at \f$r=r_1\f$,
+    and stays at unity for larger radii. */
 class RadialVectorField : public VectorField
 {
     ITEM_CONCRETE(RadialVectorField, VectorField, "a vector field pointing away from the origin")
@@ -27,6 +45,9 @@ class RadialVectorField : public VectorField
         ATTRIBUTE_QUANTITY(unityRadius, "length")
         ATTRIBUTE_MIN_VALUE(unityRadius, "[0")
         ATTRIBUTE_DEFAULT_VALUE(unityRadius, "0")
+
+        PROPERTY_DOUBLE(exponent, "the power-law exponent governing the radial dependence of the magnitude")
+        ATTRIBUTE_DEFAULT_VALUE(exponent, "1")
 
     ITEM_END()
 


### PR DESCRIPTION
**Description**
With this update, the `RadialVectorField` and `CylindricalVectorField` classes offer options to specify a power-law dependence of the vector magnitude as a function of the radial distance. This allows configuring, for example, an outward radial velocity field with a given maximum velocity up to a given distance from the origin, and decreasing velocity from thereon according to a given power-law exponent. The behavior of the probes is fully upwards compatible with previous versions.

This update also corrects a bug in the `MediumVelocityPerCellProbe` class (incorrect output unit conversion).

**Motivation**
This feature was requested by user Đorđe Savić (@djsavic) for use with AGN models .

**Tests**
Existing functional tests still work; new tests have been added.
