### PR TITLE
XRayAtomicGasMix with zero temperature disables thermal dispersion

### DIFF
--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -595,7 +595,7 @@ void XRayAtomicGasMix::setScatteringInfoIfNeeded(PhotonPacket::ScatteringInfo* s
     {
         scatinfo->valid = true;
         scatinfo->species = NR::locateClip(_fluocumprobvv[indexForLambda(lambda)], random()->uniform());
-        scatinfo->velocity = _fluovthermv[scatinfo->species] * random()->maxwell();
+        if (temperature() > 0.) scatinfo->velocity = _fluovthermv[scatinfo->species] * random()->maxwell();
     }
 }
 
@@ -614,7 +614,8 @@ void XRayAtomicGasMix::peeloffScattering(double& I, double& /*Q*/, double& /*U*/
 
     // update the photon packet wavelength to the wavelength of this fluorescence transition,
     // Doppler-shifted out of the atom velocity frame
-    lambda = PhotonPacket::shiftedEmissionWavelength(_fluolambdav[scatinfo->species], bfkobs, scatinfo->velocity);
+    lambda = _fluolambdav[scatinfo->species];
+    if (temperature() > 0.) lambda = PhotonPacket::shiftedEmissionWavelength(lambda, bfkobs, scatinfo->velocity);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -630,7 +631,8 @@ void XRayAtomicGasMix::performScattering(double lambda, const MaterialState* sta
 
     // update the photon packet wavelength to the wavelength of this fluorescence transition,
     // Doppler-shifted out of the atom velocity frame
-    lambda = PhotonPacket::shiftedEmissionWavelength(_fluolambdav[scatinfo->species], bfknew, scatinfo->velocity);
+    lambda = _fluolambdav[scatinfo->species];
+    if (temperature() > 0.) lambda = PhotonPacket::shiftedEmissionWavelength(lambda, bfknew, scatinfo->velocity);
 
     // execute the scattering event in the photon packet
     pp->scatter(bfknew, state->bulkVelocity(), lambda);

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -157,9 +157,9 @@ class XRayAtomicGasMix : public MaterialMix
         ATTRIBUTE_REQUIRED_IF(abundancies, "false")
         ATTRIBUTE_DISPLAYED_IF(abundancies, "Level2")
 
-        PROPERTY_DOUBLE(temperature, "the temperature of the gas")
+        PROPERTY_DOUBLE(temperature, "the temperature of the gas or zero to disable thermal dispersion")
         ATTRIBUTE_QUANTITY(temperature, "temperature")
-        ATTRIBUTE_MIN_VALUE(temperature, "[3")  // gas temperature must be above local Universe T_CMB
+        ATTRIBUTE_MIN_VALUE(temperature, "[0")
         ATTRIBUTE_MAX_VALUE(temperature, "1e9]")
         ATTRIBUTE_DEFAULT_VALUE(temperature, "1e4")
         ATTRIBUTE_DISPLAYED_IF(temperature, "Level2")

--- a/SMILE/serialize/ConsoleHierarchyCreator.cpp
+++ b/SMILE/serialize/ConsoleHierarchyCreator.cpp
@@ -309,7 +309,7 @@ double ConsoleHierarchyCreator::promptForDouble(string prefix, const DoublePrope
 vector<double> ConsoleHierarchyCreator::promptForDoubleList(string prefix, const DoubleListPropertyHandler* handler)
 {
     // get default and min/max values and verify that default is in range
-    bool hasDef = handler->hasDefaultValue();
+    bool hasDef = handler->hasDefaultValue() || !handler->isRequired();
     vector<double> def = handler->defaultValue();
     if (hasDef && !handler->isInRange(def)) throw FATALERROR("Default double list value out of range");
 

--- a/SMILE/wizard/DoubleListPropertyWizardPane.cpp
+++ b/SMILE/wizard/DoubleListPropertyWizardPane.cpp
@@ -25,7 +25,8 @@ namespace
     string headerMessage(DoubleListPropertyHandler* hdlr)
     {
         string message = "Enter " + hdlr->title() + " " + hdlr->rangeDescription();
-        if (hdlr->hasDefaultValue()) message += " (" + hdlr->toString(hdlr->defaultValue()) + ")";
+        if (hdlr->hasDefaultValue() || !hdlr->isRequired())
+            message += " (" + hdlr->toString(hdlr->defaultValue()) + ")";
         message += ":";
         return message;
     }


### PR DESCRIPTION
**Description**
This update allows specifying a zero gas temperature for the `XRayAtomicGasMix` class. In that case, thermal velocity dispersion is completely disabled for both extinction and fluorescence, resulting in an execution time improvement of 5% or so, depending on the simulated model.

Also, it is now possible in the console Q&A to enter an empty list for the abundancies, indicating that the default abundancies should be used.

**Motivation**
For models with cold gas, when comparing to observations that don't resolve the thermal dispersion anyway, we can just as well disable this dispersion in the simulations and win some execution time.

**Tests**
New functional tests have been added.
