### PR TITLE
Allow multiple media components to change the wavelength during scattering

### DIFF
--- a/SKIRT/core/CarbonMonoxideGasMix.cpp
+++ b/SKIRT/core/CarbonMonoxideGasMix.cpp
@@ -176,7 +176,7 @@ double CarbonMonoxideGasMix::opacityExt(double lambda, const MaterialState* stat
 ////////////////////////////////////////////////////////////////////
 
 void CarbonMonoxideGasMix::peeloffScattering(double& /*I*/, double& /*Q*/, double& /*U*/, double& /*V*/,
-                                             double& /*lambda*/, double /*w*/, Direction /*bfkobs*/, Direction /*bfky*/,
+                                             double& /*lambda*/, Direction /*bfkobs*/, Direction /*bfky*/,
                                              const MaterialState* /*state*/, const PhotonPacket* /*pp*/) const
 {}
 

--- a/SKIRT/core/CarbonMonoxideGasMix.hpp
+++ b/SKIRT/core/CarbonMonoxideGasMix.hpp
@@ -253,8 +253,8 @@ public:
     double opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function does nothing because the CO lines do not scatter. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
-                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
+    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+                           const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function does nothing because the CO lines do not scatter. */
     void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const override;

--- a/SKIRT/core/ComptonPhaseFunction.cpp
+++ b/SKIRT/core/ComptonPhaseFunction.cpp
@@ -95,7 +95,7 @@ double ComptonPhaseFunction::generateCosineFromPhaseFunction(double x) const
 
 ////////////////////////////////////////////////////////////////////
 
-void ComptonPhaseFunction::peeloffScattering(double& I, double& lambda, double w, Direction bfk, Direction bfkobs) const
+void ComptonPhaseFunction::peeloffScattering(double& I, double& lambda, Direction bfk, Direction bfkobs) const
 {
     double x = scaledEnergy(lambda);
 
@@ -104,7 +104,7 @@ void ComptonPhaseFunction::peeloffScattering(double& I, double& lambda, double w
     double value = phaseFunctionValueForCosine(x, costheta);
 
     // accumulate the weighted sum in the intensity
-    I += w * value;
+    I += value;
 
     // adjust the wavelength
     lambda *= inverseComptonfactor(x, costheta);

--- a/SKIRT/core/ComptonPhaseFunction.hpp
+++ b/SKIRT/core/ComptonPhaseFunction.hpp
@@ -75,10 +75,9 @@ public:
         photon luminosity for the given geometry and wavelength, and determines the adjusted
         wavelength of the outgoing photon packet. The luminosity contribution is added to the
         incoming value of the \em I argument, and the adjusted wavelength is stored in the \em
-        lambda argument. The \em w argument specifies the relative opacity weighting factor for
-        this medium component. See the description of the MaterialMix::peeloffScattering() function
+        lambda argument. See the description of the MaterialMix::peeloffScattering() function
         for more information. */
-    void peeloffScattering(double& I, double& lambda, double w, Direction bfk, Direction bfkobs) const;
+    void peeloffScattering(double& I, double& lambda, Direction bfk, Direction bfkobs) const;
 
     /** Given the incoming photon packet wavelength and direction this function calculates a
         randomly sampled new propagation direction for a Compton scattering event, and determines

--- a/SKIRT/core/Configuration.cpp
+++ b/SKIRT/core/Configuration.cpp
@@ -291,7 +291,7 @@ void Configuration::setupSelfBefore()
 
     // check for scattering dispersion
     for (auto medium : ms->media())
-        if (medium->mix()->hasScatteringDispersion()) _hasDispersion = true;
+        if (medium->mix()->hasScatteringDispersion()) _hasScatteringDispersion = true;
 
     // check for magnetic fields
     for (int h = 0; h != numMedia; ++h)
@@ -415,7 +415,7 @@ void Configuration::setupSelfAfter()
     }
 
     // disable path length stretching if the wavelength of a photon packet can change during its lifetime
-    if ((_hasMovingMedia || _hasDispersion || _hubbleExpansionRate || _hasLymanAlpha) && _forceScattering
+    if ((_hasMovingMedia || _hasScatteringDispersion || _hubbleExpansionRate || _hasLymanAlpha) && _forceScattering
         && _pathLengthBias > 0.)
     {
         log->warning("  Disabling path length stretching to allow Doppler shifts to be properly sampled");

--- a/SKIRT/core/Configuration.hpp
+++ b/SKIRT/core/Configuration.hpp
@@ -200,6 +200,10 @@ public:
         weight factors. */
     bool hasMultipleConstantSectionMedia() const { return _hasMultipleConstantSectionMedia; }
 
+    /** Returns true if a scattering interaction for one or more media may adjust the wavelength of
+        the interacting photon packet, and false otherwise. */
+    bool hasScatteringDispersion() const { return _hasScatteringDispersion; }
+
     /** Returns true if all media in the simulation support polarization, and false if none of the
         media do. A mixture of support and no support for polarization is not allowed and will
         cause a fatal error during setup. */
@@ -414,7 +418,7 @@ private:
     bool _hasConstantPerceivedWavelength{false};
     bool _hasSingleConstantSectionMedium{false};
     bool _hasMultipleConstantSectionMedia{false};
-    bool _hasDispersion{false};
+    bool _hasScatteringDispersion{false};
     bool _hasPolarization{false};
     bool _hasSpheroidalPolarization{false};
 

--- a/SKIRT/core/DipolePhaseFunction.cpp
+++ b/SKIRT/core/DipolePhaseFunction.cpp
@@ -119,8 +119,8 @@ namespace
 
 ////////////////////////////////////////////////////////////////////
 
-void DipolePhaseFunction::peeloffScattering(double& I, double& Q, double& U, double& V, double w, Direction bfk,
-                                            Direction bfkobs, Direction bfky, const StokesVector* sv) const
+void DipolePhaseFunction::peeloffScattering(double& I, double& Q, double& U, double& V, Direction bfk, Direction bfkobs,
+                                            Direction bfky, const StokesVector* sv) const
 {
     if (!_includePolarization)
     {
@@ -129,7 +129,7 @@ void DipolePhaseFunction::peeloffScattering(double& I, double& Q, double& U, dou
         double value = phaseFunctionValueForCosine(costheta);
 
         // accumulate the weighted sum in the intensity
-        I += w * value;
+        I += value;
     }
     else
     {
@@ -152,11 +152,10 @@ void DipolePhaseFunction::peeloffScattering(double& I, double& Q, double& U, dou
         svnew.rotateIntoPlane(bfkobs, bfky);
 
         // acumulate the weighted sum of all Stokes components to support polarization
-        w *= value;
-        I += w * svnew.stokesI();
-        Q += w * svnew.stokesQ();
-        U += w * svnew.stokesU();
-        V += w * svnew.stokesV();
+        I += value * svnew.stokesI();
+        Q += value * svnew.stokesQ();
+        U += value * svnew.stokesU();
+        V += value * svnew.stokesV();
     }
 }
 

--- a/SKIRT/core/DipolePhaseFunction.hpp
+++ b/SKIRT/core/DipolePhaseFunction.hpp
@@ -116,11 +116,10 @@ public:
     /** This function calculates the contribution of a dipole scattering event to the peel-off
         photon luminosity and polarization state for the given geometry and polarization state. The
         contributions to the Stokes vector components are added to the incoming values of the \em
-        I, \em Q, \em U, \em V arguments. The \em w argument specifies the relative opacity
-        weighting factor for this medium component. See the description of the
+        I, \em Q, \em U, \em V arguments. See the description of the
         MaterialMix::peeloffScattering() function for more information. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double w, Direction bfk, Direction bfkobs,
-                           Direction bfky, const StokesVector* sv) const;
+    void peeloffScattering(double& I, double& Q, double& U, double& V, Direction bfk, Direction bfkobs, Direction bfky,
+                           const StokesVector* sv) const;
 
     /** Given the incoming photon packet direction and polarization state, this function calculates
         and returns a randomly sampled new propagation direction for a dipole scattering event, and

--- a/SKIRT/core/DustMix.cpp
+++ b/SKIRT/core/DustMix.cpp
@@ -379,7 +379,7 @@ namespace
 
 ////////////////////////////////////////////////////////////////////
 
-void DustMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
+void DustMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs,
                                 Direction bfky, const MaterialState* /*state*/, const PhotonPacket* pp) const
 {
     switch (scatteringMode())
@@ -393,7 +393,7 @@ void DustMix::peeloffScattering(double& I, double& Q, double& U, double& V, doub
             double value = (1.0 - g) * (1.0 + g) / sqrt(t * t * t);
 
             // accumulate the weighted sum in the intensity (no support for polarization in this case)
-            I += w * value;
+            I += value;
             break;
         }
         case DustMix::ScatteringMode::MaterialPhaseFunction:
@@ -403,7 +403,7 @@ void DustMix::peeloffScattering(double& I, double& Q, double& U, double& V, doub
             double value = phaseFunctionValueForCosine(lambda, costheta);
 
             // accumulate the weighted sum in the intensity (no support for polarization in this case)
-            I += w * value;
+            I += value;
             break;
         }
         case DustMix::ScatteringMode::SphericalPolarization:
@@ -428,11 +428,10 @@ void DustMix::peeloffScattering(double& I, double& Q, double& U, double& V, doub
             sv.rotateIntoPlane(bfkobs, bfky);
 
             // acumulate the weighted sum of all Stokes components to support polarization
-            w *= value;
-            I += w * sv.stokesI();
-            Q += w * sv.stokesQ();
-            U += w * sv.stokesU();
-            V += w * sv.stokesV();
+            I += value * sv.stokesI();
+            Q += value * sv.stokesQ();
+            U += value * sv.stokesU();
+            V += value * sv.stokesV();
             break;
         }
     }

--- a/SKIRT/core/DustMix.hpp
+++ b/SKIRT/core/DustMix.hpp
@@ -220,11 +220,9 @@ public:
         from the reference direction in the previous scattering plane into the peel-off scattering
         plane, applies the Mueller matrix on the Stokes vector, and further rotates the Stokes
         vector from the reference direction in the peel-off scattering plane to the x-axis of the
-        instrument to which the peel-off photon packet is headed. If there are multiple medium
-        components, the relative opacity weighting factor applies not just to the luminosity but
-        also to the other components of the Stokes vector. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
-                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
+        instrument to which the peel-off photon packet is headed. */
+    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+                           const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state and the receiving

--- a/SKIRT/core/ElectronMix.cpp
+++ b/SKIRT/core/ElectronMix.cpp
@@ -196,9 +196,9 @@ void ElectronMix::peeloffScattering(double& I, double& Q, double& U, double& V, 
 
     // perform the scattering event in the electron rest frame
     if (_hasCompton && lambda < comptonWL)
-        _cpf.peeloffScattering(I, lambda, 1., pp->direction(), bfkobs);
+        _cpf.peeloffScattering(I, lambda, pp->direction(), bfkobs);
     else
-        _dpf.peeloffScattering(I, Q, U, V, 1., pp->direction(), bfkobs, bfky, pp);
+        _dpf.peeloffScattering(I, Q, U, V, pp->direction(), bfkobs, bfky, pp);
 
     // if we have dispersion, adjust the outgoing wavelength from the electron rest frame
     if (_hasDispersion)

--- a/SKIRT/core/ElectronMix.hpp
+++ b/SKIRT/core/ElectronMix.hpp
@@ -171,8 +171,8 @@ public:
         For electrons, the function implements wavelenth-independent dipole scattering without or
         with support for polarization depending on the user-configured \em includePolarization
         property. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
-                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
+    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+                           const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state and the receiving

--- a/SKIRT/core/FragmentDustMixDecorator.hpp
+++ b/SKIRT/core/FragmentDustMixDecorator.hpp
@@ -182,8 +182,8 @@ public:
         for the given wavelength, geometry, material state, and photon properties. The relative
         weight of each fragment's contribution is adjusted by the relative scattering opacity of
         the fragment. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
-                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
+    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+                           const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state. Specifically, it

--- a/SKIRT/core/LyaNeutralHydrogenGasMix.cpp
+++ b/SKIRT/core/LyaNeutralHydrogenGasMix.cpp
@@ -132,7 +132,7 @@ double LyaNeutralHydrogenGasMix::opacityExt(double lambda, const MaterialState* 
 
 ////////////////////////////////////////////////////////////////////
 
-void LyaNeutralHydrogenGasMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w,
+void LyaNeutralHydrogenGasMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda,
                                                  Direction bfkobs, Direction bfky, const MaterialState* state,
                                                  const PhotonPacket* pp) const
 {
@@ -149,19 +149,16 @@ void LyaNeutralHydrogenGasMix::peeloffScattering(double& I, double& Q, double& U
     if (scatinfo->dipole)
     {
         // contribution of dipole scattering with or without polarization
-        _dpf.peeloffScattering(I, Q, U, V, w, pp->direction(), bfkobs, bfky, pp);
+        _dpf.peeloffScattering(I, Q, U, V, 1., pp->direction(), bfkobs, bfky, pp);
     }
     else
     {
-        // isotropic scattering removes polarization,
-        // so the contribution is trivially 1 (multiplied by the weight for this component)
-        I += w;
+        // isotropic scattering removes polarization, so the contribution is trivially 1
+        I += 1.;
     }
 
-    // for a random fraction of the events governed by the relative Lya contribution,
     // Doppler-shift the photon packet wavelength into and out of the atom frame
-    if (random()->uniform() <= w)
-        lambda = LyaUtils::shiftWavelength(lambda, scatinfo->velocity, pp->direction(), bfkobs);
+    lambda = LyaUtils::shiftWavelength(lambda, scatinfo->velocity, pp->direction(), bfkobs);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/LyaNeutralHydrogenGasMix.cpp
+++ b/SKIRT/core/LyaNeutralHydrogenGasMix.cpp
@@ -149,7 +149,7 @@ void LyaNeutralHydrogenGasMix::peeloffScattering(double& I, double& Q, double& U
     if (scatinfo->dipole)
     {
         // contribution of dipole scattering with or without polarization
-        _dpf.peeloffScattering(I, Q, U, V, 1., pp->direction(), bfkobs, bfky, pp);
+        _dpf.peeloffScattering(I, Q, U, V, pp->direction(), bfkobs, bfky, pp);
     }
     else
     {

--- a/SKIRT/core/LyaNeutralHydrogenGasMix.hpp
+++ b/SKIRT/core/LyaNeutralHydrogenGasMix.hpp
@@ -144,8 +144,8 @@ public:
         For the Lyman-alpha material mix, the function implements resonant scattering without or
         with support for polarization depending on the user-configured \em includePolarization
         property. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
-                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
+    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+                           const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state and the receiving

--- a/SKIRT/core/MaterialMix.hpp
+++ b/SKIRT/core/MaterialMix.hpp
@@ -372,13 +372,9 @@ public:
         by the probability that a photon packet would be scattered into the direction
         \f${\bf{k}}_{\text{obs}}\f$ if its original propagation direction was \f${\bf{k}}\f$. For a
         given medium component, this biasing factor is equal to the value of the scattering phase
-        function \f$\Phi({\bf{k}},{\bf{k}}_{\text{obs}})\f$ for that medium component. If there are
-        multiple medium components, the aggregated biasing factor is the mean of the scattering
-        phase function values weighted using the relative opacities for the various components. The
-        relative opacity weight for the current component is specified as argument \em w. */
-    virtual void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w,
-                                   Direction bfkobs, Direction bfky, const MaterialState* state,
-                                   const PhotonPacket* pp) const = 0;
+        function \f$\Phi({\bf{k}},{\bf{k}}_{\text{obs}})\f$ for that medium component. */
+    virtual void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs,
+                                   Direction bfky, const MaterialState* state, const PhotonPacket* pp) const = 0;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state and the receiving

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -614,31 +614,48 @@ bool MediumSystem::weightsForScattering(ShortArray& wv, double lambda, const Pho
 
 ////////////////////////////////////////////////////////////////////
 
-void MediumSystem::peelOffScattering(double lambda, const ShortArray& wv, Direction bfkobs, Direction bfky,
+void MediumSystem::peelOffScattering(const ShortArray& wv, double lambda, Direction bfkobs, Direction bfky,
                                      PhotonPacket* pp, PhotonPacket* ppp) const
 {
     // get the cell hosting the scattering event
     int m = pp->interactionCellIndex();
 
-    // the outgoing wavelength (in the bulk velocity frame)
-    double emissionLambda = lambda;
-
-    // calculate the weighted sum of the effects on the Stokes vector and on the wavelength for all media
+    // calculate the weighted sum of the effects on the Stokes vector for all media
+    // we assume the wavelength does not change
     double I = 0., Q = 0., U = 0., V = 0.;
     for (int h = 0; h != _numMedia; ++h)
     {
-        double localLambda = lambda;
+        double Ih = 0., Qh = 0., Uh = 0., Vh = 0.;
         MaterialState mst(_state, m, h);
         pp->setScatteringComponent(h);
-        mix(m, h)->peeloffScattering(I, Q, U, V, localLambda, wv[h], bfkobs, bfky, &mst, pp);
-
-        // if this material mix changed the wavelength, it is copied as the outgoing wavelength
-        // if more than one material mix changes the wavelength, only the last one is preserved
-        if (localLambda != lambda) emissionLambda = localLambda;
+        mix(m, h)->peeloffScattering(Ih, Qh, Uh, Vh, lambda, bfkobs, bfky, &mst, pp);
+        I += Ih * wv[h];
+        Q += Qh * wv[h];
+        U += Uh * wv[h];
+        V += Vh * wv[h];
     }
 
     // pass the result to the peel-off photon packet
-    ppp->launchScatteringPeelOff(pp, bfkobs, _state.bulkVelocity(m), emissionLambda, I);
+    ppp->launchScatteringPeelOff(pp, bfkobs, _state.bulkVelocity(m), lambda, I);
+    if (_config->hasPolarization()) ppp->setPolarized(I, Q, U, V, pp->normal());
+}
+
+////////////////////////////////////////////////////////////////////
+
+void MediumSystem::peelOffScattering(int h, double w, double lambda, Direction bfkobs, Direction bfky, PhotonPacket* pp,
+                                     PhotonPacket* ppp) const
+{
+    // get the cell hosting the scattering event
+    int m = pp->interactionCellIndex();
+
+    // calculate the effects on the Stokes vector and on the wavelength for this medium component
+    double I = 0., Q = 0., U = 0., V = 0.;
+    MaterialState mst(_state, m, h);
+    pp->setScatteringComponent(h);
+    mix(m, h)->peeloffScattering(I, Q, U, V, lambda, bfkobs, bfky, &mst, pp);
+
+    // pass the result to the peel-off photon packet
+    ppp->launchScatteringPeelOff(pp, bfkobs, _state.bulkVelocity(m), lambda, I * w);
     if (_config->hasPolarization()) ppp->setPolarized(I, Q, U, V, pp->normal());
 }
 

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -629,6 +629,7 @@ void MediumSystem::peelOffScattering(double lambda, const ShortArray& wv, Direct
     {
         double localLambda = lambda;
         MaterialState mst(_state, m, h);
+        pp->setScatteringComponent(h);
         mix(m, h)->peeloffScattering(I, Q, U, V, localLambda, wv[h], bfkobs, bfky, &mst, pp);
 
         // if this material mix changed the wavelength, it is copied as the outgoing wavelength
@@ -668,6 +669,7 @@ void MediumSystem::simulateScattering(Random* random, PhotonPacket* pp) const
 
     // actually perform the scattering event for this cell and medium component
     MaterialState mst(_state, m, h);
+    pp->setScatteringComponent(h);
     mix(m, h)->performScattering(lambda, &mst, pp);
 }
 

--- a/SKIRT/core/MediumSystem.hpp
+++ b/SKIRT/core/MediumSystem.hpp
@@ -337,17 +337,32 @@ public:
         scatter in this cell). */
     bool weightsForScattering(ShortArray& wv, double lambda, const PhotonPacket* pp) const;
 
-    /** This function calculates the peel-off photon luminosity, polarization state, and wavelength
-        shift for the given wavelength, geometry, and incoming photon packet. The specified
-        placeholder peel-off photon packet is then launched using this information so that it is
-        ready for detection by instruments.
+    /** This function calculates the consolidated peel-off photon luminosity and polarization state
+        for all medium components with the specified opacity weights and for the given perceived
+        wavelength, geometry, and incoming photon packet. The specified placeholder peel-off photon
+        packet is then launched using this information so that it is ready for detection by
+        instruments. If there are multiple medium components, the contributions to the luminosity
+        (and if polarization is enabled, to the other components of the Stokes vector) are weighted
+        by the specified relative opacities of the various medium components.
 
-        If there are multiple medium components, the contributions to the luminosity (and if
-        polarization is enabled, to the other components of the Stokes vector) are weighted by the
-        relative opacities of the various medium components. If more than one component changes the
-        wavelength, only the wavelength shift returned by the last one is preserved (for lack of a
-        better strategy). */
-    void peelOffScattering(double lambda, const ShortArray& wv, Direction bfkobs, Direction bfky, PhotonPacket* pp,
+        This function should be called only when scattering events cannot change the wavelength,
+        i.e. the hasScatteringDispersion() function returns false for all material mixes in the
+        simulation. In this case, a single consolidated peel-off photon packet can be sent to each
+        intrument. */
+    void peelOffScattering(const ShortArray& wv, double lambda, Direction bfkobs, Direction bfky, PhotonPacket* pp,
+                           PhotonPacket* ppp) const;
+
+    /** This function calculates the peel-off photon luminosity, polarization state, and wavelength
+        for the specified medium component with the specified opacity weight and for the given
+        perceived wavelength, geometry, and incoming photon packet. The specified placeholder
+        peel-off photon packet is then launched using this information so that it is ready for
+        detection by instruments.
+
+        This function should be used when scattering events may change the wavelength, i.e. the
+        hasScatteringDispersion() function returns true for one or more material mixes in the
+        simulation. In this case, a seperate peel-off photon packet for each medium component must
+        be sent to each intrument. */
+    void peelOffScattering(int h, double w, double lambda, Direction bfkobs, Direction bfky, PhotonPacket* pp,
                            PhotonPacket* ppp) const;
 
     /** This function simulates a random walk scattering event of a photon packet. Most of the

--- a/SKIRT/core/SpinFlipHydrogenGasMix.cpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.cpp
@@ -212,9 +212,8 @@ double SpinFlipHydrogenGasMix::opacityExt(double lambda, const MaterialState* st
 ////////////////////////////////////////////////////////////////////
 
 void SpinFlipHydrogenGasMix::peeloffScattering(double& /*I*/, double& /*Q*/, double& /*U*/, double& /*V*/,
-                                               double& /*lambda*/, double /*w*/, Direction /*bfkobs*/,
-                                               Direction /*bfky*/, const MaterialState* /*state*/,
-                                               const PhotonPacket* /*pp*/) const
+                                               double& /*lambda*/, Direction /*bfkobs*/, Direction /*bfky*/,
+                                               const MaterialState* /*state*/, const PhotonPacket* /*pp*/) const
 {}
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SpinFlipHydrogenGasMix.hpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.hpp
@@ -291,8 +291,8 @@ public:
     double opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function does nothing because the 21 cm line does not scatter. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
-                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
+    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+                           const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function does nothing because the 21 cm line does not scatter. */
     void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const override;

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -602,23 +602,19 @@ void XRayAtomicGasMix::setScatteringInfoIfNeeded(PhotonPacket::ScatteringInfo* s
 ////////////////////////////////////////////////////////////////////
 
 void XRayAtomicGasMix::peeloffScattering(double& I, double& /*Q*/, double& /*U*/, double& /*V*/, double& lambda,
-                                         double w, Direction bfkobs, Direction /*bfky*/, const MaterialState* /*state*/,
+                                         Direction bfkobs, Direction /*bfky*/, const MaterialState* /*state*/,
                                          const PhotonPacket* pp) const
 {
     // draw a random fluorescence channel and atom velocity, unless a previous peel-off stored this already
     auto scatinfo = const_cast<PhotonPacket*>(pp)->getScatteringInfo();
     setScatteringInfoIfNeeded(scatinfo, lambda);
 
-    // isotropic scattering, so the contribution is trivially 1 (multiplied by the weight for this component)
-    I += w;
+    // isotropic scattering, so the contribution is trivially 1
+    I += 1.;
 
-    // for a random fraction of the events governed by the weight for this component,
     // update the photon packet wavelength to the wavelength of this fluorescence transition,
     // Doppler-shifted out of the atom velocity frame
-    if (random()->uniform() <= w)
-    {
-        lambda = PhotonPacket::shiftedEmissionWavelength(_fluolambdav[scatinfo->species], bfkobs, scatinfo->velocity);
-    }
+    lambda = PhotonPacket::shiftedEmissionWavelength(_fluolambdav[scatinfo->species], bfkobs, scatinfo->velocity);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -478,13 +478,12 @@ void XRayAtomicGasMix::setupSelfBefore()
     _fluocumprobvv.resize(numLambda, 0);
 
     // provide temporary array for the non-normalized fluorescence contributions (at the current wavelength)
-    Array flucontribv(fluorescenceParams.size());
+    Array fluocontribv(fluorescenceParams.size());
 
     // calculate the above for every wavelength; as before, leave the values for the outer wavelength points at zero
     for (int ell = 1; ell < numLambda - 1; ++ell)
     {
         double E = wavelengthToFromEnergy(lambdav[ell]);
-        double sigma = 0.;
 
         // interate over both cross section and fluorescence parameter sets in sync
         const auto* flp = fluorescenceParams.begin();
@@ -497,15 +496,13 @@ void XRayAtomicGasMix::setupSelfBefore()
             while (flp != fluorescenceParams.end() && flp->Z == csp.Z && flp->n == csp.n)
             {
                 double contribution = crossSection(E, sigmoid, csp) * _abundancies[csp.Z - 1] * flp->omega;
-                sigma += contribution;
-                flucontribv[flp - fluorescenceParams.begin()] = contribution;
+                fluocontribv[flp - fluorescenceParams.begin()] = contribution;
                 flp++;
             }
         }
 
-        // store the cross section and determine the normalized cumulative probability distribution
-        _sigmascav[ell] = sigma;
-        NR::cdf(_fluocumprobvv[ell], flucontribv);
+        // determine the normalized cumulative probability distribution and the cross section
+        _sigmascav[ell] = NR::cdf(_fluocumprobvv[ell], fluocontribv);
     }
 }
 

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -253,8 +253,8 @@ public:
         intensity is simply given by the relative weight of this component in the overall
         simulation. The outgoing wavelength is determined by Doppler-shifting the rest wavelength
         of the selected fluorescence transition for the selected atom velocity. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, double w, Direction bfkobs,
-                           Direction bfky, const MaterialState* state, const PhotonPacket* pp) const override;
+    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+                           const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state and the receiving

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -8,6 +8,7 @@
 
 #include "ArrayTable.hpp"
 #include "MaterialMix.hpp"
+#include "PhotonPacket.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
@@ -238,9 +239,10 @@ public:
     double opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
 
 private:
-    /** This private function draws a random fluorescence transition and atom velocity and stores this
-        information in the photon packet, unless a previous peel-off stored this already. */
-    void setScatteringInfoIfNeeded(PhotonPacket* pp, double lambda) const;
+    /** This private function draws a random fluorescence transition and atom velocity and stores
+        this information in the photon packet's scattering information record, unless a previous
+        peel-off stored this already. */
+    void setScatteringInfoIfNeeded(PhotonPacket::ScatteringInfo* scatinfo, double lambda) const;
 
 public:
     /** This function calculates the contribution of the medium component associated with this

--- a/SKIRT/utils/PhotonPacket.cpp
+++ b/SKIRT/utils/PhotonPacket.cpp
@@ -35,7 +35,7 @@ void PhotonPacket::launch(size_t historyIndex, double lambda, double L, Position
     else
         setUnpolarized();
     _hasObservedOpticalDepth = false;
-    _hasScatteringInfo = false;
+    _scatteringInfo.clear();
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -71,7 +71,7 @@ void PhotonPacket::launchEmissionPeelOff(const PhotonPacket* pp, Direction bfk)
     else
         setUnpolarized();
     _hasObservedOpticalDepth = false;
-    _hasScatteringInfo = false;
+    _scatteringInfo.clear();
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -88,7 +88,7 @@ void PhotonPacket::launchScatteringPeelOff(const PhotonPacket* pp, Direction bfk
     setDirection(bfk);
     setUnpolarized();
     _hasObservedOpticalDepth = false;
-    _hasScatteringInfo = false;
+    _scatteringInfo.clear();
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -106,7 +106,7 @@ void PhotonPacket::scatter(Direction bfk, Vec bfv, double lambda)
     setDirection(bfk);
     _lambda = bfv.isNull() ? lambda : shiftedEmissionWavelength(lambda, bfk, bfv);
     _hasObservedOpticalDepth = false;
-    _hasScatteringInfo = false;
+    _scatteringInfo.clear();
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -136,6 +136,18 @@ double PhotonPacket::shiftedReceptionWavelength(double photonWavelength, Directi
 double PhotonPacket::perceivedWavelength(Vec receiverVelocity, double expansionVelocity) const
 {
     return shiftedReceptionWavelength(_lambda, direction(), receiverVelocity, expansionVelocity);
+}
+
+////////////////////////////////////////////////////////////////////
+
+PhotonPacket::ScatteringInfo* PhotonPacket::getScatteringInfo()
+{
+    for (auto& candidate : _scatteringInfo)
+    {
+        if (_h == candidate._h) return &candidate;
+    }
+    _scatteringInfo.emplace_back(_h);
+    return &_scatteringInfo.back();
 }
 
 ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
With this update, the code properly supports models that include two or more media that may change a photon packet's wavelength during a scattering event, for example caused by the thermal velocity of the interacting particle. Previously, wavelength changes from multiple media would interfere, producing incorrect results.

**Motivation**
We can now combine, for example, gas with x-ray fluorescence (implemented as scattering) and electrons exhibiting Compton scattering in a simulation.

**Technical description**
This feature required two fairly technical adjustments to the code:
- All peel-off and random walk scattering operations for a given scattering event share the same randomly generated values including the interacting particle velocity. The related mechanism has been extended to store this information for each medium component separately.
- As long as the wavelength cannot change during a scattering event, the contributions from all medium components are consolidated in a single peel-off photon packet for each instrument. However, it is impossible to consolidate the effect of multiple wavelengths in a single photon packet. Thus, if the wavelength _can_ change, the code now sends a separate peel-off photon packet for each medium component to each instrument.

**Tests**
Appriopriate functional tests have been added; everything else still works.
