### PR TITLE
Allow text column files as resources

### DIFF
--- a/SKIRT/core/TextInFile.cpp
+++ b/SKIRT/core/TextInFile.cpp
@@ -58,14 +58,14 @@ namespace
 
 ////////////////////////////////////////////////////////////////////
 
-TextInFile::TextInFile(const SimulationItem* item, string filename, string description)
+TextInFile::TextInFile(const SimulationItem* item, string filename, string description, bool resource)
 {
     // remember the units system and the logger
     _units = item->find<Units>();
     _log = item->find<Log>();
 
-    // get the filepath
-    string filepath = item->find<FilePaths>()->input(filename);
+    // get the full path for the resource or for the input file
+    string filepath = resource ? FilePaths::resource(filename) : item->find<FilePaths>()->input(filename);
 
     // if the file is in SKIRT stored column format, open a binary file
     if (StringUtils::endsWith(filepath, ".scol"))

--- a/SKIRT/core/TextInFile.hpp
+++ b/SKIRT/core/TextInFile.hpp
@@ -82,12 +82,14 @@ public:
         the input file path and an appropriate logger; (2) \em filename specifies the name of the
         file, including filename extension but excluding path and simulation prefix; (3) \em
         description describes the contents of the file for use in the log message issued after the
-        file is successfully opened.
+        file is successfully opened; (4) \em resource indicates whether the file is located in the
+        resources directory (true) or in the regular user input file directory (false, the default
+        value).
 
         If the specified file has the \c .scol filename extension, the implementation automatically
         switches to reading the binary SKIRT column file format instead of the regular column text
         format. For more information, see the class header. */
-    TextInFile(const SimulationItem* item, string filename, string description);
+    TextInFile(const SimulationItem* item, string filename, string description, bool resource = false);
 
     /** This function closes the file if it was not already closed. It is best to call close() or
         allow the object to go out of scope before logging other messages or starting another


### PR DESCRIPTION
**Description**
This is a technical update that allows providing built-in resources formatted as text column files or their binary equivalent `.scol` (SKIRT column format).

**Motivation**
All current resources are provided as SKIRT stored tables (`.stab`), which represent quantities tabulated over one or more axes and interpolated between the axis points. Non-interpolatable data such as a list of Einstein coefficients for selected electronic transitions does not lend itself to this format but can be easily represented as a column text file (or its binary equivalent to save space and accelerate reading).
