### PR TITLE
Add convergence mechanism for iterative semi-dynamic medium state updates

### DIFF
--- a/SKIRT/core/CarbonMonoxideGasMix.cpp
+++ b/SKIRT/core/CarbonMonoxideGasMix.cpp
@@ -120,6 +120,13 @@ UpdateStatus CarbonMonoxideGasMix::updateSpecificState(MaterialState* state, con
 
 ////////////////////////////////////////////////////////////////////
 
+bool CarbonMonoxideGasMix::isSpecificStateConverged(int numCells, int /*numUpdated*/, int numNotConverged) const
+{
+    return static_cast<double>(numNotConverged) / static_cast<double>(numCells) <= maxFractionNotConverged();
+}
+
+////////////////////////////////////////////////////////////////////
+
 double CarbonMonoxideGasMix::mass() const
 {
     return Constants::Mproton();  // ... should be CO molecule mass

--- a/SKIRT/core/CarbonMonoxideGasMix.cpp
+++ b/SKIRT/core/CarbonMonoxideGasMix.cpp
@@ -100,8 +100,10 @@ void CarbonMonoxideGasMix::initializeSpecificState(MaterialState* state, double 
 
 ////////////////////////////////////////////////////////////////////
 
-bool CarbonMonoxideGasMix::updateSpecificState(MaterialState* state, const Array& Jv) const
+UpdateStatus CarbonMonoxideGasMix::updateSpecificState(MaterialState* state, const Array& Jv) const
 {
+    UpdateStatus status;
+
     // leave the properties untouched if the cell does not contain any material for this component
     if (state->numberDensity() > 0.)
     {
@@ -111,9 +113,9 @@ bool CarbonMonoxideGasMix::updateSpecificState(MaterialState* state, const Array
         // set the level populations (here some arbitrary example value
         for (int p = 1; p <= numLevelPops; ++p) state->setCustom(p, 1.);
 
-        return true;
+        status.updateConverged();
     }
-    return false;
+    return status;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/CarbonMonoxideGasMix.hpp
+++ b/SKIRT/core/CarbonMonoxideGasMix.hpp
@@ -213,8 +213,8 @@ public:
     /** Based on the specified radiation field and the input model properties found in the given
         material state, this function determines the level populations for the supported CO
         transitions and stores these results back in the given material state. The function returns
-        true if the material state has indeed be changed, and false otherwise. */
-    bool updateSpecificState(MaterialState* state, const Array& Jv) const override;
+        the update status as described for the UpdateStatus class. */
+    UpdateStatus updateSpecificState(MaterialState* state, const Array& Jv) const override;
 
     //======== Low-level material properties =======
 

--- a/SKIRT/core/CarbonMonoxideGasMix.hpp
+++ b/SKIRT/core/CarbonMonoxideGasMix.hpp
@@ -160,6 +160,12 @@ class CarbonMonoxideGasMix : public EmittingGasMix
         ATTRIBUTE_DEFAULT_VALUE(defaultMolecularHydrogenRatio, "100")
         ATTRIBUTE_DISPLAYED_IF(defaultMolecularHydrogenRatio, "Level2")
 
+        PROPERTY_DOUBLE(maxFractionNotConverged, "the maximum fraction of not-converged spatial cells")
+        ATTRIBUTE_MIN_VALUE(maxFractionNotConverged, "[0")
+        ATTRIBUTE_MAX_VALUE(maxFractionNotConverged, "1]")
+        ATTRIBUTE_DEFAULT_VALUE(maxFractionNotConverged, "0.001")
+        ATTRIBUTE_DISPLAYED_IF(maxFractionNotConverged, "Level3")
+
     ITEM_END()
 
     //============= Construction - Setup - Destruction =============
@@ -215,6 +221,14 @@ public:
         transitions and stores these results back in the given material state. The function returns
         the update status as described for the UpdateStatus class. */
     UpdateStatus updateSpecificState(MaterialState* state, const Array& Jv) const override;
+
+    /** This function returns true if the state of the medium component corresponding to this
+        material mix can be considered to be converged based on the given spatial cell statistics,
+        and false otherwise. The \em numCells, \em numUpdated and \em numNotConverged arguments
+        specify respectively the number of spatial cells in the simulation, the number of cells
+        updated during the latest update cycle, and the number of updated cells that have not yet
+        converged. */
+    bool isSpecificStateConverged(int numCells, int numUpdated, int numNotConverged) const override;
 
     //======== Low-level material properties =======
 

--- a/SKIRT/core/DynamicStateRecipe.cpp
+++ b/SKIRT/core/DynamicStateRecipe.cpp
@@ -9,20 +9,8 @@
 
 ////////////////////////////////////////////////////////////////////
 
-bool DynamicStateRecipe::endUpdate(int numCells, int numUpdated, int numNotConverged)
+bool DynamicStateRecipe::endUpdate(int /*numCells*/, int /*numUpdated*/, int numNotConverged)
 {
-    // log converged or not
-    if (numNotConverged <= maxNotConvergedCells())
-        find<Log>()->info(type() + " has converged");
-    else
-        find<Log>()->info(type() + " has not yet converged");
-
-    // log extra info
-    find<Log>()->info("  Updated cells: " + std::to_string(numUpdated) + " out of " + std::to_string(numCells) + " ("
-                      + StringUtils::toString(100. * numUpdated / numCells, 'f', 2) + " %)");
-    find<Log>()->info("  Not converged: " + std::to_string(numNotConverged) + " out of " + std::to_string(numCells)
-                      + " (" + StringUtils::toString(100. * numNotConverged / numCells, 'f', 2) + " %)");
-
     return numNotConverged <= maxNotConvergedCells();
 }
 

--- a/SKIRT/core/DynamicStateRecipe.hpp
+++ b/SKIRT/core/DynamicStateRecipe.hpp
@@ -28,7 +28,7 @@ class MaterialState;
     At the end of each iteration step, the functions for each configured recipe are called in the
     following order: the beginUpdate() function; the update() function for each spatial cell and
     for each medium component in the simulation; and finally the endUpdate() function. The latter
-    function also returns a Boolean that indicates whether the iteration can be considered to have
+    function returns a Boolean that indicates whether the iteration can be considered to have
     converged for this recipe.
 
     A recipe is allowed to discover information about the configuration of the simulation, for
@@ -100,19 +100,18 @@ public:
     virtual UpdateStatus update(MaterialState* state, const Array& Jv) = 0;
 
     /** This function is called after updating has completed at the end of each iteration step. It
-        returns true if the recipe has converged and false if not. In addition to determining the
-        binary yes/no convergence result, the function also issues a log message reporting the
-        degree of convergence. To assist with these tasks, the \em numCells, \em numUpdated and \em
-        numNotConverged arguments specify respectively the number of spatial cells in the
-        simulation, the number of cells updated during this update cycle, and the number of updated
-        cells that have not yet converged.
+        returns true if, based on the given spatial cell statistics, the recipe has converged.
+        Otherwise it returns false. The \em numCells, \em numUpdated and \em numNotConverged
+        arguments specify respectively the number of spatial cells in the simulation, the number of
+        cells updated during this update cycle, and the number of updated cells that have not yet
+        converged.
 
-        The default implementation in this base class provides basic logging and returns true if
-        the actual number of not-converged cells exceeds the configured maximum number of
-        not-converged cells, and false otherwise. Subclasses may provide more complex
-        implementations. In case a recipe needs to tracks additional information in the update()
-        function, the tracked data must be aggregated across processes because the update()
-        function can be called from separate parallel processes. */
+        The default implementation in this base class returns true if the actual number of
+        not-converged cells does not exceed the configured maximum number of not-converged cells,
+        and false otherwise. Subclasses may provide more complex implementations. In case a recipe
+        needs to tracks additional information in the update() function, the tracked data must be
+        aggregated across processes because the update() function can be called from separate
+        parallel processes. */
     virtual bool endUpdate(int numCells, int numUpdated, int numNotConverged);
 };
 

--- a/SKIRT/core/MaterialMix.cpp
+++ b/SKIRT/core/MaterialMix.cpp
@@ -117,6 +117,13 @@ UpdateStatus MaterialMix::updateSpecificState(MaterialState* /*state*/, const Ar
 
 ////////////////////////////////////////////////////////////////////
 
+bool MaterialMix::isSpecificStateConverged(int /*numCells*/, int /*numUpdated*/, int /*numNotConverged*/) const
+{
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////
+
 DisjointWavelengthGrid* MaterialMix::emissionWavelengthGrid() const
 {
     throw FATALERROR("This function implementation should never be called");

--- a/SKIRT/core/MaterialMix.cpp
+++ b/SKIRT/core/MaterialMix.cpp
@@ -110,7 +110,7 @@ double MaterialMix::asymmpar(double /*lambda*/) const
 
 ////////////////////////////////////////////////////////////////////
 
-bool MaterialMix::updateSpecificState(MaterialState* /*state*/, const Array& /*Jv*/) const
+UpdateStatus MaterialMix::updateSpecificState(MaterialState* /*state*/, const Array& /*Jv*/) const
 {
     throw FATALERROR("This function implementation should never be called");
 }

--- a/SKIRT/core/MaterialMix.hpp
+++ b/SKIRT/core/MaterialMix.hpp
@@ -397,15 +397,30 @@ public:
     //======== Medium state updates =======
 
     /** If this material mix has a semi-dynamic medium state, i.e. if the
-        hasSemiDynamicMediumState() function returns true, this function is invoked at the end of a
-        primary emission segment. Based on the specified radiation field, if needed, the function
-        updates any values in the specific material state for this cell that may inform the local
-        emission and/or extinction properties of the material during secondary emission. The
-        function returns the update status as described for the UpdateStatus class. This
-        information is used to optimize the synchronization of changes across multiple processes
-        and to determine whether an iterative update has converged, if applicable. The default
-        implementation in this base class throws a fatal error. */
+        hasSemiDynamicMediumState() function returns true, this function is invoked for each
+        spatial cell at the end of an emission segment that in turn will be followed by a secondary
+        emission segment. Based on the specified radiation field, if needed, the function updates
+        any values in the specific material state for this cell and medium component that may
+        inform the local emission and/or extinction properties of the material during secondary
+        emission. The function returns the update status as described for the UpdateStatus class.
+        This information is used to optimize the synchronization of changes across multiple
+        processes and to determine whether an iterative update has converged, if applicable.
+
+        This function may be called in parallel across multiple threads and processes. It should
+        not update any information outside the specific medium state of the given cell and medium
+        component. The default implementation in this base class throws a fatal error. */
     virtual UpdateStatus updateSpecificState(MaterialState* state, const Array& Jv) const;
+
+    /** If this material mix has a semi-dynamic medium state, i.e. if the
+        hasSemiDynamicMediumState() function returns true, this function is invoked (once) \em
+        after updateSpecificState() has been called for all spatial cells. The \em numCells, \em
+        numUpdated and \em numNotConverged arguments specify respectively the number of spatial
+        cells in the simulation, the number of cells updated during this update cycle, and the
+        number of updated cells that have not yet converged. Based on this information and any
+        relevant user configuration options, the function returns true if the medium state is
+        considered to be converged and false if not. The default implementation in this base class
+        always returns true. */
+    virtual bool isSpecificStateConverged(int numCells, int numUpdated, int numNotConverged) const;
 
     //======== Secondary continuum emission =======
 

--- a/SKIRT/core/MaterialMix.hpp
+++ b/SKIRT/core/MaterialMix.hpp
@@ -11,6 +11,7 @@
 #include "SimulationItem.hpp"
 #include "SnapshotParameter.hpp"
 #include "StateVariable.hpp"
+#include "UpdateStatus.hpp"
 class Configuration;
 class MaterialState;
 class PhotonPacket;
@@ -397,13 +398,14 @@ public:
 
     /** If this material mix has a semi-dynamic medium state, i.e. if the
         hasSemiDynamicMediumState() function returns true, this function is invoked at the end of a
-        primary emission segment. Based on the specified radiation field, the function updates any
-        values in the specific material state for this cell that may inform the local emission
-        and/or extinction properties of the material during secondary emission. The function
-        returns true if the medium state has indeed be changed, and false if the medium state has
-        remained unchanged (this allows optimizing the synchronization of changes across multiple
-        processes). The default implementation in this base class throws a fatal error. */
-    virtual bool updateSpecificState(MaterialState* state, const Array& Jv) const;
+        primary emission segment. Based on the specified radiation field, if needed, the function
+        updates any values in the specific material state for this cell that may inform the local
+        emission and/or extinction properties of the material during secondary emission. The
+        function returns the update status as described for the UpdateStatus class. This
+        information is used to optimize the synchronization of changes across multiple processes
+        and to determine whether an iterative update has converged, if applicable. The default
+        implementation in this base class throws a fatal error. */
+    virtual UpdateStatus updateSpecificState(MaterialState* state, const Array& Jv) const;
 
     //======== Secondary continuum emission =======
 

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -1176,6 +1176,12 @@ bool MediumSystem::updateDynamicMediumState()
     int numUpdated, numNotConverged;
     std::tie(numUpdated, numNotConverged) = _state.synchronize(flags);
 
+    // log statistics
+    log->info("  Updated cells: " + std::to_string(numUpdated) + " out of " + std::to_string(_numCells) + " ("
+              + StringUtils::toString(100. * numUpdated / _numCells, 'f', 2) + " %)");
+    log->info("  Not converged: " + std::to_string(numNotConverged) + " out of " + std::to_string(_numCells) + " ("
+              + StringUtils::toString(100. * numNotConverged / _numCells, 'f', 2) + " %)");
+
     // tell all recipes to end the update cycle and collect convergence info
     bool converged = true;
     for (auto recipe : recipes) converged &= recipe->endUpdate(_numCells, numUpdated, numNotConverged);

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -1227,7 +1227,7 @@ bool MediumSystem::updateSemiDynamicMediumState()
 
     // collect convergence info
     bool converged = true;
-    ///    for (int h : _sdms_hv) converged &= mix(0, h)->isSpecificStateConverged(_numCells, numUpdated, numNotConverged);
+    for (int h : _sdms_hv) converged &= mix(0, h)->isSpecificStateConverged(_numCells, numUpdated, numNotConverged);
     return converged;
 }
 

--- a/SKIRT/core/MediumSystem.hpp
+++ b/SKIRT/core/MediumSystem.hpp
@@ -650,11 +650,15 @@ public:
         dynamic medium state recipe has been configured for the simulation. */
     bool updateDynamicMediumState();
 
-    /** This function updates the semi-dynamic medium state for all media that require/support such
-        an update based on the currently established radiation field by invoking the corresponding
-        material mix function for all spatial cells. The function assumes that the radiation field
-        has been calculated. */
-    void updateSemiDynamicMediumState();
+    /** This function updates the semi-dynamic medium state for all relevant medium components
+        based on the currently established radiation field. A medium component is relevant in the
+        context of this function if the hasSemiDynamicMediumState() function of its material mix
+        returns true. The update is performed by invoking the updateSpecificState() function of the
+        material mix for all spatial cells. The function returns true if the medium states for all
+        medium components have converged, and false otherwise.
+
+        This function assumes that the radiation field has been calculated. */
+    bool updateSemiDynamicMediumState();
 
     //======================== Data Members ========================
 

--- a/SKIRT/core/MediumSystem.hpp
+++ b/SKIRT/core/MediumSystem.hpp
@@ -657,7 +657,9 @@ public:
         material mix for all spatial cells. The function returns true if the medium states for all
         medium components have converged, and false otherwise.
 
-        This function assumes that the radiation field has been calculated. */
+        This function assumes that the radiation field has been calculated and that at least one
+        medium component in the simulation is configured with a material mix requiring/supporting a
+        semi-dynamic medium state. */
     bool updateSemiDynamicMediumState();
 
     //======================== Data Members ========================

--- a/SKIRT/core/MediumSystem.hpp
+++ b/SKIRT/core/MediumSystem.hpp
@@ -676,6 +676,7 @@ private:
     vector<int> _dust_hv;  // a list of indices for media components containing dust
     vector<int> _gas_hv;   // a list of indices for media components containing gas
     vector<int> _elec_hv;  // a list of indices for media components containing electrons
+    vector<int> _sdms_hv;  // a list of indices for media components with a semi-dynamic medium state
 
     // relevant for any simulation mode that stores the radiation field
     WavelengthGrid* _wavelengthGrid{0};  // index ell

--- a/SKIRT/core/SpinFlipHydrogenGasMix.cpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.cpp
@@ -100,40 +100,43 @@ void SpinFlipHydrogenGasMix::initializeSpecificState(MaterialState* state, doubl
 
 ////////////////////////////////////////////////////////////////////
 
-bool SpinFlipHydrogenGasMix::updateSpecificState(MaterialState* state, const Array& Jv) const
+UpdateStatus SpinFlipHydrogenGasMix::updateSpecificState(MaterialState* state, const Array& Jv) const
 {
     if (_indexUV < 0) throw FATALERROR("State update should not be called if there is no radiation field");
+    UpdateStatus status;
 
     // if the cell has no hydrogen or the neutral fraction is zero, then leave the atomic fraction at zero
     double nH = state->numberDensity();
     double fHIpH2 = state->custom(NEUTRAL_FRACTION);
-    if (nH <= 0. || fHIpH2 <= 0.) return false;
+    if (nH > 0. && fHIpH2 > 0.)
+    {
+        // get the radiation field
+        // scaled to the reference Milky Way radiation field at 1000 Angstrom
+        // converted from 1e6 photons/cm2/s/sr/eV to internal units W/m2/m/sr
+        constexpr double h = Constants::h();
+        constexpr double c = Constants::c();
+        constexpr double Qel = Constants::Qelectron();
+        constexpr double JMW = 1e6 * 1e4 * (h * c * h * c / (lambdaUV * lambdaUV * lambdaUV)) / Qel;
+        double U = Jv[_indexUV] / JMW;
 
-    // get the radiation field
-    // scaled to the reference Milky Way radiation field at 1000 Angstrom
-    // converted from 1e6 photons/cm2/s/sr/eV to internal units W/m2/m/sr
-    constexpr double h = Constants::h();
-    constexpr double c = Constants::c();
-    constexpr double Qel = Constants::Qelectron();
-    constexpr double JMW = 1e6 * 1e4 * (h * c * h * c / (lambdaUV * lambdaUV * lambdaUV)) / Qel;
-    double U = Jv[_indexUV] / JMW;
+        // get the metallicity scaled to the solar reference value
+        double D = state->metallicity() / 0.0127;
 
-    // get the metallicity scaled to the solar reference value
-    double D = state->metallicity() / 0.0127;
+        // perform the partitioning scheme
+        double Dstar = 1.5e-3 * log(1. + pow(3 * U, 1.7));
+        double nstar = 25e6;
+        double alpha = 2.5 * U / (1. + 0.25 * U * U);
+        double s = 0.04 / (Dstar + D);
+        double g = (1. + alpha * s + s * s) / (1. + s);
+        double Lambda = log(1. + g * pow(D, 3. / 7.) * pow(U / 15., 4. / 7.));
+        double x = pow(Lambda, 3. / 7.) * log(D / Lambda * nH / nstar);
+        double fH2 = 1. / (1. + exp(-4. * x - 3. * x * x * x));
 
-    // perform the partitioning scheme
-    double Dstar = 1.5e-3 * log(1. + pow(3 * U, 1.7));
-    double nstar = 25e6;
-    double alpha = 2.5 * U / (1. + 0.25 * U * U);
-    double s = 0.04 / (Dstar + D);
-    double g = (1. + alpha * s + s * s) / (1. + s);
-    double Lambda = log(1. + g * pow(D, 3. / 7.) * pow(U / 15., 4. / 7.));
-    double x = pow(Lambda, 3. / 7.) * log(D / Lambda * nH / nstar);
-    double fH2 = 1. / (1. + exp(-4. * x - 3. * x * x * x));
-
-    // set the atomic fraction
-    state->setCustom(ATOMIC_FRACTION, max(0., fHIpH2 - fH2));
-    return true;
+        // set the atomic fraction
+        state->setCustom(ATOMIC_FRACTION, max(0., fHIpH2 - fH2));
+        status.updateConverged();
+    }
+    return status;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SpinFlipHydrogenGasMix.hpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.hpp
@@ -250,9 +250,9 @@ public:
     /** Based on the specified radiation field and the input model properties found in the given
         material state, this function performs the partitioning scheme described in the class
         header and stores the resulting atomic hydrogen fraction back in the given material state.
-        The function returns true if the material state has indeed be changed, and false otherwise.
+        The function returns the update status as described for the UpdateStatus class.
         */
-    bool updateSpecificState(MaterialState* state, const Array& Jv) const override;
+    UpdateStatus updateSpecificState(MaterialState* state, const Array& Jv) const override;
 
     //======== Low-level material properties =======
 


### PR DESCRIPTION
**Description**
This pull request adds a convergence mechanism for iterative semi-dynamic medium state updates, similar to the mechanism already implemented for dynamic medium state updates.

**Motivation**
The `CarbonMonoxideGasMix` class calculates the electronic energy level populations (from which the emitted line spectrum is derived) during iterative semi-dynamic medium state updates, requiring a mechanism to determine convergence. In the future, similar calculations for other molecular or atomic lines will require such a mechanism as well. 

**Tests**
All functional tests still work without change, although the order of log messages related to convergence has changed in some cases. The new mechanism has been tested with a stub implementation of the `CarbonMonoxideGasMix` class. It still needs to be fully tested with an actual implementation.
