### PR TITLE
Add stub implementations for CO and X-ray gas mixes

### DIFF
--- a/SKIRT/core/CarbonMonoxideGasMix.cpp
+++ b/SKIRT/core/CarbonMonoxideGasMix.cpp
@@ -1,0 +1,225 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "CarbonMonoxideGasMix.hpp"
+#include "Configuration.hpp"
+#include "Constants.hpp"
+#include "DisjointWavelengthGrid.hpp"
+#include "FatalError.hpp"
+#include "MaterialState.hpp"
+#include "StringUtils.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // number of level populations
+    constexpr int numLevelPops = 40;
+
+    // number of supported lines
+    constexpr int numLines = 40;
+
+    // ...
+}
+
+////////////////////////////////////////////////////////////////////
+
+void CarbonMonoxideGasMix::setupSelfBefore()
+{
+    EmittingGasMix::setupSelfBefore();
+
+    auto config = find<Configuration>();
+    if (config->hasSecondaryEmission())
+    {
+        // ...
+    }
+}
+
+////////////////////////////////////////////////////////////////////
+
+bool CarbonMonoxideGasMix::hasExtraSpecificState() const
+{
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////
+
+bool CarbonMonoxideGasMix::hasSemiDynamicMediumState() const
+{
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////
+
+bool CarbonMonoxideGasMix::hasLineEmission() const
+{
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////
+
+vector<SnapshotParameter> CarbonMonoxideGasMix::parameterInfo() const
+{
+    return vector<SnapshotParameter>{SnapshotParameter("H2 number density", "volumenumberdensity", "1/cm3")};
+}
+
+////////////////////////////////////////////////////////////////////
+
+vector<StateVariable> CarbonMonoxideGasMix::specificStateVariableInfo() const
+{
+    vector<StateVariable> result{StateVariable::numberDensity(), StateVariable::temperature(),
+                                 StateVariable::custom(0, "H2 number density", "volumenumberdensity")};
+
+    // add one custom variable for each level population
+    // (the indices start at one because index zero is taken by the H2 number density)
+    for (int p = 1; p <= numLevelPops; ++p)
+        result.push_back(StateVariable::custom(p, "level population " + StringUtils::toString(p), ""));
+
+    return result;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void CarbonMonoxideGasMix::initializeSpecificState(MaterialState* state, double /*metallicity*/, double temperature,
+                                                   const Array& params) const
+{
+    // leave the properties untouched if the cell does not contain any material for this component
+    if (state->numberDensity() > 0.)
+    {
+        // if no value was imported, use default value
+        // make sure the temperature is at least the local universe CMB temperature
+        state->setTemperature(max(Constants::Tcmb(), temperature >= 0. ? temperature : defaultTemperature()));
+        state->setCustom(0, params.size() ? params[0] : state->numberDensity() * defaultMolecularHydrogenRatio());
+
+        // clear the level populations
+        for (int p = 1; p <= numLevelPops; ++p) state->setCustom(p, 0.);
+    }
+}
+
+////////////////////////////////////////////////////////////////////
+
+bool CarbonMonoxideGasMix::updateSpecificState(MaterialState* state, const Array& Jv) const
+{
+    // leave the properties untouched if the cell does not contain any material for this component
+    if (state->numberDensity() > 0.)
+    {
+        // ...
+        (void)Jv;
+
+        // set the level populations (here some arbitrary example value
+        for (int p = 1; p <= numLevelPops; ++p) state->setCustom(p, 1.);
+
+        return true;
+    }
+    return false;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CarbonMonoxideGasMix::mass() const
+{
+    return Constants::Mproton();  // ... should be CO molecule mass
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CarbonMonoxideGasMix::sectionAbs(double lambda) const
+{
+    // ...
+    (void)lambda;
+
+    return 1.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CarbonMonoxideGasMix::sectionSca(double /*lambda*/) const
+{
+    return 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CarbonMonoxideGasMix::sectionExt(double lambda) const
+{
+    return sectionAbs(lambda);
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CarbonMonoxideGasMix::opacityAbs(double lambda, const MaterialState* state, const PhotonPacket* /*pp*/) const
+{
+    // ...
+    (void)lambda;
+    (void)state;
+
+    return 1.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CarbonMonoxideGasMix::opacitySca(double /*lambda*/, const MaterialState* /*state*/,
+                                        const PhotonPacket* /*pp*/) const
+{
+    return 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CarbonMonoxideGasMix::opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const
+{
+    return opacityAbs(lambda, state, pp);
+}
+
+////////////////////////////////////////////////////////////////////
+
+void CarbonMonoxideGasMix::peeloffScattering(double& /*I*/, double& /*Q*/, double& /*U*/, double& /*V*/,
+                                             double& /*lambda*/, double /*w*/, Direction /*bfkobs*/, Direction /*bfky*/,
+                                             const MaterialState* /*state*/, const PhotonPacket* /*pp*/) const
+{}
+
+////////////////////////////////////////////////////////////////////
+
+void CarbonMonoxideGasMix::performScattering(double /*lambda*/, const MaterialState* /*state*/,
+                                             PhotonPacket* /*pp*/) const
+{}
+
+////////////////////////////////////////////////////////////////////
+
+Array CarbonMonoxideGasMix::lineEmissionCenters() const
+{
+    Array centers(numLines);
+    // ...
+    return centers;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Array CarbonMonoxideGasMix::lineEmissionMasses() const
+{
+    Array masses(numLines);
+    // ...
+    return masses;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Array CarbonMonoxideGasMix::lineEmissionSpectrum(const MaterialState* state, const Array& /*Jv*/) const
+{
+    Array luminosities(numLines);
+    // ...
+    (void)state;
+
+    return luminosities;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double CarbonMonoxideGasMix::indicativeTemperature(const MaterialState* state, const Array& /*Jv*/) const
+{
+    return state->temperature();
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/CarbonMonoxideGasMix.hpp
+++ b/SKIRT/core/CarbonMonoxideGasMix.hpp
@@ -1,0 +1,293 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef CARBONMONOXIDEGASMIX_HPP
+#define CARBONMONOXIDEGASMIX_HPP
+
+#include "EmittingGasMix.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** The CarbonMonoxideGasMix class describes the material properties related to selected rotational
+    and rovibrational transitions in carbon monoxide (CO).
+
+    The energy levels of CO are discretized into vibrational levels (quantum number \f$v\f$) and
+    more subdivided rotational levels (quantum number \f$J\f$). The vibrational levels are
+    quantized by the magnitude of the dipole moment, and the rotational levels are quantized by the
+    magnitude of the dipole rotation. This class supports transitions involving vibrational levels
+    \f$v=0\f$ and \f$v=1\f$ and rotational levels up to \f$J=20\f$. The selection rules allow two
+    types of transitions between these energy levels. Rotational transitions change the rotational
+    energy level by \f$\Delta J=\pm 1\f$. The corresponding lines are in the far-infrared to
+    millimeter wavelength range, up to about 2600 \f$\mu\mathrm{m}\f$. Rovibrational transitions
+    change both the rotational and vibrational levels at the same time (\f$\Delta J=\pm1\f$ and
+    \f$v=0-1\f$). The corresponding lines, at least for the two supported vibrational levels, are
+    all in the near infrared around 4.7 \f$\mu\mathrm{m}\f$.
+
+    For each supported transition, the emission luminosity and self-absorption opacity in a given
+    cell are determined from gas properties defined in the input model (CO number density,
+    molecular hydrogen number density, kinetic gas temperature) and the local radiation field
+    calculated by the simulation taking into account dust extinction. The class performs an
+    iterative, non-LTE calculation including the effects of collisional transitions (excitation and
+    de-excitation with molecular hydrogen as interaction partner) and photonic transitions
+    (spontaneous emission, absorption, and induced emission). This allows establishing the energy
+    level distribution (population) for a wide range of material densities and radiation fields.
+
+    <b>Configuring the simulation</b>
+
+    Simulations of the CO transition spectra should include primary sources and a dust medium in
+    addition to a medium component configured with the carbon monoxide mix (this class).
+    Furthermore, the \em simulationMode should be set to "DustAndGasEmission" and \em
+    iterateSecondaryEmission should be enabled. The radiation field wavelength grid should properly
+    resolve the UV, optical, and infrared wavelength range (relevant for dust emission) and the
+    wavelength ranges of the supported CO transition lines.
+
+    Separate instruments can be configured for the relevant wavelength ranges, e.g. using a
+    logarithmic grid for the continuum spectrum and linear grids for the line profiles.
+
+    During primary emission, the simulation determines the radiation field resulting from the
+    primary sources and dust attenuation (CO line absorption is taken to be zero at this stage).
+    The resulting radiation field allows a first estimation of the CO level populations for each
+    spatial grid cell; this calculation happens in the updateSpecificState() function, which is
+    invoked at the end of primary emission.
+
+    During secondary emission, the simulation takes into account emission from all configured media
+    (dust continuum and CO lines) in addition to absorption by these same media (dust and CO). For
+    CO, the previously stored level populations allow calculating the line emission spectrum and
+    the line self-absorption cross sections. This results in an updated radiation field, which will
+    in turn influence the CO level populations (and for high optical depths, possibly the dust
+    temperature), which in turn influences the secondary emission spectra. In order to obtain a
+    self-consistent result, the simulation must therefore iterate over secondary emission.
+
+    As indicated above, the input model must provide values for the spatial distribution of three
+    medium properties: CO number density, molecular hydrogen number density, and kinetic gas
+    temperature. These values remain constant during the simulation. Most often, this information
+    will be read from an input file by associating the CO material mix with a subclass of
+    ImportedMedium. For that medium component, the ski file attribute \em importTemperature
+    <b>must</b> be set to 'true', and \em importMetallicity and \em importVariableMixParams must be
+    left at 'false'. The additional column required by the CO material mix (molecular hydrogen
+    number density) is automatically imported and is expected <b>after</b> all other columns. For
+    example, if bulk velocities are also imported for this medium component (i.e. \em
+    importVelocity is 'true'), the column order would be \f[ ..., n_\mathrm{CO}, T_\mathrm{kin},
+    v_\mathrm{x}, v_\mathrm{y}, v_\mathrm{z}, n_\mathrm{H2} \f]
+
+    For basic testing purposes, the CO material mix can also be associated with a geometric medium
+    component. The geometry then defines the spatial density distribution (i.e.
+    \f$n_\mathrm{CO}\f$), and the material mix offers configuration properties to specify a fixed
+    default value for the gas temperature and for the number of hydrogen molecules per CO molecule
+    that will be used across the spatial domain. In this case, the molecular hydrogen number
+    density is thus implicitly defined based on the CO number density by a constant multiplier.
+
+    <b>Level populations</b>
+
+    The level populations \f$n_i\f$ (used later to calculate the emission luminosities and the
+    absorption opacities) are obtained by solving the statistical equilibrium equations. The
+    equation for the energy level with index \f$i\f$ (where indices increase from lowest to highest
+    energy state) is given by
+
+    \f[ \sum^{N_\mathrm{lp}}_{j>i} n_jA_{ji} + \sum^{N_\mathrm{lp}}_{j\neq i} \Big[ (n_jB_{ji} -
+    n_iB_{ij})J_\lambda(\lambda_{ij})\Big] + \sum^{N_\mathrm{lp}}_{j\neq i}
+    \big[n_jC_{ji}(n_\mathrm{H2} ,T_\mathrm{kin}) - n_iC_{ij}(n_\mathrm{H2},T_\mathrm{kin})\big]=0,
+    \f]
+
+    where \f$\lambda_{ij}\f$ is the transition wavelength and \f$A_{ij}\f$, \f$B_{ij}\f$,
+    \f$B_{ji}\f$ are the Einstein coefficients for spontaneous emission, induced emission, and
+    absorption, and \f$C_{ij}\f$, \f$C_{ji}\f$ the coefficients for collisional excitation and
+    de-excitation. These coefficients are taken from the literature (references to be provided).
+
+    \em Note
+
+    We assume that the level populations of all molecules in a given spatial cell are the same, and
+    to calculate them we use the mean intensity of the radiation field at the rest wavelength of
+    each transition. This means that the radiation field wavelength grid needs just a single bin
+    for each transition. We consider this assumption to be valid if the width of the velocity bin
+    (or wavelength bin) of the observed spectrum is larger than the velocity dispersion of each
+    cell. In reality, however, the molecules in a cell have a velocity dispersion and the perceived
+    transition wavelength is different for each molecule. Therefore, one should calculate the mean
+    intensities of each level transition at several velocity bins in the wavelength range
+    corresponding to the velocity dispersion. However, the computational cost becomes very large.
+
+    <b>Emission</b>
+
+    The integrated line luminosity \f$L_\ell\f$ corresponding to the transition with index
+    \f$\ell\f$ for a given spatial cell is given by
+
+    \f[ L_\ell = \frac{hc}{\lambda_\ell} A_{ul} n_u V_\mathrm{cell}, \f]
+
+    where \f$\lambda_\ell\f$ is the transition wavelength, \f$u\f$ and \f$l\f$ are the indices of
+    the energy levels before and after the corresponding transition, and \f$V_\mathrm{cell}\f$ is
+    the volume of the cell. The SKIRT framework automatically adds a Gaussian line profile assuming
+    a thermal velocity corresponding to the kinetic temperature in the cell and the mass of a CO
+    molecule, in addition to any Doppler shifts caused by the bulk velocity in the cell.
+
+    <b>Absorption</b>
+
+    During primary emission, absorption cannot be calculated (and is taken to be zero) because the
+    level populations have not yet been established. During secondary emission, the absorption
+    opacity \f$k^\text{abs}(\lambda)\f$ as a function of wavelength \f$\lambda\f$ is given by
+
+    \f[ k^\text{abs}(\lambda) = \sum_\ell \, \frac{h c}{4\pi \lambda_\ell}(n_l\,B_{lu}-n_u\,B_{ul})
+    \,\phi_\ell(\lambda) \f]
+
+    where the sum with index \f$\ell\f$ runs over all supported lines, \f$u\f$ and \f$l\f$ are the
+    indices of the energy levels before and after the corresponding transition, and
+    \f$\phi_\ell(\lambda)\f$ is the Gaussian profile of line \f$\ell\f$.
+
+    The calculation explicitly includes the Gaussian line profile caused by thermal motion of the
+    molecules in the local bulk velocity frame of the cell. Moreover, the absorption profiles of
+    all supported lines are superposed on top of each other. In practice, the implementation
+    attempts to calculate just the terms that have a significant contribution at any given
+    wavelength.
+
+    */
+class CarbonMonoxideGasMix : public EmittingGasMix
+{
+    ITEM_CONCRETE(CarbonMonoxideGasMix, EmittingGasMix,
+                  "A gas mix supporting the carbon monoxide rotational and rovibrational transitions")
+        ATTRIBUTE_TYPE_INSERT(CarbonMonoxideGasMix, "CustomMediumState")
+
+        PROPERTY_DOUBLE(defaultTemperature, "the default temperature of the gas")
+        ATTRIBUTE_QUANTITY(defaultTemperature, "temperature")
+        ATTRIBUTE_MIN_VALUE(defaultTemperature, "[3")  // gas temperature must be above local Universe T_CMB
+        ATTRIBUTE_MAX_VALUE(defaultTemperature, "1e9]")
+        ATTRIBUTE_DEFAULT_VALUE(defaultTemperature, "1e4")
+        ATTRIBUTE_DISPLAYED_IF(defaultTemperature, "Level2")
+
+        PROPERTY_DOUBLE(defaultMolecularHydrogenRatio, "the default ratio of H2 over CO molecule numbers")
+        ATTRIBUTE_MIN_VALUE(defaultMolecularHydrogenRatio, "[0")
+        ATTRIBUTE_MAX_VALUE(defaultMolecularHydrogenRatio, "1e6]")
+        ATTRIBUTE_DEFAULT_VALUE(defaultMolecularHydrogenRatio, "100")
+        ATTRIBUTE_DISPLAYED_IF(defaultMolecularHydrogenRatio, "Level2")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function determines and caches some values used in the other functions. */
+    void setupSelfBefore() override;
+
+    //======== Capabilities =======
+
+public:
+    /** This function returns true, indicating that the cross sections returned by this material
+        mix depend on the values of specific state variables other than the number density. */
+    bool hasExtraSpecificState() const override;
+
+    /** This function returns true, indicating that this material has a semi-dynamic medium state.
+        */
+    bool hasSemiDynamicMediumState() const override;
+
+    /** This function returns true, indicating that this material supports secondary line emission
+        from gas. */
+    bool hasLineEmission() const override;
+
+    //======== Medium state setup =======
+
+public:
+    /** This function returns the number and type of import parameters required by this particular
+        material mix as a list of SnapshotParameter objects. For this class, the function returns a
+        descriptor for the molecular hydrogen density import parameter. Importing the kinetic gas
+        temperature should be enabled through the corresponding standard configuration flag. */
+    vector<SnapshotParameter> parameterInfo() const override;
+
+    /** This function returns a list of StateVariable objects describing the specific state
+        variables used by the receiving material mix. For this class, the function returns a list
+        containing descriptors for the properties defined in the input model (CO number density, H2
+        number density, and temperature) and for a number of variables to hold the CO level
+        populations derived from the radiation field when the semi-dynamic medium state is updated.
+        */
+    vector<StateVariable> specificStateVariableInfo() const override;
+
+    /** This function initializes the specific state variables requested by this material mix
+        through the specificStateVariableInfo() function except for the CO number density. For this
+        class, the function initializes the H2 number density and the temperature to the specified
+        imported values, or if not available, to the user-configured default values. The level
+        populations are set to zero. */
+    void initializeSpecificState(MaterialState* state, double metallicity, double temperature,
+                                 const Array& params) const override;
+
+    //======== Medium state updates =======
+
+    /** Based on the specified radiation field and the input model properties found in the given
+        material state, this function determines the level populations for the supported CO
+        transitions and stores these results back in the given material state. The function returns
+        true if the material state has indeed be changed, and false otherwise. */
+    bool updateSpecificState(MaterialState* state, const Array& Jv) const override;
+
+    //======== Low-level material properties =======
+
+public:
+    /** This function returns the mass of a neutral hydrogen atom. */
+    double mass() const override;
+
+    /** This function returns the absorption cross section per CO atom at the given wavelength and
+        using the default gas properties configured for this material mix. */
+    double sectionAbs(double lambda) const override;
+
+    /** This function returns the scattering cross section per CO atom, which is trivially zero for
+        all wavelengths. */
+    double sectionSca(double lambda) const override;
+
+    /** This function returns the total extinction cross section per CO atom at the given
+        wavelength and using the default gas properties configured for this material mix. The
+        extinction cross section is identical to the absorption cross section because the
+        scattering cross section is zero. */
+    double sectionExt(double lambda) const override;
+
+    //======== High-level photon life cycle =======
+
+    /** This function returns the CO absorption opacity \f$k^\text{abs}= n_\mathrm{CO}
+        \varsigma^\text{abs}\f$ for the given wavelength and material state. The photon packet
+        properties are not used. */
+    double opacityAbs(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function returns the CO scattering opacity \f$k^\text{sca}\f$ which is trivially zero
+        at all wavelengths. */
+    double opacitySca(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function returns the CO extinction opacity \f$k^\text{ext}=k^\text{abs}\f$ for the
+        given wavelength and material state, which equals the absorption opacity because the
+        scattering opacity is zero. The photon packet properties are not used. */
+    double opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function does nothing because the CO lines do not scatter. */
+    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
+                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function does nothing because the CO lines do not scatter. */
+    void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const override;
+
+    //======== Secondary emission =======
+
+    /** This function returns a list with the line centers of the supported CO transitions. */
+    Array lineEmissionCenters() const override;
+
+    /** This function returns a list with the masses of the particle emitting each of the lines,
+        i.e. the CO molecule in each case. */
+    Array lineEmissionMasses() const override;
+
+    /** This function returns a list with the line luminosities for the supported transitions in
+        the spatial cell and medium component represented by the specified material state and the
+        receiving material mix when it would be embedded in the specified radiation field. */
+    Array lineEmissionSpectrum(const MaterialState* state, const Array& Jv) const override;
+
+    //======== Temperature =======
+
+    /** This function returns an indicative temperature of the material mix when it would be
+        embedded in a given radiation field. The implementation in this class ignores the radiation
+        field and returns the temperature stored in the specific state for the relevant spatial
+        cell and medium component. This value corresponds to the temperature defined by the input
+        model at the start of the simulation. */
+    double indicativeTemperature(const MaterialState* state, const Array& Jv) const override;
+
+    //======================== Data Members ========================
+
+private:
+    // ...
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/EmittingGasMix.cpp
+++ b/SKIRT/core/EmittingGasMix.cpp
@@ -8,6 +8,13 @@
 
 ////////////////////////////////////////////////////////////////////
 
+MaterialMix::MaterialType EmittingGasMix::materialType() const
+{
+    return MaterialType::Gas;
+}
+
+////////////////////////////////////////////////////////////////////
+
 Range EmittingGasMix::wavelengthRange() const
 {
     Range lineRange, contRange;

--- a/SKIRT/core/EmittingGasMix.hpp
+++ b/SKIRT/core/EmittingGasMix.hpp
@@ -41,7 +41,14 @@ class EmittingGasMix : public MaterialMix, public SourceWavelengthRangeInterface
 
     ITEM_END()
 
-    //======================== Other Functions =======================
+    //======== Material type =======
+
+public:
+    /** This function returns the fundamental material type represented by this material mix, which
+        is MaterialType::Gas. */
+    MaterialType materialType() const override;
+
+    //======== Wavelength range interface =======
 
 public:
     /** This function returns the wavelength range of the gas emission wavelength grid,

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -262,6 +262,7 @@
 #include "VoronoiMeshSource.hpp"
 #include "VoronoiMeshSpatialGrid.hpp"
 #include "WeingartnerDraineDustMix.hpp"
+#include "XRayAtomicGasMix.hpp"
 #include "ZubkoDustMix.hpp"
 #include "ZubkoGraphiteGrainSizeDistribution.hpp"
 #include "ZubkoPAHGrainSizeDistribution.hpp"
@@ -540,6 +541,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
 
     ItemRegistry::add<ElectronMix>();
     ItemRegistry::add<LyaNeutralHydrogenGasMix>();
+    ///ItemRegistry::add<XRayAtomicGasMix>();
     ItemRegistry::add<EmittingGasMix>();
     ItemRegistry::add<SpinFlipHydrogenGasMix>();
     ///ItemRegistry::add<CarbonMonoxideGasMix>();

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -25,6 +25,7 @@
 #include "BrokenExpDiskGeometry.hpp"
 #include "BruzualCharlotSED.hpp"
 #include "BruzualCharlotSEDFamily.hpp"
+#include "CarbonMonoxideGasMix.hpp"
 #include "CartesianSpatialGrid.hpp"
 #include "CastelliKuruczSED.hpp"
 #include "CastelliKuruczSEDFamily.hpp"
@@ -541,6 +542,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<LyaNeutralHydrogenGasMix>();
     ItemRegistry::add<EmittingGasMix>();
     ItemRegistry::add<SpinFlipHydrogenGasMix>();
+    ///ItemRegistry::add<CarbonMonoxideGasMix>();
 
     // material mix families
     ItemRegistry::add<MaterialMixFamily>();

--- a/SKIRT/core/SpinFlipHydrogenGasMix.cpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.cpp
@@ -45,13 +45,6 @@ void SpinFlipHydrogenGasMix::setupSelfBefore()
 
 ////////////////////////////////////////////////////////////////////
 
-MaterialMix::MaterialType SpinFlipHydrogenGasMix::materialType() const
-{
-    return MaterialType::Gas;
-}
-
-////////////////////////////////////////////////////////////////////
-
 bool SpinFlipHydrogenGasMix::hasExtraSpecificState() const
 {
     return true;

--- a/SKIRT/core/SpinFlipHydrogenGasMix.hpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.hpp
@@ -208,10 +208,6 @@ protected:
     //======== Capabilities =======
 
 public:
-    /** This function returns the fundamental material type represented by this material mix, which
-        is MaterialType::Gas. */
-    MaterialType materialType() const override;
-
     /** This function returns true, indicating that the cross sections returned by this material
         mix depend on the values of specific state variables other than the number density. */
     bool hasExtraSpecificState() const override;

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -17,11 +17,11 @@ namespace
     constexpr size_t numAtoms = 30;
 
     // default abundancies taken from Table 2 of Anders & Grevesse (1989), the default abundance table in Xspec
-    constexpr std::initializer_list<double> default_abundancies = {
+    constexpr std::initializer_list<double> defaultAbundancies = {
         1.00E+00, 9.77E-02, 1.45E-11, 1.41E-11, 3.98E-10, 3.63E-04, 1.12E-04, 8.51E-04, 3.63E-08, 1.23E-04,
         2.14E-06, 3.80E-05, 2.95E-06, 3.55E-05, 2.82E-07, 1.62E-05, 3.16E-07, 3.63E-06, 1.32E-07, 2.29E-06,
         1.26E-09, 9.77E-08, 1.00E-08, 4.68E-07, 2.45E-07, 4.68E-05, 8.32E-08, 1.78E-06, 1.62E-08, 3.98E-08};
-    static_assert(numAtoms == default_abundancies.size(), "Incorrect number of default abundancies");
+    static_assert(numAtoms == defaultAbundancies.size(), "Incorrect number of default abundancies");
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -32,7 +32,7 @@ void XRayAtomicGasMix::setupSelfBefore()
 
     // verify the number of abundancies; if the list is empty, use our default list
     if (_abundancies.empty())
-        _abundancies = default_abundancies;
+        _abundancies = defaultAbundancies;
     else if (_abundancies.size() != numAtoms)
         throw FATALERROR("The abundancies list must have exactly " + std::to_string(numAtoms) + " values");
 }

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -1,0 +1,135 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "XRayAtomicGasMix.hpp"
+#include "Constants.hpp"
+#include "FatalError.hpp"
+#include "MaterialState.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // support the elements with atomic number up to 30
+    // H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar, K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
+    constexpr size_t numAtoms = 30;
+
+    // default abundancies taken from Table 2 of Anders & Grevesse (1989), the default abundance table in Xspec
+    constexpr std::initializer_list<double> default_abundancies = {
+        1.00E+00, 9.77E-02, 1.45E-11, 1.41E-11, 3.98E-10, 3.63E-04, 1.12E-04, 8.51E-04, 3.63E-08, 1.23E-04,
+        2.14E-06, 3.80E-05, 2.95E-06, 3.55E-05, 2.82E-07, 1.62E-05, 3.16E-07, 3.63E-06, 1.32E-07, 2.29E-06,
+        1.26E-09, 9.77E-08, 1.00E-08, 4.68E-07, 2.45E-07, 4.68E-05, 8.32E-08, 1.78E-06, 1.62E-08, 3.98E-08};
+    static_assert(numAtoms == default_abundancies.size(), "Incorrect number of default abundancies");
+}
+
+////////////////////////////////////////////////////////////////////
+
+void XRayAtomicGasMix::setupSelfBefore()
+{
+    MaterialMix::setupSelfBefore();
+
+    // verify the number of abundancies; if the list is empty, use our default list
+    if (_abundancies.empty())
+        _abundancies = default_abundancies;
+    else if (_abundancies.size() != numAtoms)
+        throw FATALERROR("The abundancies list must have exactly " + std::to_string(numAtoms) + " values");
+}
+
+////////////////////////////////////////////////////////////////////
+
+MaterialMix::MaterialType XRayAtomicGasMix::materialType() const
+{
+    return MaterialType::Gas;
+}
+
+////////////////////////////////////////////////////////////////////
+
+bool XRayAtomicGasMix::hasScatteringDispersion() const
+{
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////
+
+vector<StateVariable> XRayAtomicGasMix::specificStateVariableInfo() const
+{
+    return vector<StateVariable>{StateVariable::numberDensity()};
+}
+
+////////////////////////////////////////////////////////////////////
+
+double XRayAtomicGasMix::mass() const
+{
+    return Constants::Mproton();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double XRayAtomicGasMix::sectionAbs(double lambda) const
+{
+    (void)lambda;
+    return 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double XRayAtomicGasMix::sectionSca(double lambda) const
+{
+    (void)lambda;
+    return 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double XRayAtomicGasMix::sectionExt(double lambda) const
+{
+    (void)lambda;
+    return 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double XRayAtomicGasMix::opacityAbs(double lambda, const MaterialState* state, const PhotonPacket* /*pp*/) const
+{
+    double number = state->numberDensity();
+    return number > 0. ? sectionAbs(lambda) * number : 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double XRayAtomicGasMix::opacitySca(double lambda, const MaterialState* state, const PhotonPacket* /*pp*/) const
+{
+    double number = state->numberDensity();
+    return number > 0. ? sectionSca(lambda) * number : 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double XRayAtomicGasMix::opacityExt(double lambda, const MaterialState* state, const PhotonPacket* /*pp*/) const
+{
+    double number = state->numberDensity();
+    return number > 0. ? sectionExt(lambda) * number : 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void XRayAtomicGasMix::peeloffScattering(double& /*I*/, double& /*Q*/, double& /*U*/, double& /*V*/, double& /*lambda*/,
+                                         double /*w*/, Direction /*bfkobs*/, Direction /*bfky*/,
+                                         const MaterialState* /*state*/, const PhotonPacket* /*pp*/) const
+{}
+
+////////////////////////////////////////////////////////////////////
+
+void XRayAtomicGasMix::performScattering(double /*lambda*/, const MaterialState* /*state*/, PhotonPacket* /*pp*/) const
+{}
+
+////////////////////////////////////////////////////////////////////
+
+double XRayAtomicGasMix::indicativeTemperature(const MaterialState* /*state*/, const Array& /*Jv*/) const
+{
+    return temperature();
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -1,0 +1,220 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef XRAYATOMICGASMIX_HPP
+#define XRAYATOMICGASMIX_HPP
+
+#include "MaterialMix.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** The XRayAtomicGasMix class describes the material properties related to photo-absorption and
+    fluorescence by atomic gas in the X-ray wavelength range. The class assumes a gas containing a
+    mixture of non-ionized elements with atomic numbers from 1 (hydrogen) up to 30 (zinc). The
+    spatial density distribution of the gas is established by setting the hydrogen density. The
+    relative abundances of the 30 elements and the temperature of the gas can be configured by the
+    user as constant properties. In other words, the abundances and the temperature are considered
+    to be spatially constant (for a given medium component), while the overall density can
+    obviously vary across space as usual.
+
+    Photo-absorption by an atom is the process where the energy of a photon is used to liberate a
+    bound electron from one of the electron shells of the atom. This class supports
+    photo-absorption by any of the 30 elements in the gas for any of the electron shells, i.e. up
+    to the K, L, M, or N shell depending on the atomic number of the element. The corresponding
+    cross sections can be found in the literature (see below).
+
+    Fluorescence (in this context) is the process where an electron from a higher energy level
+    "falls" into an empty space created by photo-absorption, emitting a new photon with a different
+    energy. For each electron shell and for each possible fluorescence transition towards that
+    shell, the \em yield defines the the probability that such fluorescence event occurs after an
+    electron has been liberated in that shell. This class supports K\f$\alpha\f$ and K\f$\beta\f$
+    fluorescence (transitions from higher shells towards the K shell) for all elements in the gas.
+    The corresponding yields can be found in the literature (see below).
+
+    Because fluorescence only occurs as the result of a photo-absorption event, this class
+    implements fluorescence as a form of scattering (where the wavelength of the photon being
+    scattered changes) as opposed to emission. This allows both photo-absorption and fluorescence
+    to be treated during primary emission. A possible drawback is that the weaker fluorescence
+    lines will be represented by a fairly small number of photon packets.
+
+    <b>Configuring the simulation</b>
+
+    In addition to a medium component configured with the material mix represented by this class,
+    simulations will usually include primary sources and possibly a dust medium. As indicated
+    above, there is no need to include secondary emission, so the simulation mode can be set to
+    "ExtinctionOnly" and there is no need to store the radiation field. The resulting continuum
+    spectrum and absorption and emission features can be recorded by a single instrument configured
+    with a high-resolution wavelength grid, or separate instruments can be configured with
+    wavelength grids to resolve specific features of interest.
+
+    The input model must define the spatial distribution of the hydrogen number density
+    \f$n_\mathrm{H} = n_\mathrm{HI} + n_\mathrm{HII} + 2\,n_\mathrm{H2}\f$, i.e. including atomic,
+    ionized, and molecular hydrogen. Note the factor 2 in this equation; \f$n_\mathrm{H}\f$ in fact
+    specifies the number of hydrogen protons per volume rather than the number of hydrogen-like
+    particles per volume.
+
+    If this material mix is associated with a geometric medium component, the geometry defines the
+    spatial density distribution \f$n_\mathrm{H}\f$. Alternatively, if the material mix is
+    associated with a subclass of ImportedMedium, the spatial density distribution is read from an
+    input file. In that case, the ski file attributes \em importMetallicity, \em importTemperature,
+    and \em importVariableMixParams must be left at 'false'. For example, if bulk velocities are
+    also imported for this medium component (i.e. \em importVelocity is 'true'), the column order
+    would be \f[ ..., n_\mathrm{H}, v_\mathrm{x}, v_\mathrm{y}, v_\mathrm{z} \f]
+
+    The relative abundances of the 30 elements in the gas and the temperature of the gas are
+    configured in the ski file as constant properties. In other words, the abundances and the
+    temperature are considered to be spatially constant (for a given medium component). If the list
+    of abundances is left empty in the ski file, default abundancies are used, taken from Table 2
+    of Anders & Grevesse (1989), the default abundance table in Xspec. In the default list, the
+    abundance of hydrogen is set to unity. However, it is acceptable to specify a hydrogen
+    abundance lower than one, for example to model an ionized hydrogen fraction.
+
+    <b>Extinction (photo-absorption) cross section</b>
+
+    ...
+
+    <b>Scattering (fluorescence) cross section</b>
+
+    ...
+
+    <b>Performing scattering (fluorescence)</b>
+
+    ...
+
+    */
+class XRayAtomicGasMix : public MaterialMix
+{
+    ITEM_CONCRETE(XRayAtomicGasMix, MaterialMix,
+                  "A gas mix supporting photo-absorption and fluorescence for X-ray wavelengths")
+
+        PROPERTY_DOUBLE_LIST(abundancies, "the abundancies for the elements with atomic number Z = 1,...,30")
+        ATTRIBUTE_MIN_VALUE(abundancies, "[0")
+        ATTRIBUTE_MAX_VALUE(abundancies, "1]")
+        ATTRIBUTE_REQUIRED_IF(abundancies, "false")
+        ATTRIBUTE_DISPLAYED_IF(abundancies, "Level2")
+
+        PROPERTY_DOUBLE(temperature, "the temperature of the gas")
+        ATTRIBUTE_QUANTITY(temperature, "temperature")
+        ATTRIBUTE_MIN_VALUE(temperature, "[3")  // gas temperature must be above local Universe T_CMB
+        ATTRIBUTE_MAX_VALUE(temperature, "1e9]")
+        ATTRIBUTE_DEFAULT_VALUE(temperature, "1e4")
+        ATTRIBUTE_DISPLAYED_IF(temperature, "Level2")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function precalculates relevant cross sections and relative constribution over a
+        high-resolution wavelength grid. */
+    void setupSelfBefore() override;
+
+    //======== Capabilities =======
+
+public:
+    /** This function returns the fundamental material type represented by this material mix, which
+        is MaterialType::Gas. */
+    MaterialType materialType() const override;
+
+    /** This function returns true, indicating that a scattering interaction for this material mix
+        may adjust the wavelength of the interacting photon packet. */
+    bool hasScatteringDispersion() const override;
+
+    //======== Medium state setup =======
+
+public:
+    /** This function returns a list of StateVariable objects describing the specific state
+        variables used by the receiving material mix. For this class, the function returns just the
+        descriptor for the number density. */
+    vector<StateVariable> specificStateVariableInfo() const override;
+
+    //======== Low-level material properties =======
+
+public:
+    /** This function returns the mass of a hydrogen atom. */
+    double mass() const override;
+
+    /** This function returns the absorption (i.e. extinction minus fluorescence) cross section per
+        hydrogen atom at the given wavelength and using the abundances and temperature configured
+        for this material mix. */
+    double sectionAbs(double lambda) const override;
+
+    /** This function returns the scattering (i.e. fluorescence) cross section per hydrogen atom at
+        the given wavelength and using the abundances and temperature configured for this material
+        mix. */
+    double sectionSca(double lambda) const override;
+
+    /** This function returns the extinction cross section per hydrogen atom at the given
+        wavelength and using the abundances and temperature configured for this material mix. */
+    double sectionExt(double lambda) const override;
+
+    //======== High-level photon life cycle =======
+
+    /** This function returns the absorption (i.e. extinction minus fluorescence) opacity at the
+        given wavelength and material state, using the abundances and temperature configured for
+        this material mix. The photon packet properties are not used. */
+    double opacityAbs(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function returns the scattering (i.e. fluorescence) opacity at the given wavelength
+        and material state, using the abundances and temperature configured for this material mix.
+        The photon packet properties are not used. */
+    double opacitySca(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function returns the extinction opacity at the given wavelength and material state,
+        using the abundances and temperature configured for this material mix. The photon packet
+        properties are not used. */
+    double opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function calculates the contribution of the medium component associated with this
+        material mix to the peel-off photon luminosity, polarization state, and wavelength shift
+        for the given wavelength, geometry, material state, and photon properties. The
+        contributions to the Stokes vector components are added to the incoming values of the \em
+        I, \em Q, \em U, \em V arguments. If there is wavelength shift, the new wavelength value
+        replaces the incoming value of the \em lambda argument.
+
+        Since we force the peel-off photon packet to be scattered from the direction \f${\bf{k}}\f$
+        into the direction \f${\bf{k}}_{\text{obs}}\f$, the corresponding biasing factor is given
+        by the probability that a photon packet would be scattered into the direction
+        \f${\bf{k}}_{\text{obs}}\f$ if its original propagation direction was \f${\bf{k}}\f$. For a
+        given medium component, this biasing factor is equal to the value of the scattering phase
+        function \f$\Phi({\bf{k}},{\bf{k}}_{\text{obs}})\f$ for that medium component. If there are
+        multiple medium components, the aggregated biasing factor is the mean of the scattering
+        phase function values weighted using the relative opacities for the various components. The
+        relative opacity weight for the current component is specified as argument \em w. */
+    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
+                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function performs a scattering event on the specified photon packet in the spatial
+        cell and medium component represented by the specified material state and the receiving
+        material mix. Most of the properties of the photon packet remain unaltered, including the
+        position and the luminosity. The properties that change include the number of scattering
+        events experienced by the photon packet, which is increased by one, the propagation
+        direction, which is generated randomly, the wavelength, which is properly Doppler-shifted
+        for the bulk velocity of the medium, and the polarization state, which may be affected by
+        the scattering process.
+
+        The calculation takes all physical processes into account, including the bulk velocity and
+        Hubble expansion velocity in the cell, any relevant material state variables such as the
+        temperature of a gas medium, and any relevant properties of the incoming photon packet such
+        as the polarization state. The first argument specifies the perceived wavelength of the
+        photon packet at the scattering location so that this value does not need to be
+        recalculated within the function. */
+    void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const override;
+
+    //======== Temperature =======
+
+    /** This function returns an indicative temperature of the material mix when it would be
+        embedded in a given radiation field. The implementation in this class ignores the radiation
+        field and returns the (spatially constant) temperature configured for this material mix. */
+    double indicativeTemperature(const MaterialState* state, const Array& Jv) const override;
+
+    //======================== Data Members ========================
+
+private:
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -73,15 +73,43 @@
 
     <b>Extinction (photo-absorption) cross section</b>
 
-    ...
+    The total extinction cross section per hydrogen atom for this material mix is obtained by
+    accumulating the photo-absorption cross sections for all shells and for all individual
+    elements, weighted by element abundancy, and convolved with a Gaussian profile reflecting each
+    element's thermal velocity. Because the abundancies and the temperature are fixed, this
+    calculation can be performed during setup and the result stored, discretized on a
+    high-resolution wavelength grid for later retrieval.
+
+    Verner and Yakovlev (1995, www.pa.uky.edu/~verner/photo.html) provide analytic fits to the
+    photo-absorption cross sections \f$\sigma_{ph}(E)\f$ as a function of photon energy \f$E\f$ for
+    the ground-state shells of the first 30 atomic elements:
+
+    \f[\begin{aligned} \sigma_{ph}(E) &= \begin{cases} 0 & E < E_\mathrm{th} \\ \sigma_0 \,
+    F(E/E_0) & E \ge E_\mathrm{th} \end{cases}, \\ F(y) &= \left[(y-1)^2+y_{\rm w}^2 \right]y^{-Q}
+    \left(1+ \sqrt{(y/y_{\rm a})} \right )^{-P}, \\ Q&=5.5+l-0.5P, \end{aligned} \f]
+
+    with \f$E_\mathrm{th}\f$ the tabulated ionization threshold energy, \f$\sigma_0\f$, \f$E_0\f$,
+    \f$y_{\rm w}\f$, \f$y_{\rm a}\f$ and \f$P\f$ five tabulated fitting parameters, and \f$l\f$ the
+    subshell orbital quantum number (\f$l=0, 1, 2, 3\f$ for s, p, d, f orbitals respectively).
 
     <b>Scattering (fluorescence) cross section</b>
 
-    ...
+    The total "scattering" cross section per hydrogen atom for this material mix is obtained
+    similarly, but now including only the K shell photo-absorption cross section for each element
+    and multiplying by the appropriate fluorescence yields in addition to element abundancy.
+
+    The total "absorption" cross section is then simply obtained by subtracting the "scattering"
+    cross section from the extinction cross section.
 
     <b>Performing scattering (fluorescence)</b>
 
-    ...
+    The function performing an actual scattering event randomly selects one of the supported
+    fluorescence transitions (i.e. K\f$\alpha\f$ or K\f$\beta\f$ for one of the supported
+    elements). The relative probabilities for these transitions (as a function of incoming photon
+    packet wavelength) are also calculated during setup. The selected transition determines the
+    fluorescence wavelength. The outgoing photon packet wavelength is then obtained by adding a
+    random Gaussian dispersion reflecting the interacting element's thermal velocity. The emission
+    direction is isotropic.
 
     */
 class XRayAtomicGasMix : public MaterialMix

--- a/SMILE/serialize/XmlHierarchyCreator.cpp
+++ b/SMILE/serialize/XmlHierarchyCreator.cpp
@@ -139,8 +139,11 @@ namespace
                                        + "' is (are) out of range " + handler->rangeDescription());
             }
             else
-                _reader.throwError("Value '" + value + "' for property '" + handler->name()
-                                   + "' can't be converted to list of doubles");
+            {
+                if (!StringUtils::squeeze(value).empty())
+                    _reader.throwError("Value '" + value + "' for property '" + handler->name()
+                                       + "' can't be converted to list of doubles");
+            }
         }
 
         void visitPropertyHandler(ItemPropertyHandler* handler) override

--- a/SMILE/wizard/DoubleListPropertyWizardPane.cpp
+++ b/SMILE/wizard/DoubleListPropertyWizardPane.cpp
@@ -16,6 +16,7 @@ namespace
     // returns true if text is a valid double list, and all numbers are within range
     bool isValidAndInRange(DoubleListPropertyHandler* hdlr, string text)
     {
+        if (text.empty() && !hdlr->isRequired()) return true;
         if (!hdlr->isValidDoubleList(text)) return false;
         return hdlr->isInRange(hdlr->toDoubleList(text));
     }
@@ -32,7 +33,7 @@ namespace
     // sets the default value for this property, if there is one
     void setDefaultValue(DoubleListPropertyHandler* hdlr, QLineEdit* field)
     {
-        if (hdlr->hasDefaultValue())
+        if (hdlr->hasDefaultValue() || !hdlr->isRequired())
         {
             field->setText(QString::fromStdString(hdlr->toString(hdlr->defaultValue())));
             hdlr->setValue(hdlr->defaultValue());
@@ -75,6 +76,7 @@ DoubleListPropertyWizardPane::DoubleListPropertyWizardPane(std::unique_ptr<Prope
 
     // if the property has been configured, put its value in the text field
     // otherwise, if there is a default value, put that in both the text field and the property value
+    // otherwise, if the property is optional, put an empty string in both the text field and the property value
     // otherwise, just empty the text field (an invalid value that will have to be updated by the user)
     if (hdlr->isConfigured())
         _field->setText(QString::fromStdString(hdlr->toString(hdlr->value())));


### PR DESCRIPTION
**Description**
This update adds stub implementations (with empty functions and some documentation) for CO and X-ray atomic gas mixes. At this point, the new classes cannot be configured in the ski file (because they are not included in the simulation item registry).

**Motivation**
Adding these non-working implementations will facilitate joint development efforts.
