### PR TITLE
Improved X-ray bound-electron scattering 

### DIFF
--- a/SKIRT/core/TextInFile.hpp
+++ b/SKIRT/core/TextInFile.hpp
@@ -301,6 +301,7 @@ private:
 
     bool _hasTextOpen{false};    // true if a regular column text format file is currently open
     bool _hasBinaryOpen{false};  // true if a binary stored column format file is currently open
+    bool _isResource{false};     // true if the file is a resource (as opposed to a user input file)
     bool _hasFileInfo{false};    // becomes true if the file has column header info
     bool _hasProgInfo{false};    // becomes true if the program has added at least one column
 

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -254,7 +254,7 @@ namespace
     double interpolateQ(double x, double sintheta2, const Array& qv, const Array& fv)
     {
         double q = scaledEnergyTo12keV * x * sintheta2;
-        if (q < 1e-2) return NR::clampedValue<NR::interpolateLinLin>(q, qv, fv);
+        if (q < 1e-3) return NR::clampedValue<NR::interpolateLinLin>(q, qv, fv);
         return NR::clampedValue<NR::interpolateLogLog>(q, qv, fv);
     }
 
@@ -267,10 +267,10 @@ namespace
         Random* _random{nullptr};
 
         // precalculated discretizations
-        Array _costhetav{numTheta};
-        Array _sinthetav{numTheta};
-        Array _sin2thetav{numTheta};
-        Array _sintheta2v{numTheta};
+        Array _costhetav = Array(numTheta);
+        Array _sinthetav = Array(numTheta);
+        Array _sin2thetav = Array(numTheta);
+        Array _sintheta2v = Array(numTheta);
 
     public:
         BoundComptonHelper(SimulationItem* item)
@@ -409,10 +409,10 @@ namespace
         DipolePhaseFunction _dpf;
 
         // precalculated discretizations
-        Array _costhetav{numTheta};
-        Array _cos2thetav{numTheta};
-        Array _sinthetav{numTheta};
-        Array _sintheta2v{numTheta};
+        Array _costhetav = Array(numTheta);
+        Array _cos2thetav = Array(numTheta);
+        Array _sinthetav = Array(numTheta);
+        Array _sintheta2v = Array(numTheta);
 
     public:
         SmoothRayleighHelper(SimulationItem* item)
@@ -533,10 +533,10 @@ namespace
         DipolePhaseFunction _dpf;
 
         // precalculated discretizations
-        Array _costhetav{numTheta};
-        Array _cos2thetav{numTheta};
-        Array _sinthetav{numTheta};
-        Array _sintheta2v{numTheta};
+        Array _costhetav = Array(numTheta);
+        Array _cos2thetav = Array(numTheta);
+        Array _sinthetav = Array(numTheta);
+        Array _sintheta2v = Array(numTheta);
 
     public:
         AnomalousRayleighHelper(SimulationItem* item)
@@ -649,7 +649,6 @@ namespace
             return _random->direction(bfk, generateCosineFromPhaseFunction(x, Z));
         }
     };
-
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -976,13 +976,13 @@ void XRayAtomicGasMix::peeloffScattering(double& I, double& /*Q*/, double& /*U*/
     // Rayleigh scattering in electron rest frame
     if (scatinfo->species < static_cast<int>(numAtoms))
     {
-        _ray->peeloffScattering(I, lambda, scatinfo->species, pp->direction(), bfkobs);
+        _ray->peeloffScattering(I, lambda, scatinfo->species + 1, pp->direction(), bfkobs);
     }
 
     // Compton scattering in electron rest frame
     else if (scatinfo->species < static_cast<int>(2 * numAtoms))
     {
-        _com->peeloffScattering(I, lambda, scatinfo->species - numAtoms, pp->direction(), bfkobs);
+        _com->peeloffScattering(I, lambda, scatinfo->species - numAtoms + 1, pp->direction(), bfkobs);
     }
 
     // fluorescence
@@ -1017,13 +1017,13 @@ void XRayAtomicGasMix::performScattering(double lambda, const MaterialState* sta
     // Rayleigh scattering: determine the new propagation direction
     if (scatinfo->species < static_cast<int>(numAtoms))
     {
-        bfknew = _ray->performScattering(lambda, scatinfo->species, pp->direction());
+        bfknew = _ray->performScattering(lambda, scatinfo->species + 1, pp->direction());
     }
 
     // Compton scattering: determine the new propagation direction and wavelength
     else if (scatinfo->species < static_cast<int>(2 * numAtoms))
     {
-        bfknew = _com->performScattering(lambda, scatinfo->species - numAtoms, pp->direction());
+        bfknew = _com->performScattering(lambda, scatinfo->species - numAtoms + 1, pp->direction());
     }
 
     // fluorescence

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -309,7 +309,7 @@ namespace
     private:
         double phaseFunctionValue(double x, double costheta, int Z) const
         {
-            constexpr double norm = 3. / 16. / M_PI * Constants::sigmaThomson();
+            constexpr double norm = 3. / 4. * Constants::sigmaThomson();
             double C = comptonFactor(x, costheta);
             double sin2theta = (1 - costheta) * (1 + costheta);
             double phase = C * C * C + C - C * C * sin2theta;
@@ -454,7 +454,7 @@ namespace
     private:
         double phaseFunctionValue(double x, double costheta, int Z) const
         {
-            constexpr double norm = 3. / 16. / M_PI * Constants::sigmaThomson();
+            constexpr double norm = 3. / 4. * Constants::sigmaThomson();
             double phase = 1. + costheta * costheta;
             double section = NR::value<NR::interpolateLogLog>(x, _RSSv[0], _RSSv[Z]);
             double sintheta2 = sqrt(0.5 * (1 - costheta));
@@ -585,7 +585,7 @@ namespace
     private:
         double phaseFunctionValue(double x, double costheta, int Z) const
         {
-            constexpr double norm = 3. / 16. / M_PI * Constants::sigmaThomson();
+            constexpr double norm = 3. / 4. * Constants::sigmaThomson();
             double phase = 1. + costheta * costheta;
             double section = NR::clampedValue<NR::interpolateLogLog>(x, _RSAv[2 * Z], _RSAv[2 * Z + 1]);
             double sintheta2 = sqrt(0.5 * (1 - costheta));

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -11,35 +11,26 @@
 #include "NR.hpp"
 #include "Random.hpp"
 #include "Range.hpp"
+#include "TextInFile.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
 namespace
 {
-    // support the elements with atomic number up to 30
-    // 1   2   3   4  5  6  7  8  9  10  11  12  13  14 15 16  17  18 19  20  21  22 23  24  25  26  27  28  29  30
-    // H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar, K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
-    constexpr size_t numAtoms = 30;
+    // basic atom information
+    struct AtomParams
+    {
+        AtomParams(const Array& a) : mass(a[0]), abund(a[1]) {}
+        double mass;   // atom mass (amu)
+        double abund;  // the default or configured relative abundance (1)
+    };
 
-    // default abundancies from Table 2 of Anders & Grevesse (1989), the default abundance table in Xspec
-    constexpr std::initializer_list<double> defaultAbundancies = {
-        1.00E+00, 9.77E-02, 1.45E-11, 1.41E-11, 3.98E-10, 3.63E-04, 1.12E-04, 8.51E-04, 3.63E-08, 1.23E-04,
-        2.14E-06, 3.80E-05, 2.95E-06, 3.55E-05, 2.82E-07, 1.62E-05, 3.16E-07, 3.63E-06, 1.32E-07, 2.29E-06,
-        1.26E-09, 9.77E-08, 1.00E-08, 4.68E-07, 2.45E-07, 4.68E-05, 8.32E-08, 1.78E-06, 1.62E-08, 3.98E-08};
-    static_assert(numAtoms == defaultAbundancies.size(), "Incorrect number of default abundancies");
-
-    // atomic masses (amu) from EADL (Evaluated Atomic Data Library of the Lawrence Livermore National Laboratory)
-    constexpr std::initializer_list<double> masses = {
-        1.00790e+00, 4.00260e+00, 6.94100e+00, 9.01218e+00, 1.08100e+01, 1.20110e+01, 1.40067e+01, 1.59994e+01,
-        1.89984e+01, 2.01790e+01, 2.29898e+01, 2.43050e+01, 2.69815e+01, 2.80855e+01, 3.09738e+01, 3.20600e+01,
-        3.54530e+01, 3.99480e+01, 3.90983e+01, 4.00800e+01, 4.49559e+01, 4.79000e+01, 5.09415e+01, 5.19960e+01,
-        5.49380e+01, 5.58470e+01, 5.89332e+01, 5.87000e+01, 6.35460e+01, 6.53800e+01};
-    static_assert(numAtoms == masses.size(), "Incorrect number of masses");
-
-    // photo-absorption cross sections from Table 1 in Verner, D. A., & Yakovlev, D. G. 1995, A&AS, 109, 125
-    // downloaded from www.pa.uky.edu/~verner/photo.html and removed lines for ionized atoms
+    // photo-absorption cross section parameters
     struct CrossSectionParams
     {
+        CrossSectionParams(const Array& a)
+            : Z(a[0]), n(a[1]), l(a[2]), Eth(a[3]), E0(a[4]), sigma0(a[5]), ya(a[6]), P(a[7]), yw(a[8])
+        {}
         short Z;        // atomic number
         short n;        // principal quantum number of the shell
         short l;        // orbital quantum number of the subshell
@@ -50,250 +41,15 @@ namespace
         double P;       // fit parameter (1)
         double yw;      // fit parameter (1)
     };
-    constexpr std::initializer_list<CrossSectionParams> crossSectionParams = {
-        {1, 1, 0, 0.1360E+02, 0.4298E+00, 0.5475E+05, 0.3288E+02, 0.2963E+01, 0.0000E+00},
-        {2, 1, 0, 0.2459E+02, 0.5996E+01, 0.4470E+04, 0.2199E+01, 0.6098E+01, 0.0000E+00},
-        {3, 2, 0, 0.5392E+01, 0.3466E+01, 0.4774E+02, 0.2035E+02, 0.4423E+01, 0.0000E+00},
-        {3, 1, 0, 0.6439E+02, 0.2740E+02, 0.1564E+03, 0.3382E+02, 0.1490E+01, 0.0000E+00},
-        {4, 2, 0, 0.9323E+01, 0.3427E+01, 0.1423E+04, 0.2708E+01, 0.1064E+02, 0.0000E+00},
-        {4, 1, 0, 0.1193E+03, 0.4093E+02, 0.1306E+03, 0.1212E+03, 0.1348E+01, 0.0000E+00},
-        {5, 2, 1, 0.8298E+01, 0.6658E+01, 0.3643E+03, 0.9500E+01, 0.5469E+01, 0.5608E+00},
-        {5, 2, 0, 0.1405E+02, 0.6495E+01, 0.1525E+05, 0.1352E+01, 0.1218E+02, 0.0000E+00},
-        {5, 1, 0, 0.1940E+03, 0.6155E+02, 0.9698E+02, 0.7354E+02, 0.1438E+01, 0.0000E+00},
-        {6, 2, 1, 0.1126E+02, 0.9435E+01, 0.1152E+04, 0.5687E+01, 0.6336E+01, 0.4474E+00},
-        {6, 2, 0, 0.1939E+02, 0.1026E+02, 0.4564E+04, 0.1568E+01, 0.1085E+02, 0.0000E+00},
-        {6, 1, 0, 0.2910E+03, 0.8655E+02, 0.7421E+02, 0.5498E+02, 0.1503E+01, 0.0000E+00},
-        {7, 2, 1, 0.1453E+02, 0.1164E+02, 0.1029E+05, 0.2361E+01, 0.8821E+01, 0.4239E+00},
-        {7, 2, 0, 0.2541E+02, 0.1482E+02, 0.7722E+03, 0.2306E+01, 0.9139E+01, 0.0000E+00},
-        {7, 1, 0, 0.4048E+03, 0.1270E+03, 0.4748E+02, 0.1380E+03, 0.1252E+01, 0.0000E+00},
-        {8, 2, 1, 0.1362E+02, 0.1391E+02, 0.1220E+06, 0.1364E+01, 0.1140E+02, 0.4103E+00},
-        {8, 2, 0, 0.2848E+02, 0.1994E+02, 0.2415E+03, 0.3241E+01, 0.8037E+01, 0.0000E+00},
-        {8, 1, 0, 0.5380E+03, 0.1774E+03, 0.3237E+02, 0.3812E+03, 0.1083E+01, 0.0000E+00},
-        {9, 2, 1, 0.1742E+02, 0.1658E+02, 0.2775E+06, 0.1242E+01, 0.1249E+02, 0.3857E+00},
-        {9, 2, 0, 0.3786E+02, 0.2568E+02, 0.1097E+03, 0.4297E+01, 0.7303E+01, 0.0000E+00},
-        {9, 1, 0, 0.6940E+03, 0.2390E+03, 0.2295E+02, 0.1257E+04, 0.9638E+00, 0.0000E+00},
-        {10, 2, 1, 0.2156E+02, 0.2000E+02, 0.1691E+05, 0.2442E+01, 0.1043E+02, 0.3345E+00},
-        {10, 2, 0, 0.4847E+02, 0.3204E+02, 0.5615E+02, 0.5808E+01, 0.6678E+01, 0.0000E+00},
-        {10, 1, 0, 0.8701E+03, 0.3144E+03, 0.1664E+02, 0.2042E+06, 0.8450E+00, 0.0000E+00},
-        {11, 3, 0, 0.5139E+01, 0.5968E+01, 0.1460E+01, 0.2557E+08, 0.3789E+01, 0.0000E+00},
-        {11, 2, 1, 0.3814E+02, 0.3655E+02, 0.2486E+03, 0.3222E+03, 0.3570E+01, 0.1465E+00},
-        {11, 2, 0, 0.7084E+02, 0.4537E+02, 0.1142E+02, 0.2395E+03, 0.3380E+01, 0.0000E+00},
-        {11, 1, 0, 0.1079E+04, 0.4216E+03, 0.1119E+02, 0.5642E+08, 0.7736E+00, 0.0000E+00},
-        {12, 3, 0, 0.7646E+01, 0.9393E+01, 0.3034E+01, 0.2625E+08, 0.3923E+01, 0.0000E+00},
-        {12, 2, 1, 0.5490E+02, 0.4937E+02, 0.2023E+03, 0.1079E+05, 0.2960E+01, 0.1463E-01},
-        {12, 2, 0, 0.9400E+02, 0.4587E+02, 0.1671E+02, 0.2389E+02, 0.4742E+01, 0.0000E+00},
-        {12, 1, 0, 0.1311E+04, 0.2711E+03, 0.3561E+02, 0.2374E+02, 0.1952E+01, 0.0000E+00},
-        {13, 3, 1, 0.5986E+01, 0.1860E+02, 0.1828E+03, 0.2797E+01, 0.1084E+02, 0.3076E+00},
-        {13, 3, 0, 0.1133E+02, 0.1204E+02, 0.5384E+01, 0.4341E+03, 0.4088E+01, 0.0000E+00},
-        {13, 2, 1, 0.8040E+02, 0.6445E+02, 0.1735E+03, 0.1131E+05, 0.2762E+01, 0.2337E-01},
-        {13, 2, 0, 0.1256E+03, 0.5594E+02, 0.1425E+02, 0.3094E+02, 0.4399E+01, 0.0000E+00},
-        {13, 1, 0, 0.1567E+04, 0.3670E+03, 0.2206E+02, 0.4405E+02, 0.1588E+01, 0.0000E+00},
-        {14, 3, 1, 0.8152E+01, 0.2212E+02, 0.1845E+03, 0.3849E+01, 0.9721E+01, 0.2921E+00},
-        {14, 3, 0, 0.1517E+02, 0.1413E+02, 0.1166E+02, 0.2288E+02, 0.5334E+01, 0.0000E+00},
-        {14, 2, 1, 0.1060E+03, 0.7808E+02, 0.1532E+03, 0.5765E+07, 0.2639E+01, 0.2774E-03},
-        {14, 2, 0, 0.1560E+03, 0.7017E+02, 0.1166E+02, 0.4742E+02, 0.3933E+01, 0.0000E+00},
-        {14, 1, 0, 0.1846E+04, 0.5322E+03, 0.1184E+02, 0.2580E+03, 0.1102E+01, 0.0000E+00},
-        {15, 3, 1, 0.1049E+02, 0.2580E+02, 0.9925E+02, 0.6712E+01, 0.8516E+01, 0.2765E+00},
-        {15, 3, 0, 0.2017E+02, 0.1658E+02, 0.1125E+02, 0.2613E+02, 0.5205E+01, 0.0000E+00},
-        {15, 2, 1, 0.1400E+03, 0.8812E+02, 0.1512E+03, 0.2230E+04, 0.2795E+01, 0.3422E-03},
-        {15, 2, 0, 0.1940E+03, 0.8632E+02, 0.9931E+01, 0.6594E+02, 0.3617E+01, 0.0000E+00},
-        {15, 1, 0, 0.2154E+04, 0.6472E+03, 0.9167E+01, 0.2562E+03, 0.1063E+01, 0.0000E+00},
-        {16, 3, 1, 0.1036E+02, 0.2975E+02, 0.5644E+02, 0.1321E+02, 0.7513E+01, 0.2621E+00},
-        {16, 3, 0, 0.2130E+02, 0.1916E+02, 0.1003E+02, 0.3296E+02, 0.5038E+01, 0.0000E+00},
-        {16, 2, 1, 0.1700E+03, 0.9152E+02, 0.1883E+03, 0.7193E+02, 0.3633E+01, 0.2485E+00},
-        {16, 2, 0, 0.2350E+03, 0.1047E+03, 0.8520E+01, 0.9469E+02, 0.3346E+01, 0.0000E+00},
-        {16, 1, 0, 0.2477E+04, 0.8114E+03, 0.6649E+01, 0.3734E+04, 0.8646E+00, 0.0000E+00},
-        {17, 3, 1, 0.1297E+02, 0.3398E+02, 0.4539E+02, 0.2232E+02, 0.6896E+01, 0.2479E+00},
-        {17, 3, 0, 0.2531E+02, 0.2231E+02, 0.6628E+01, 0.1843E+03, 0.4196E+01, 0.0000E+00},
-        {17, 2, 1, 0.2090E+03, 0.8004E+02, 0.3053E+03, 0.3498E+02, 0.4457E+01, 0.2017E+00},
-        {17, 2, 0, 0.2780E+03, 0.1092E+03, 0.1059E+02, 0.2491E+02, 0.4205E+01, 0.0000E+00},
-        {17, 1, 0, 0.2830E+04, 0.9700E+03, 0.5255E+01, 0.1856E+07, 0.7888E+00, 0.0000E+00},
-        {18, 3, 1, 0.1576E+02, 0.3854E+02, 0.4872E+02, 0.2640E+02, 0.6662E+01, 0.2355E+00},
-        {18, 3, 0, 0.2892E+02, 0.2525E+02, 0.6394E+01, 0.1700E+03, 0.4223E+01, 0.0000E+00},
-        {18, 2, 1, 0.2492E+03, 0.1647E+03, 0.8372E+02, 0.5452E+02, 0.3328E+01, 0.6270E+00},
-        {18, 2, 0, 0.3260E+03, 0.1302E+03, 0.9185E+01, 0.2693E+02, 0.4021E+01, 0.0000E+00},
-        {18, 1, 0, 0.3203E+04, 0.1135E+04, 0.4280E+01, 0.3285E+08, 0.7631E+00, 0.0000E+00},
-        {19, 4, 0, 0.4341E+01, 0.3824E+01, 0.7363E+00, 0.2410E+08, 0.4427E+01, 0.2049E-03},
-        {19, 3, 1, 0.2466E+02, 0.4138E+02, 0.2614E+02, 0.2143E+03, 0.5631E+01, 0.2437E+00},
-        {19, 3, 0, 0.4080E+02, 0.2910E+02, 0.6377E+01, 0.2229E+04, 0.3587E+01, 0.0000E+00},
-        {19, 2, 1, 0.3014E+03, 0.2666E+03, 0.3107E+02, 0.7187E+07, 0.2067E+01, 0.5274E+00},
-        {19, 2, 0, 0.3843E+03, 0.1602E+03, 0.6389E+01, 0.1044E+03, 0.3159E+01, 0.0000E+00},
-        {19, 1, 0, 0.3614E+04, 0.1171E+04, 0.4540E+01, 0.6165E+04, 0.8392E+00, 0.0000E+00},
-        {20, 4, 0, 0.6113E+01, 0.7366E+01, 0.2373E+01, 0.2082E+03, 0.4841E+01, 0.5841E-03},
-        {20, 3, 1, 0.3443E+02, 0.4487E+02, 0.9017E+02, 0.1465E+02, 0.7498E+01, 0.2754E+00},
-        {20, 3, 0, 0.4830E+02, 0.3012E+02, 0.7227E+01, 0.1736E+03, 0.4165E+01, 0.0000E+00},
-        {20, 2, 1, 0.3523E+03, 0.1529E+03, 0.1282E+03, 0.2217E+03, 0.3087E+01, 0.3343E-02},
-        {20, 2, 0, 0.4425E+03, 0.1201E+03, 0.1010E+02, 0.2468E+02, 0.4592E+01, 0.0000E+00},
-        {20, 1, 0, 0.4043E+04, 0.6947E+03, 0.1586E+02, 0.2563E+02, 0.1966E+01, 0.0000E+00},
-        {21, 4, 0, 0.7342E+01, 0.8324E+01, 0.2252E+01, 0.4118E+03, 0.4588E+01, 0.1441E-03},
-        {21, 3, 2, 0.8010E+01, 0.9733E+01, 0.2488E+03, 0.2066E+02, 0.1022E+02, 0.3104E+00},
-        {21, 3, 1, 0.3360E+02, 0.4936E+02, 0.6176E+02, 0.2186E+02, 0.7081E+01, 0.2671E+00},
-        {21, 3, 0, 0.5640E+02, 0.3284E+02, 0.6849E+01, 0.1709E+03, 0.4207E+01, 0.0000E+00},
-        {21, 2, 1, 0.4054E+03, 0.1593E+03, 0.1473E+03, 0.6007E+02, 0.3635E+01, 0.3208E-02},
-        {21, 2, 0, 0.5032E+03, 0.1180E+03, 0.1065E+02, 0.2172E+02, 0.4911E+01, 0.0000E+00},
-        {21, 1, 0, 0.4494E+04, 0.7367E+03, 0.1554E+02, 0.2940E+02, 0.1937E+01, 0.0000E+00},
-        {22, 4, 0, 0.6820E+01, 0.9184E+01, 0.2167E+01, 0.4297E+03, 0.4552E+01, 0.3612E-02},
-        {22, 3, 2, 0.9940E+01, 0.1102E+02, 0.5478E+03, 0.1610E+02, 0.1096E+02, 0.2972E+00},
-        {22, 3, 1, 0.4000E+02, 0.5424E+02, 0.5924E+02, 0.2151E+02, 0.7123E+01, 0.2645E+00},
-        {22, 3, 0, 0.6500E+02, 0.3562E+02, 0.6517E+01, 0.1572E+03, 0.4268E+01, 0.0000E+00},
-        {22, 2, 1, 0.4640E+03, 0.1814E+03, 0.1291E+03, 0.6629E+02, 0.3531E+01, 0.5519E-04},
-        {22, 2, 0, 0.5690E+03, 0.1177E+03, 0.1068E+02, 0.2144E+02, 0.5085E+01, 0.0000E+00},
-        {22, 1, 0, 0.4972E+04, 0.6826E+03, 0.2029E+02, 0.2415E+02, 0.2187E+01, 0.0000E+00},
-        {23, 4, 0, 0.6740E+01, 0.1002E+02, 0.2059E+01, 0.3914E+03, 0.4565E+01, 0.5057E-03},
-        {23, 3, 2, 0.1200E+02, 0.1146E+02, 0.3134E+04, 0.7037E+01, 0.1377E+02, 0.3417E+00},
-        {23, 3, 1, 0.4700E+02, 0.5937E+02, 0.7599E+02, 0.1488E+02, 0.7586E+01, 0.2690E+00},
-        {23, 3, 0, 0.7700E+02, 0.3668E+02, 0.6690E+01, 0.7759E+02, 0.4706E+01, 0.0000E+00},
-        {23, 2, 1, 0.5270E+03, 0.2290E+03, 0.8513E+02, 0.5037E+03, 0.2767E+01, 0.9964E-03},
-        {23, 2, 0, 0.6380E+03, 0.9688E+02, 0.1212E+02, 0.1905E+02, 0.5757E+01, 0.0000E+00},
-        {23, 1, 0, 0.5475E+04, 0.6550E+03, 0.2420E+02, 0.2343E+02, 0.2326E+01, 0.0000E+00},
-        {24, 4, 0, 0.6767E+01, 0.9636E+01, 0.6532E+00, 0.5232E+03, 0.4641E+01, 0.9332E-04},
-        {24, 3, 2, 0.8660E+01, 0.7244E+01, 0.1485E+04, 0.9671E+01, 0.1575E+02, 0.7760E+00},
-        {24, 3, 1, 0.4900E+02, 0.6567E+02, 0.5313E+02, 0.1981E+02, 0.7258E+01, 0.2601E+00},
-        {24, 3, 0, 0.7900E+02, 0.4234E+02, 0.5602E+01, 0.1356E+03, 0.4374E+01, 0.0000E+00},
-        {24, 2, 1, 0.5850E+03, 0.1865E+03, 0.1540E+03, 0.5560E+02, 0.3823E+01, 0.5785E-02},
-        {24, 2, 0, 0.7030E+03, 0.1588E+03, 0.8555E+01, 0.2258E+02, 0.4789E+01, 0.0000E+00},
-        {24, 1, 0, 0.5996E+04, 0.1035E+04, 0.1025E+02, 0.3343E+02, 0.1822E+01, 0.0000E+00},
-        {25, 4, 0, 0.7434E+01, 0.1183E+02, 0.1549E+01, 0.2920E+07, 0.4113E+01, 0.3256E-01},
-        {25, 3, 2, 0.1430E+02, 0.1311E+02, 0.1668E+05, 0.4497E+01, 0.1646E+02, 0.3881E+00},
-        {25, 3, 1, 0.5940E+02, 0.7040E+02, 0.6697E+02, 0.1485E+02, 0.7643E+01, 0.2659E+00},
-        {25, 3, 0, 0.9460E+02, 0.4114E+02, 0.6172E+01, 0.5928E+02, 0.4989E+01, 0.0000E+00},
-        {25, 2, 1, 0.6554E+03, 0.2737E+03, 0.7498E+02, 0.3952E+03, 0.2793E+01, 0.4661E-01},
-        {25, 2, 0, 0.7816E+03, 0.8316E+02, 0.1156E+02, 0.2187E+02, 0.6149E+01, 0.0000E+00},
-        {25, 1, 0, 0.6550E+04, 0.8758E+03, 0.1592E+02, 0.3965E+02, 0.1947E+01, 0.0000E+00},
-        {26, 4, 0, 0.7902E+01, 0.1277E+02, 0.1468E+01, 0.1116E+06, 0.4112E+01, 0.3238E-01},
-        {26, 3, 2, 0.1470E+02, 0.1407E+02, 0.1850E+05, 0.4458E+01, 0.1691E+02, 0.4039E+00},
-        {26, 3, 1, 0.6600E+02, 0.7630E+02, 0.6298E+02, 0.1479E+02, 0.7672E+01, 0.2646E+00},
-        {26, 3, 0, 0.1040E+03, 0.4334E+02, 0.5921E+01, 0.5293E+02, 0.5129E+01, 0.0000E+00},
-        {26, 2, 1, 0.7240E+03, 0.2948E+03, 0.7191E+02, 0.3219E+03, 0.2837E+01, 0.6314E-01},
-        {26, 2, 0, 0.8570E+03, 0.5727E+02, 0.1076E+02, 0.2785E+02, 0.6635E+01, 0.0000E+00},
-        {26, 1, 0, 0.7124E+04, 0.8044E+03, 0.2055E+02, 0.3633E+02, 0.2118E+01, 0.0000E+00},
-        {27, 4, 0, 0.7864E+01, 0.1370E+02, 0.1555E+01, 0.7559E+03, 0.4337E+01, 0.3355E-01},
-        {27, 3, 2, 0.1580E+02, 0.1581E+02, 0.4931E+04, 0.6607E+01, 0.1532E+02, 0.3676E+00},
-        {27, 3, 1, 0.7300E+02, 0.8256E+02, 0.4587E+02, 0.1973E+02, 0.7331E+01, 0.2573E+00},
-        {27, 3, 0, 0.1150E+03, 0.5097E+02, 0.4896E+01, 0.1198E+03, 0.4513E+01, 0.0000E+00},
-        {27, 2, 1, 0.8000E+03, 0.2832E+03, 0.9075E+02, 0.7686E+02, 0.3416E+01, 0.4833E-04},
-        {27, 2, 0, 0.9400E+03, 0.8888E+02, 0.1030E+02, 0.2797E+02, 0.5913E+01, 0.0000E+00},
-        {27, 1, 0, 0.7725E+04, 0.6269E+03, 0.3582E+02, 0.3161E+02, 0.2476E+01, 0.0000E+00},
-        {28, 4, 0, 0.7637E+01, 0.1468E+02, 0.1437E+01, 0.7411E+03, 0.4342E+01, 0.3908E-01},
-        {28, 3, 2, 0.1700E+02, 0.6063E+01, 0.1186E+04, 0.6823E+01, 0.2223E+02, 0.6227E-02},
-        {28, 3, 1, 0.8200E+02, 0.8896E+02, 0.4351E+02, 0.1942E+02, 0.7372E+01, 0.2566E+00},
-        {28, 3, 0, 0.1250E+03, 0.5448E+02, 0.4611E+01, 0.1157E+03, 0.4548E+01, 0.0000E+00},
-        {28, 2, 1, 0.8760E+03, 0.3043E+03, 0.8611E+02, 0.7868E+02, 0.3408E+01, 0.1680E-04},
-        {28, 2, 0, 0.1024E+04, 0.1132E+03, 0.9424E+01, 0.2712E+02, 0.5643E+01, 0.0000E+00},
-        {28, 1, 0, 0.8348E+04, 0.7366E+03, 0.2836E+02, 0.3622E+02, 0.2316E+01, 0.0000E+00},
-        {29, 4, 0, 0.7726E+01, 0.1436E+02, 0.4681E+00, 0.2383E+04, 0.4224E+01, 0.3736E-01},
-        {29, 3, 2, 0.1064E+02, 0.7279E+01, 0.1027E+04, 0.7988E+01, 0.2033E+02, 0.1582E+01},
-        {29, 3, 1, 0.8300E+02, 0.9617E+02, 0.4275E+02, 0.1747E+02, 0.7555E+01, 0.2599E+00},
-        {29, 3, 0, 0.1288E+03, 0.6198E+02, 0.4164E+01, 0.1158E+03, 0.4488E+01, 0.0000E+00},
-        {29, 2, 1, 0.9470E+03, 0.2826E+03, 0.1093E+03, 0.6688E+02, 0.3668E+01, 0.9174E-06},
-        {29, 2, 0, 0.1106E+04, 0.2502E+03, 0.5938E+01, 0.2402E+02, 0.4576E+01, 0.0000E+00},
-        {29, 1, 0, 0.8988E+04, 0.1788E+04, 0.4870E+01, 0.7645E+02, 0.1451E+01, 0.0000E+00},
-        {30, 4, 0, 0.9394E+01, 0.1673E+02, 0.1236E+01, 0.1029E+04, 0.4259E+01, 0.3962E-01},
-        {30, 3, 2, 0.1730E+02, 0.1818E+02, 0.1017E+05, 0.5288E+01, 0.1736E+02, 0.4667E+00},
-        {30, 3, 1, 0.9700E+02, 0.1025E+03, 0.3930E+02, 0.1876E+02, 0.7456E+01, 0.2559E+00},
-        {30, 3, 0, 0.1450E+03, 0.6195E+02, 0.4094E+01, 0.1086E+03, 0.4614E+01, 0.0000E+00},
-        {30, 2, 1, 0.1037E+04, 0.3486E+03, 0.7784E+02, 0.8298E+02, 0.3391E+01, 0.1125E-07},
-        {30, 2, 0, 0.1203E+04, 0.9755E+02, 0.9077E+01, 0.3219E+02, 0.5888E+01, 0.0000E+00},
-        {30, 1, 0, 0.9667E+04, 0.8320E+03, 0.2586E+02, 0.4497E+02, 0.2215E+01, 0.0000E+00}};
 
-    // fluorescence parameters taken from Table 5 of Bearden (1967) and
-    // from Part 3 of the LLNL Evaluated Atomic Data Library (EADL), Perkins et al. (1991)
-    // there is a separate record for each fluorescence transition
-    // fluorescence records MUST be sorted on Z and n in the same way as the cross section parameter records
+    // fluorescence parameters
     struct FluorescenceParams
     {
+        FluorescenceParams(const Array& a) : Z(a[0]), n(a[1]), omega(a[2]), E(a[3]) {}
         short Z;       // atomic number
         short n;       // principal quantum number of the shell (always 1 because we only support K shell)
         double omega;  // fluorescence yield (1)
         double E;      // energy of the emitted photon (eV)
-    };
-    constexpr std::initializer_list<FluorescenceParams> fluorescenceParams = {
-        {6, 1, 5.61488e-04, 277.00},    // Ka2
-        {6, 1, 1.12060e-03, 277.00},    // Ka1
-        {7, 1, 1.09420e-03, 392.40},    // Ka2
-        {7, 1, 2.18181e-03, 392.40},    // Ka1
-        {8, 1, 1.90768e-03, 524.90},    // Ka2
-        {8, 1, 3.80027e-03, 524.90},    // Ka1
-        {9, 1, 3.06841e-03, 676.80},    // Ka2
-        {9, 1, 6.10743e-03, 676.80},    // Ka1
-        {10, 1, 4.64329e-03, 848.60},   // Ka2
-        {10, 1, 9.22967e-03, 848.60},   // Ka1
-        {11, 1, 6.68996e-03, 1040.98},  // Ka2
-        {11, 1, 1.32959e-02, 1040.98},  // Ka1
-        {12, 1, 9.27327e-03, 1253.60},  // Ka2
-        {12, 1, 1.84189e-02, 1253.60},  // Ka1
-        {13, 1, 1.23699e-02, 1486.27},  // Ka2
-        {13, 1, 2.45528e-02, 1486.70},  // Ka1
-        {13, 1, 7.55854e-05, 1557.45},  // Kb3
-        {13, 1, 1.50039e-04, 1557.45},  // Kb1
-        {14, 1, 1.59791e-02, 1739.38},  // Ka2
-        {14, 1, 3.17052e-02, 1739.98},  // Ka1
-        {14, 1, 2.72402e-04, 1835.94},  // Kb3
-        {14, 1, 5.40444e-04, 1835.94},  // Kb1
-        {15, 1, 2.01220e-02, 2012.70},  // Ka2
-        {15, 1, 3.98749e-02, 2013.70},  // Ka1
-        {15, 1, 6.21469e-04, 2139.10},  // Kb3
-        {15, 1, 1.23210e-03, 2139.10},  // Kb1
-        {16, 1, 2.47822e-02, 2306.64},  // Ka2
-        {16, 1, 4.90644e-02, 2307.84},  // Ka1
-        {16, 1, 1.15591e-03, 2464.04},  // Kb3
-        {16, 1, 2.28902e-03, 2464.04},  // Kb1
-        {17, 1, 2.99473e-02, 2620.78},  // Ka2
-        {17, 1, 5.92357e-02, 2622.39},  // Ka1
-        {17, 1, 1.90852e-03, 2815.60},  // Kb3
-        {17, 1, 3.77764e-03, 2815.60},  // Kb1
-        {18, 1, 3.55868e-02, 2955.63},  // Ka2
-        {18, 1, 7.03336e-02, 2957.70},  // Ka1
-        {18, 1, 2.91258e-03, 3190.50},  // Kb3
-        {18, 1, 5.75646e-03, 3190.50},  // Kb1
-        {19, 1, 4.18599e-02, 3311.10},  // Ka2
-        {19, 1, 8.26518e-02, 3313.80},  // Ka1
-        {19, 1, 3.99739e-03, 3589.60},  // Kb3
-        {19, 1, 7.91008e-03, 3589.60},  // Kb1
-        {20, 1, 4.87196e-02, 3688.09},  // Ka2
-        {20, 1, 9.61323e-02, 3691.68},  // Ka1
-        {20, 1, 5.17776e-03, 4012.70},  // Kb3
-        {20, 1, 1.02489e-02, 4012.70},  // Kb1
-        {21, 1, 5.63841e-02, 4086.10},  // Ka2
-        {21, 1, 1.11130e-01, 4090.60},  // Ka1
-        {21, 1, 6.22301e-03, 4460.50},  // Kb3
-        {21, 1, 1.23040e-02, 4460.50},  // Kb1
-        {22, 1, 6.45982e-02, 4504.86},  // Ka2
-        {22, 1, 1.27140e-01, 4510.84},  // Ka1
-        {22, 1, 7.32672e-03, 4931.81},  // Kb3
-        {22, 1, 1.44750e-02, 4931.81},  // Kb1
-        {23, 1, 7.32827e-02, 4944.64},  // Ka2
-        {23, 1, 1.44051e-01, 4952.20},  // Ka1
-        {23, 1, 8.48408e-03, 5427.29},  // Kb3
-        {23, 1, 1.67441e-02, 5427.29},  // Kb1
-        {24, 1, 8.25759e-02, 5405.51},  // Ka2
-        {24, 1, 1.62090e-01, 5414.72},  // Ka1
-        {24, 1, 9.49389e-03, 5946.71},  // Kb3
-        {24, 1, 1.87010e-02, 5946.71},  // Kb1
-        {25, 1, 9.17726e-02, 5887.65},  // Ka2
-        {25, 1, 1.79949e-01, 5898.75},  // Ka1
-        {25, 1, 1.09360e-02, 6490.45},  // Kb3
-        {25, 1, 2.15229e-02, 6490.45},  // Kb1
-        {26, 1, 1.01391e-01, 6390.84},  // Ka2
-        {26, 1, 1.98621e-01, 6403.84},  // Ka1
-        {26, 1, 1.22111e-02, 7057.98},  // Kb3
-        {26, 1, 2.40042e-02, 7057.98},  // Kb1
-        {27, 1, 1.11220e-01, 6915.30},  // Ka2
-        {27, 1, 2.17470e-01, 6930.32},  // Ka1
-        {27, 1, 1.35020e-02, 7649.43},  // Kb3
-        {27, 1, 2.65130e-02, 7649.43},  // Kb1
-        {28, 1, 1.21060e-01, 7460.89},  // Ka2
-        {28, 1, 2.36419e-01, 7478.15},  // Ka1
-        {28, 1, 1.48050e-02, 8264.66},  // Kb3
-        {28, 1, 2.90299e-02, 8264.66},  // Kb1
-        {29, 1, 1.31119e-01, 8027.83},  // Ka2
-        {29, 1, 2.55668e-01, 8047.78},  // Ka1
-        {29, 1, 1.58899e-02, 8905.29},  // Kb3
-        {29, 1, 3.10908e-02, 8905.29},  // Kb1
-        {30, 1, 1.40620e-01, 8615.78},  // Ka2
-        {30, 1, 2.73809e-01, 8638.86},  // Ka1
-        {30, 1, 1.73890e-02, 9572.00},  // Kb3
-        {30, 1, 3.39969e-02, 9572.00},  // Kb1
     };
 
     // wavelength range over which our cross sections may be nonzero
@@ -305,6 +61,18 @@ namespace
 
 namespace
 {
+    // load data from resource file with N columns into a vector of structs of type S that can be constructed
+    // from an array with N elements, and return that vector
+    template<class S, int N> vector<S> loadResource(const SimulationItem* item, string filename, string description)
+    {
+        vector<S> result;
+        TextInFile infile(item, filename, description, true);
+        for (int i = 0; i != N; ++i) infile.addColumn(string());
+        Array row;
+        while (infile.readRow(row)) result.emplace_back(row);
+        return result;
+    }
+
     // convert photon energy in eV to and from wavelength in m (same conversion in both directions)
     double wavelengthToFromEnergy(double x)
     {
@@ -348,18 +116,27 @@ void XRayAtomicGasMix::setupSelfBefore()
     MaterialMix::setupSelfBefore();
     auto config = find<Configuration>();
 
-    // ---- abundancies ----
+    // ---- load resources ----
 
-    // verify the number of abundancies; if the list is empty, use our default list
-    if (_abundancies.empty())
-        _abundancies = defaultAbundancies;
-    else if (_abundancies.size() != numAtoms)
-        throw FATALERROR("The abundancies list must have exactly " + std::to_string(numAtoms) + " values");
+    // load the atom masses and default abundancies
+    auto atomv = loadResource<AtomParams, 2>(this, "AtomBasics.txt", "atom masses");
+    _numAtoms = atomv.size();
+
+    // if the configured abundancies list is nonempty, use it instead of the defaults
+    if (!_abundancies.empty())
+    {
+        if (_abundancies.size() != _numAtoms)
+            throw FATALERROR("The abundancies list must have exactly " + std::to_string(_numAtoms) + " values");
+        for (size_t i = 0; i != _numAtoms; ++i) atomv[i].abund = _abundancies[i];
+    }
+
+    // load the photo-absorption cross section parameters
+    auto crossSectionParams = loadResource<CrossSectionParams, 9>(this, "PhotoAbsorption.txt", "photo-absorption data");
+
+    // load the fluorescence parameters
+    auto fluorescenceParams = loadResource<FluorescenceParams, 4>(this, "Fluorescence.txt", "fluorescence data");
 
     // ---- thermal dispersion ----
-
-    // copy the atom masses (in amu) into a temporary vector
-    vector<double> massv = masses;
 
     // calculate the parameters for the sigmoid function approximating the convolution with a Gaussian
     // at the threshold energy for each cross section record, and store the result into a temporary vector;
@@ -369,20 +146,20 @@ void XRayAtomicGasMix::setupSelfBefore()
     sigmoidv.reserve(crossSectionParams.size());
     for (const auto& params : crossSectionParams)
     {
-        double Es = params.Eth * vtherm(temperature(), massv[params.Z - 1]) / Constants::c();
+        double Es = params.Eth * vtherm(temperature(), atomv[params.Z - 1].mass) / Constants::c();
         double sigmamax = crossSection(params.Eth + 2. * Es, params);
         sigmoidv.emplace_back(Es, sigmamax);
     }
 
     // calculate and store the thermal velocities corresponding to the scattering channels
-    _vthermscav.reserve(numAtoms + fluorescenceParams.size());
-    for (double mass : masses)
+    _vthermscav.reserve(_numAtoms + fluorescenceParams.size());
+    for (const auto& atom : atomv)
     {
-        _vthermscav.push_back(vtherm(temperature(), mass));
+        _vthermscav.push_back(vtherm(temperature(), atom.mass));
     }
     for (const auto& params : fluorescenceParams)
     {
-        _vthermscav.push_back(vtherm(temperature(), massv[params.Z - 1]));
+        _vthermscav.push_back(vtherm(temperature(), atomv[params.Z - 1].mass));
     }
 
     // ---- wavelength grid ----
@@ -457,7 +234,7 @@ void XRayAtomicGasMix::setupSelfBefore()
 
     // determine total nr of electrons per hydrogen atom
     double numElectrons = 0.;
-    for (size_t Z = 1; Z <= numAtoms; ++Z) numElectrons += Z * _abundancies[Z - 1];
+    for (size_t Z = 1; Z <= _numAtoms; ++Z) numElectrons += Z * atomv[Z - 1].abund;
 
     // calculate the extinction cross section at every wavelength; to guarantee that the cross section is zero
     // for wavelengths outside our range, leave the values for the outer wavelength points at zero
@@ -474,7 +251,7 @@ void XRayAtomicGasMix::setupSelfBefore()
         int index = 0;
         for (const auto& params : crossSectionParams)
         {
-            sigma += crossSection(E, sigmoidv[index++], params) * _abundancies[params.Z - 1];
+            sigma += crossSection(E, sigmoidv[index++], params) * atomv[params.Z - 1].abund;
         }
         _sigmaextv[ell] = sigma;
     }
@@ -490,7 +267,7 @@ void XRayAtomicGasMix::setupSelfBefore()
     _cumprobscavv.resize(numLambda, 0);
 
     // provide temporary array for the non-normalized fluorescence/scattering contributions (at the current wavelength)
-    Array contribv(numAtoms + fluorescenceParams.size());
+    Array contribv(_numAtoms + fluorescenceParams.size());
 
     // calculate the above for every wavelength; as before, leave the values for the outer wavelength points at zero
     for (int ell = 1; ell < numLambda - 1; ++ell)
@@ -500,10 +277,10 @@ void XRayAtomicGasMix::setupSelfBefore()
 
         // bound electron scattering
         double section = Constants::sigmaThomson() * _cpf.sectionSca(lambda);
-        for (size_t Z = 1; Z <= numAtoms; ++Z) contribv[Z - 1] = Z * _abundancies[Z - 1] * section;
+        for (size_t Z = 1; Z <= _numAtoms; ++Z) contribv[Z - 1] = Z * atomv[Z - 1].abund * section;
 
         // fluorescence: interate over both cross section and fluorescence parameter sets in sync
-        const auto* flp = fluorescenceParams.begin();
+        auto flp = fluorescenceParams.begin();
         int index = 0;
         for (const auto& csp : crossSectionParams)
         {
@@ -512,8 +289,8 @@ void XRayAtomicGasMix::setupSelfBefore()
             // process all fluorescence parameter sets matching this cross section set
             while (flp != fluorescenceParams.end() && flp->Z == csp.Z && flp->n == csp.n)
             {
-                double contribution = crossSection(E, sigmoid, csp) * _abundancies[csp.Z - 1] * flp->omega;
-                contribv[numAtoms + flp - fluorescenceParams.begin()] = contribution;
+                double contribution = crossSection(E, sigmoid, csp) * atomv[csp.Z - 1].abund * flp->omega;
+                contribv[_numAtoms + flp - fluorescenceParams.begin()] = contribution;
                 flp++;
             }
         }
@@ -627,7 +404,7 @@ void XRayAtomicGasMix::peeloffScattering(double& I, double& /*Q*/, double& /*U*/
     setScatteringInfoIfNeeded(scatinfo, lambda);
 
     // bound electron scattering
-    if (scatinfo->species < static_cast<int>(numAtoms))
+    if (scatinfo->species < static_cast<int>(_numAtoms))
     {
         // if we have dispersion, adjust the incoming wavelength to the electron rest frame
         if (temperature() > 0.)
@@ -644,7 +421,7 @@ void XRayAtomicGasMix::peeloffScattering(double& I, double& /*Q*/, double& /*U*/
         I += 1.;
 
         // update the photon packet wavelength to the wavelength of this fluorescence transition
-        lambda = _lambdafluov[scatinfo->species - numAtoms];
+        lambda = _lambdafluov[scatinfo->species - _numAtoms];
     }
 
     // if we have dispersion, Doppler-shift the outgoing wavelength from the electron rest frame
@@ -663,7 +440,7 @@ void XRayAtomicGasMix::performScattering(double lambda, const MaterialState* sta
     Direction bfknew;
 
     // bound electron scatterimg
-    if (scatinfo->species < static_cast<int>(numAtoms))
+    if (scatinfo->species < static_cast<int>(_numAtoms))
     {
         // if we have dispersion, adjust the incoming wavelength to the electron rest frame
         if (temperature() > 0.)
@@ -677,7 +454,7 @@ void XRayAtomicGasMix::performScattering(double lambda, const MaterialState* sta
     else
     {
         // update the photon packet wavelength to the wavelength of this fluorescence transition
-        lambda = _lambdafluov[scatinfo->species - numAtoms];
+        lambda = _lambdafluov[scatinfo->species - _numAtoms];
 
         // draw a random, isotropic outgoing direction
         bfknew = random()->direction();

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -15,8 +15,8 @@
 /** The XRayAtomicGasMix class describes the material properties of neutral atomic gas in the X-ray
     wavelength range, taking into account the effects of photo-absorption, fluorescence, and
     scattering by bound electrons. To avoid the use of this material mix outside of the regime for
-    which it has been designed, all cross sections are forced to zero below 4 eV and above 310
-    keV (corresponding approximately to a wavelength range from 4 pm to 310 nm).
+    which it has been designed, all cross sections are forced to zero below 4.3 eV and above 500
+    keV (corresponding approximately to a wavelength range from 2.5 pm to 290 nm).
 
     The class assumes a gas containing a mixture of non-ionized elements with atomic numbers from 1
     (hydrogen) up to 30 (zinc). The spatial density distribution of the gas is established by
@@ -334,7 +334,6 @@ public:
 
 private:
     // all data members are precalculated in setupSelfAfter()
-    size_t _numAtoms{0};  // number of supported atoms
 
     // wavelength grid (shifted to the left of the actually sampled points to approximate rounding)
     Array _lambdav;  // indexed on ell

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -128,17 +128,47 @@
     similarly, but now including only the K shell photo-absorption cross section for each element
     and multiplying by the appropriate fluorescence yields in addition to element abundancy.
 
-    <b>Electron scattering cross section</b>
+    <b>Electron scattering</b>
 
     As described above, this class provides three implementations for the scattering of X-rays
-    photons by the electrons bound to the atoms.
+    photons by the electrons bound to the atoms. These implementations involve four types of
+    scattering: free-electron Compton scattering, bound-electron Compton scattering, smooth
+    Rayleigh scattering, and anomalous Rayleigh scattering. Note that, in all cases, the listed
+    cross sections must be multiplied by the abundance of the corresponding element relative to
+    hydrogen.
 
-    For the free-electron implementation, the cross section per hydrogen atom for each element is
-    given by \f$\sigma_\mathrm{C}\,Z\,a_Z\f$, where \f$\sigma_\mathrm{C}\f$ is the
-    (wavelength-dependent) Compton cross section, \f$Z\f$ is the atomic number, and \f$a_Z\f$ is
-    the abundance of the corresponding element relative to hydrogen.
+    For free-electron Compton scattering, the cross section for an element with atomic number
+    \f$Z\f$ is given by \f$Z\,\sigma_\mathrm{C}\f$, where \f$\sigma_\mathrm{C}\f$ is the
+    (wavelength-dependent) Compton cross section for a single free electron. The implementation of
+    the scattering events is delegated to the ComptonPhaseFunction class; see there for more
+    information on the cross section and phase function for free-electron Compton scattering.
 
-    TO DO: describe the other two implementations.
+    The other scattering implementations depend on quantities that are available for each element
+    \f$Z\f$ in tabulated form as a function of the incoming photon energy \f$E\f$ or as a function
+    of the dimensionless momentum transfer parameter \f$q\f$, \f[q= \frac{E}{12.4 \, \mathrm{keV}}
+    \cdot \sin(\theta/2), \f] with \f$\theta\f$ the scattering angle.
+
+    For bound-electron Compton scattering, the cross sections \f$\sigma_{CS, Z}(E)\f$ are available
+    as a table. The normalised scattering phase function for element Z is given by \f[ \Phi_{CS,
+    Z}(\theta, E)= \frac{3}{16\pi}\, \frac{\sigma_T}{\sigma_{CS, Z}(E)}\Big[C^3(\theta, E) +
+    C(\theta, E) -C^2(\theta, E)\sin^2\theta\Big] \cdot S_Z(q), \f] with tabulated incoherent
+    scattering functions \f$S_Z(q)\f$ and the Compton factor \f$C(\theta, E)\f$ defined as \f[
+    C(\theta, E) = {\Big[{1+\frac{E}{m_ec^2}(1-\cos \theta)\Big]}}^{-1}. \f] Also, inelastic
+    bound-Compton scattering will change the photon energy by the Compton factor, just as for
+    free-electron scattering.
+
+    For smooth Rayleigh scattering, the cross sections \f$\sigma_{RSS, Z}(E)\f$ are available as a
+    table. The normalised scattering phase function for element Z is given by \f[ \Phi_{RSS,
+    Z}(\theta, E)= \frac{3}{16\pi}\, \frac{\sigma_T}{\sigma_{RSS, Z}(E)}\Big[ 1 + \cos^2\theta
+    \Big] \cdot F_Z^2(q), \f] with tabulated atomic form factors \f$F_Z(q)\f$, which converge to
+    \f$Z\f$ at small \f$q\f$ and decrease to zero for large \f$q\f$.
+
+    Similarly, for anomalous Rayleigh scattering, the cross sections \f$\sigma_{RSA, Z}(E)\f$ are
+    available as a table. The normalised scattering phase function for element Z is now given by
+    \f[ \Phi_{RSA, Z}(\theta, E)= \frac{3}{16\pi}\, \frac{\sigma_T}{\sigma_{RSA, Z}(E)}\Big[ 1 +
+    \cos^2\theta \Big] \cdot \Big[\big(F_Z(q) + F'_Z(E)\big)^2 + {F''_Z}^2(E)\Big], \f] with the
+    same atomic form factors \f$F_Z(q)\f$ as before, and tabulated real and imaginary anomalous
+    scattering functions \f$F'_Z(E)\f$ and \f$F''_Z(E)\f$.
 
     <b>Performing scattering</b>
 
@@ -147,10 +177,10 @@
     K\f$\alpha\f$ or K\f$\beta\f$ fluorescence transition for one of the supported elements). The
     relative probabilities for these transitions as a function of incoming photon packet wavelength
     are also calculated during setup. The selected transition determines the scattering mechanism.
-    For bound electrons, Rayleigh or Compton scattering is used. For fluorescence, the emission direction is
-    isotropic, and the outgoing wavelength is the fluorescence wavelength. In both cases, a random
-    Gaussian dispersion reflecting the interacting element's thermal velocity is applied to the
-    outgoing wavelength.
+    For bound electrons, Rayleigh or Compton scattering is used. For fluorescence, the emission
+    direction is isotropic, and the outgoing wavelength is the fluorescence wavelength. In both
+    cases, a random Gaussian dispersion reflecting the interacting element's thermal velocity is
+    applied to the outgoing wavelength.
 
     <b>Thermal dispersion</b>
 
@@ -181,7 +211,8 @@
     */
 class XRayAtomicGasMix : public MaterialMix
 {
-    /** The enumeration type indicating the implementation used for scattering by bound electrons. */
+    /** The enumeration type indicating the implementation used for scattering by bound electrons.
+        */
     ENUM_DEF(BoundElectrons, Free, Good, Exact)
         ENUM_VAL(BoundElectrons, Free, "use free-electron Compton scattering")
         ENUM_VAL(BoundElectrons, Good, "use smooth Rayleigh scattering and exact bound-Compton scattering")

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -150,7 +150,7 @@
 
     For bound-electron Compton scattering, the cross sections \f$\sigma_{CS, Z}(E)\f$ are available
     as a table. The normalised scattering phase function for element Z is given by \f[ \Phi_{CS,
-    Z}(\theta, E)= \frac{3}{16\pi}\, \frac{\sigma_T}{\sigma_{CS, Z}(E)}\Big[C^3(\theta, E) +
+    Z}(\theta, E)= \frac{3}{4}\, \frac{\sigma_T}{\sigma_{CS, Z}(E)}\Big[C^3(\theta, E) +
     C(\theta, E) -C^2(\theta, E)\sin^2\theta\Big] \cdot S_Z(q), \f] with tabulated incoherent
     scattering functions \f$S_Z(q)\f$ and the Compton factor \f$C(\theta, E)\f$ defined as \f[
     C(\theta, E) = {\Big[{1+\frac{E}{m_ec^2}(1-\cos \theta)\Big]}}^{-1}. \f] Also, inelastic
@@ -159,13 +159,13 @@
 
     For smooth Rayleigh scattering, the cross sections \f$\sigma_{RSS, Z}(E)\f$ are available as a
     table. The normalised scattering phase function for element Z is given by \f[ \Phi_{RSS,
-    Z}(\theta, E)= \frac{3}{16\pi}\, \frac{\sigma_T}{\sigma_{RSS, Z}(E)}\Big[ 1 + \cos^2\theta
+    Z}(\theta, E)= \frac{3}{4}\, \frac{\sigma_T}{\sigma_{RSS, Z}(E)}\Big[ 1 + \cos^2\theta
     \Big] \cdot F_Z^2(q), \f] with tabulated atomic form factors \f$F_Z(q)\f$, which converge to
     \f$Z\f$ at small \f$q\f$ and decrease to zero for large \f$q\f$.
 
     Similarly, for anomalous Rayleigh scattering, the cross sections \f$\sigma_{RSA, Z}(E)\f$ are
     available as a table. The normalised scattering phase function for element Z is now given by
-    \f[ \Phi_{RSA, Z}(\theta, E)= \frac{3}{16\pi}\, \frac{\sigma_T}{\sigma_{RSA, Z}(E)}\Big[ 1 +
+    \f[ \Phi_{RSA, Z}(\theta, E)= \frac{3}{4}\, \frac{\sigma_T}{\sigma_{RSA, Z}(E)}\Big[ 1 +
     \cos^2\theta \Big] \cdot \Big[\big(F_Z(q) + F'_Z(E)\big)^2 + {F''_Z}^2(E)\Big], \f] with the
     same atomic form factors \f$F_Z(q)\f$ as before, and tabulated real and imaginary anomalous
     scattering functions \f$F'_Z(E)\f$ and \f$F''_Z(E)\f$.
@@ -236,7 +236,7 @@ class XRayAtomicGasMix : public MaterialMix
         ATTRIBUTE_DISPLAYED_IF(temperature, "Level2")
 
         PROPERTY_ENUM(scatterBoundElectrons, BoundElectrons, "implementation of scattering by bound electrons")
-        ATTRIBUTE_DEFAULT_VALUE(scatterBoundElectrons, "Free")
+        ATTRIBUTE_DEFAULT_VALUE(scatterBoundElectrons, "Good")
         ATTRIBUTE_DISPLAYED_IF(scatterBoundElectrons, "Level3")
 
     ITEM_END()

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -16,8 +16,8 @@
 /** The XRayAtomicGasMix class describes the material properties of neutral atomic gas in the X-ray
     wavelength range, taking into account the effects of photo-absorption, fluorescence, and
     scattering by bound electrons. To avoid the use of this material mix outside of the regime for
-    which it has been designed, all cross sections are forced to zero below 4.3 eV and above 300
-    keV (corresponding to a wavelength range from 4 pm to 290 nm).
+    which it has been designed, all cross sections are forced to zero below 4 eV and above 310
+    keV (corresponding approximately to a wavelength range from 4 pm to 310 nm).
 
     The class assumes a gas containing a mixture of non-ionized elements with atomic numbers from 1
     (hydrogen) up to 30 (zinc). The spatial density distribution of the gas is established by

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -307,6 +307,7 @@ public:
 
 private:
     // all data members are precalculated in setupSelfAfter()
+    size_t _numAtoms{0}; // number of supported atoms
 
     // wavelength grid (shifted to the left of the actually sampled points to approximate rounding)
     Array _lambdav;  // indexed on ell

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -7,7 +7,6 @@
 #define XRAYATOMICGASMIX_HPP
 
 #include "ArrayTable.hpp"
-#include "ComptonPhaseFunction.hpp"
 #include "MaterialMix.hpp"
 #include "PhotonPacket.hpp"
 
@@ -218,6 +217,9 @@ protected:
         high-resolution wavelength grid. */
     void setupSelfBefore() override;
 
+    /** The destructor destructs the phase function helpers that were created during setup. */
+    ~XRayAtomicGasMix();
+
     //======== Private support functions =======
 
 private:
@@ -326,6 +328,10 @@ public:
 
     //======================== Data Members ========================
 
+public:
+    // base class for bound-electron scattering helpers (public because we derive from it in anonymous namespace)
+    class ScatteringHelper;
+
 private:
     // all data members are precalculated in setupSelfAfter()
     size_t _numAtoms{0};  // number of supported atoms
@@ -347,11 +353,9 @@ private:
     vector<double> _vthermscav;   // indexed on m
     ArrayTable<2> _cumprobscavv;  // indexed on ell, m
 
-    // bound-electron scattering resources depending on the configured implementation
-    ComptonPhaseFunction _cpf;  // the free-electron Compton phase function helper
-    vector<Array> _RSSv;        // 0: E (keV); 1-30: smooth Rayleigh cross sections (cm2)
-    vector<Array> _RSAv;        // 2*Z: E (keV); 2*Z+1: anomalous Rayleigh cross sections (cm2)
-    vector<Array> _CSv;         // 0: E (keV); 1-30: bound Compton cross sections (cm2)
+    // bound-electron scattering helpers depending on the configured implementation
+    ScatteringHelper* _ray{nullptr};  // Rayleigh scattering helper
+    ScatteringHelper* _com{nullptr};  // Compton scattering helper
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/resources/ExpectedResources.txt
+++ b/SKIRT/resources/ExpectedResources.txt
@@ -1,2 +1,3 @@
 Core 6
 BPASS 1
+AtomsMolecules 1


### PR DESCRIPTION
**Description**
This update improves the implementation in the `XRayAtomicGasMix` class of X-ray photon scattering by bound electrons in the neutral atomic gas. This process can be elastic (Rayleigh scattering) or inelastic (bound-Compton scattering). The user can now select one of three implementations through the `scatterBoundElectrons` option. In increasing order of accuracy and computational effort, these are:

- _Free_: use free-electron Compton scattering. This approximation works reasonably well for high energies (because the bound-electron scattering cross section approaches that of free-electron scattering) and for lower energies (because the total scattering cross section is dominated by photo-absorption anyway). However, it is less accurate for intermediate energies.

- _Good_: use the smooth Rayleigh scattering approximation and exact bound-Compton scattering. This reflects the implementation by most X-ray codes and can be considered to be a good approximation. It relies on tabulated cross sections and correction factors.

- _Exact_: use anomalous Rayleigh scattering and exact bound-Compton scattering. This implementation accurately reflects the physical processes, apart from approximations caused by discretization, tabulation, and interpolation.

**Motivation**
The previous implementation (corresponding to the _Free_ option discussed above) was not sufficiently accurate in some relevant photon energy ranges.

**Compatibility**
The _Good_ option is now used by default. As a result, existing ski files will run slower and may produce a slightly different (assumedly better) result. To reproduce the old behavior, set the option to _Free_.

**Tests**
Functional tests were added. 

