### PR TITLE
Accelerate sampling the Compton scattering angle

### DIFF
--- a/SKIRT/core/ComptonPhaseFunction.cpp
+++ b/SKIRT/core/ComptonPhaseFunction.cpp
@@ -12,11 +12,6 @@
 
 namespace
 {
-    // discretization of the phase function over scattering angle: theta from 0 to pi, index t
-    constexpr int numTheta = 361;
-    constexpr int maxTheta = numTheta - 1;
-    constexpr double deltaTheta = M_PI / maxTheta;
-
     // returns the photon energy scaled to the electron rest energy: h nu / m_e c^2
     double scaledEnergy(double lambda) { return (Constants::h() / Constants::Melectron() / Constants::c()) / lambda; }
 
@@ -43,19 +38,6 @@ void ComptonPhaseFunction::initialize(Random* random)
 {
     // cache random number generator
     _random = random;
-
-    // construct a theta grid and precalculate values used in generateCosineFromPhaseFunction()
-    // to accelerate construction of the cumulative phase function distribution
-    _costhetav.resize(numTheta);
-    _sinthetav.resize(numTheta);
-    _sin2thetav.resize(numTheta);
-    for (int t = 0; t != numTheta; ++t)
-    {
-        double theta = t * deltaTheta;
-        _costhetav[t] = cos(theta);
-        _sinthetav[t] = sin(theta);
-        _sin2thetav[t] = _sinthetav[t] * _sinthetav[t];
-    }
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -80,17 +62,31 @@ double ComptonPhaseFunction::phaseFunctionValueForCosine(double x, double costhe
 
 double ComptonPhaseFunction::generateCosineFromPhaseFunction(double x) const
 {
-    // construct the normalized cumulative phase function distribution for this x
-    Array thetaXv;
-    NR::cdf(thetaXv, maxTheta, [this, x](int t) {
-        t += 1;
-        double C = comptonFactor(x, _costhetav[t]);
-        double phase = C * C * C + C - C * C * _sin2thetav[t];
-        return phase * _sinthetav[t];
-    });
+    // get scaled energy with different definition
+    double e = 2. * x;
 
-    // draw a random cosine from this distribution
-    return _random->cdfLinLin(_costhetav, thetaXv);
+    // draw random number from the distribution of the inverse Compton factor
+    double r;
+    while (true)
+    {
+        double xi1 = _random->uniform();
+        double xi2 = _random->uniform();
+        double xi3 = _random->uniform();
+
+        if (xi1 <= 27. / (2. * e + 29.))
+        {
+            r = (e + 1.) / (e * xi2 + 1.);
+            if (xi3 <= (std::pow((e + 2. - 2. * r) / e, 2) + 1.) / 2.) break;
+        }
+        else
+        {
+            r = e * xi2 + 1;
+            if (xi3 <= 6.75 * (r - 1) * (r - 1) / (r * r * r)) break;
+        }
+    }
+
+    // convert from inverse Compton factor to cosine theta
+    return 1 - (r - 1) / x;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ComptonPhaseFunction.hpp
+++ b/SKIRT/core/ComptonPhaseFunction.hpp
@@ -40,7 +40,20 @@ class Random;
     where \f$\theta\f$ is the scattering angle and \f$C(x, \theta)\f$ is the Compton factor defined
     earlier.
 
-    */
+    <b>Sampling from the phase function</b>
+
+    To draw a random scattering angle from the phase function, we use the algorithm described by
+    Hua et al. 1997 (Computers in Physics 11, 660), which is a variation of the technique first
+    suggested by Pei 1979 and often referred to as Khan's technique. A combination of composition
+    and rejection methods, the algorithm avoids expensive operations and has a rejection rate of
+    about 1/3 depending on the energy.
+
+    Using our notation for the scaled energy \f$x\f$ of the incoming photon (see above), Hua et al.
+    1997 define the doubled scaled incoming photon energy \f$\epsilon=2 x\f$ and the inverse
+    Compton factor \f$r = 1 + x (1-\cos\theta)\f$. The sampling algorithm draws a random number for
+    \f$r\f$, i.e. from the probability distribution for the inverse Compton factor at a given
+    energy. The scattering angle can then easily be obtained from the definition of the inverse
+    Compton factor. */
 class ComptonPhaseFunction
 {
     //============= Construction - Setup - Destruction =============
@@ -90,11 +103,6 @@ public:
 private:
     // the simulation's random number generator - initialized by initialize()
     Random* _random{nullptr};
-
-    // precalculated discretizations - initialized by initialize()
-    Array _costhetav;
-    Array _sinthetav;
-    Array _sin2thetav;
 };
 
 ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
This update implements a variation on Khan's technique as described by Hua et al. 1997 (Computers in Physics 11, 660) to sample a scattering angle from the Compton phase function (for scattering by electrons at high photon energies). The algorithm is a combination of the composition and rejection method; it avoids expensive operations and has a rejection rate of about 1/3 depending on the energy.


**Motivation**
As compared to the previous implementation using numerical inversion of the cumulative distribution (which had to be constructed for every scattering event), this method uses less memory and runs faster. A model with a power-law source surrounded by a shell of electrons with optical depth of 10 at 100 keV (essentially all photon packets are scattered at least once) runs almost twice as fast. For more involved configurations with complex geometries and/or including other media types, the performance gain will be smaller.

**Tests**
Verified the existing functional tests.
