### PR TITLE
Support NaN values in column text files

### DIFF
--- a/SKIRT/core/TextInFile.cpp
+++ b/SKIRT/core/TextInFile.cpp
@@ -271,26 +271,29 @@ void TextInFile::addColumn(string description, string quantity, string defaultUn
     if (col.quantity.empty())  // dimensionless quantity
     {
         if (!col.unit.empty() && col.unit != "1")
-            throw FATALERROR("Invalid units for dimensionless quantity in column " + std::to_string(_numLogCols));
+            throw FATALERROR("Invalid units (" + col.unit + ") for dimensionless quantity in column "
+                             + std::to_string(_numLogCols));
         col.unit = "1";
     }
     else if (col.quantity == "specific")  // arbitrarily scaled value per wavelength or per frequency
     {
         col.waveExponent = waveExponentForSpecificQuantity(_units, col.unit);
         if (col.waveExponent == ERROR_NO_EXPON)
-            throw FATALERROR("Invalid units for specific quantity in column " + std::to_string(_numLogCols));
+            throw FATALERROR("Invalid units (" + col.unit + ") for specific quantity '" + col.quantity + "' in column "
+                             + std::to_string(_numLogCols));
         if (col.waveExponent)
         {
             col.waveIndex = waveIndexForSpecificQuantity();
             if (col.waveIndex == ERROR_NO_INDEX)
-                throw FATALERROR("No preceding wavelength column for specific quantity in column "
-                                 + std::to_string(_numLogCols));
+                throw FATALERROR("No preceding wavelength column for specific quantity '" + col.quantity
+                                 + "' in column " + std::to_string(_numLogCols));
         }
     }
     else
     {
         if (!_units->has(col.quantity, col.unit))
-            throw FATALERROR("Invalid units for quantity in column " + std::to_string(_numLogCols));
+            throw FATALERROR("Invalid units (" + col.unit + ") for quantity '" + col.quantity + "' in column "
+                             + std::to_string(_numLogCols));
         double offset;  // all SKIRT units have a zero offset
         std::tie(col.convFactor, col.convPower, offset) = _units->def(col.quantity, col.unit);
     }


### PR DESCRIPTION
**Description**
Some standard library implementations do not support reading NaN or Inf values from a text input stream, while others do. This update provides backup support for NaN values in the `TextInFile` class on those platforms that don't support them automatically. The error messages issued by the `TextInFile` class are now also more informative.

_Note_: supporting infinite values is more complex because of the need for handling the negative sign which may be already consumed by the stream, and, at least for now, we don't need infinite values anyway.

**Motivation**
The resource files for anomalous Rayleigh scattering used by the `XRayAtomicGasMix` class contain NaN values.

**Tests**
Tested the `XRayAtomicGasMix` class with GCC on Ubuntu as well as Clang on Mac OS.
