### PR TITLE
Include secondary emission in LaunchedPacketsProbe

### DIFF
--- a/SKIRT/core/SecondarySourceSystem.cpp
+++ b/SKIRT/core/SecondarySourceSystem.cpp
@@ -69,8 +69,14 @@ void SecondarySourceSystem::setupSelfBefore()
 
 void SecondarySourceSystem::installLaunchCallBack(ProbePhotonPacketInterface* callback)
 {
-    if (_callback) throw FATALERROR("Cannot install more than one photon packet launch probe");
-    _callback = callback;
+    _callbackv.push_back(callback);
+}
+
+////////////////////////////////////////////////////////////////////
+
+int SecondarySourceSystem::numSources() const
+{
+    return _sources.size();
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -131,8 +137,8 @@ void SecondarySourceSystem::launch(PhotonPacket* pp, size_t historyIndex) const
     // add origin info (the index reflects the secondary source, not the medium component)
     pp->setSecondaryOrigin(s);
 
-    // invoke launch call-back if installed
-    if (_callback) _callback->probePhotonPacket(pp);
+    // invoke any installed launch call-backs
+    for (auto callback : _callbackv) callback->probePhotonPacket(pp);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SecondarySourceSystem.hpp
+++ b/SKIRT/core/SecondarySourceSystem.hpp
@@ -199,6 +199,9 @@ public:
     //======================== Other Functions =======================
 
 public:
+    /** This function returns the number of secondary sources in the secondary source system. */
+    int numSources() const;
+
     /** This function prepares the mapping of history indices to sources and tells all sources to
         prepare their individual mapping of history indices to spatial cells. The function returns
         false if the total bolometric luminosity of the secondary sources is zero (which means no
@@ -219,7 +222,7 @@ private:
     double _xi;                         // the configured secondary source bias
 
     // initialized by installLaunchCallBack()
-    ProbePhotonPacketInterface* _callback{nullptr};  // interface to be invoked for each packet launch if nonzero
+    vector<ProbePhotonPacketInterface*> _callbackv;  // interfaces to be invoked for each packet launch
 
     // initialized by prepareForLaunch()
     double _L{0};        // the total bolometric luminosity of all sources (absolute number)

--- a/SKIRT/core/SourceSystem.cpp
+++ b/SKIRT/core/SourceSystem.cpp
@@ -44,8 +44,7 @@ void SourceSystem::setupSelfAfter()
 
 void SourceSystem::installLaunchCallBack(ProbePhotonPacketInterface* callback)
 {
-    if (_callback) throw FATALERROR("Cannot install more than one photon packet launch probe");
-    _callback = callback;
+    _callbackv.push_back(callback);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -109,8 +108,8 @@ void SourceSystem::launch(PhotonPacket* pp, size_t historyIndex) const
     // add additional info
     pp->setPrimaryOrigin(h);
 
-    // invoke launch call-back if installed
-    if (_callback) _callback->probePhotonPacket(pp);
+    // invoke any installed launch call-backs
+    for (auto callback : _callbackv) callback->probePhotonPacket(pp);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SourceSystem.hpp
+++ b/SKIRT/core/SourceSystem.hpp
@@ -140,7 +140,7 @@ private:
     double _L{0};  // the total bolometric luminosity of all sources (absolute number)
     Array _Lv;     // the relative bolometric luminosity of each source (normalized to unity)
     Array _Wv;     // the relative launch weight for each source (normalized to unity)
-    ProbePhotonPacketInterface* _callback{nullptr};  // interface to be invoked for each packet launch if nonzero
+    vector<ProbePhotonPacketInterface*> _callbackv;  // interfaces to be invoked for each packet launch
 
     // intialized by prepareForLaunch()
     double _Lpp{0};      // the average luminosity contribution for each packet


### PR DESCRIPTION
**Description**
This pull request extends the `LaunchedPacketsProbe` to include columns for secondary sources, if applicable. Also, it is now possible to include multiple `LaunchedPacketsProbe` instances in a configuration, for example to cover several distinct wavelength ranges.

**Motivation**
Exposing this information will help fine-tune secondary emission bias factors, for example in simulations with both dust and gas emission.

**Tests**
Existing functional tests still work. The column headers of the `LaunchedPacketsProbe` probe output have been updated to differentiate between primary and secondary emission.
