### PR TITLE
Introduce optional explicit absorption in the photon packet life cycle

### DIFF
--- a/SKIRT/core/Configuration.cpp
+++ b/SKIRT/core/Configuration.cpp
@@ -101,6 +101,7 @@ void Configuration::setupSelfBefore()
     // ---- set configuration relevant for simulations that have media ----
 
     // retrieve basic photon life-cycle options
+    _explicitAbsorption = ms->photonPacketOptions()->explicitAbsorption();
     _forceScattering = ms->photonPacketOptions()->forceScattering();
     _minWeightReduction = ms->photonPacketOptions()->minWeightReduction();
     _minScattEvents = ms->photonPacketOptions()->minScattEvents();

--- a/SKIRT/core/Configuration.cpp
+++ b/SKIRT/core/Configuration.cpp
@@ -110,9 +110,6 @@ void Configuration::setupSelfBefore()
     // check for negative extinction, which requires explicit absorption
     for (auto medium : ms->media())
         if (medium->mix()->hasNegativeExtinction()) _hasNegativeExtinction = true;
-    if (_hasNegativeExtinction && !_explicitAbsorption)
-        throw FATALERROR(
-            "Media with negative extinction (stimulated emission) require explicit absorption to be enabled");
 
     // retrieve Lyman-alpha options
     if (simulationMode == SimulationMode::LyaExtinctionOnly)
@@ -419,6 +416,14 @@ void Configuration::setupSelfAfter()
     }
 
     // --- other warnings ---
+
+    // enable explicit absorption when we have negative extinction because
+    // the photon cycle without explicit absorption does not support negative extinction
+    if (_hasNegativeExtinction && !_explicitAbsorption)
+    {
+        log->warning("  Enabling explicit absorption to allow handling negative extinction cross sections");
+        _explicitAbsorption = true;
+    }
 
     // enable forced scattering when we have a radiation field because
     // the photon cycle without forced scattering does not support storing the radiation field

--- a/SKIRT/core/Configuration.cpp
+++ b/SKIRT/core/Configuration.cpp
@@ -107,6 +107,13 @@ void Configuration::setupSelfBefore()
     _minScattEvents = ms->photonPacketOptions()->minScattEvents();
     _pathLengthBias = ms->photonPacketOptions()->pathLengthBias();
 
+    // check for negative extinction, which requires explicit absorption
+    for (auto medium : ms->media())
+        if (medium->mix()->hasNegativeExtinction()) _hasNegativeExtinction = true;
+    if (_hasNegativeExtinction && !_explicitAbsorption)
+        throw FATALERROR(
+            "Media with negative extinction (stimulated emission) require explicit absorption to be enabled");
+
     // retrieve Lyman-alpha options
     if (simulationMode == SimulationMode::LyaExtinctionOnly)
     {
@@ -272,7 +279,7 @@ void Configuration::setupSelfBefore()
         }
     }
 
-    // check for semi-dymamic medium state
+    // check for semi-dynamic medium state
     if (_hasSecondaryEmission)
         for (auto medium : ms->media())
             if (medium->mix()->hasSemiDynamicMediumState()) _hasSemiDynamicState = true;

--- a/SKIRT/core/Configuration.cpp
+++ b/SKIRT/core/Configuration.cpp
@@ -415,7 +415,7 @@ void Configuration::setupSelfAfter()
         log->warning("  Selecting a grid with the model symmetry might be more efficient");
     }
 
-    // --- other warnings ---
+    // --- log (and possibly adjust) photon cycle options ---
 
     // enable explicit absorption when we have negative extinction because
     // the photon cycle without explicit absorption does not support negative extinction
@@ -433,6 +433,14 @@ void Configuration::setupSelfAfter()
         _forceScattering = true;
     }
 
+    // log photon cycle variations
+    if (_hasMedium)
+    {
+        string ea = _explicitAbsorption ? "with" : "no";
+        string fs = _forceScattering ? "with" : "no";
+        log->info("  Photon life cycle: " + ea + " explicit absorption; " + fs + " forced scattering");
+    }
+
     // disable path length stretching if the wavelength of a photon packet can change during its lifetime
     if ((_hasMovingMedia || _hasScatteringDispersion || _hubbleExpansionRate || _hasLymanAlpha) && _forceScattering
         && _pathLengthBias > 0.)
@@ -440,6 +448,8 @@ void Configuration::setupSelfAfter()
         log->warning("  Disabling path length stretching to allow Doppler shifts to be properly sampled");
         _pathLengthBias = 0.;
     }
+
+    // --- log magnetic field issues ---
 
     // if there is a magnetic field, there usually should be spheroidal particles
     if (_magneticFieldMediumIndex >= 0 && !_hasSpheroidalPolarization)

--- a/SKIRT/core/Configuration.hpp
+++ b/SKIRT/core/Configuration.hpp
@@ -295,6 +295,10 @@ public:
 
     // ----> photon cycle
 
+    /** Returns true if explicit absorption should be used during the photon cycle, false if not.
+        */
+    bool explicitAbsorption() const { return _explicitAbsorption; }
+
     /** Returns true if forced scattering should be used during the photon cycle, false if not. */
     bool forceScattering() const { return _forceScattering; }
 
@@ -457,6 +461,7 @@ private:
     double _maxFractionOfPrevious{0.03};
 
     // photon cycle
+    bool _explicitAbsorption{false};
     bool _forceScattering{true};
     double _minWeightReduction{1e4};
     int _minScattEvents{0};

--- a/SKIRT/core/Configuration.hpp
+++ b/SKIRT/core/Configuration.hpp
@@ -295,6 +295,11 @@ public:
 
     // ----> photon cycle
 
+    /** Returns true if the extinction cross section (the sum of the absorption and scattering
+        cross section) for one or more material mixes in the simulation can be negative, and false
+        if not. */
+    bool hasNegativeExtinction() const { return _hasNegativeExtinction; }
+
     /** Returns true if explicit absorption should be used during the photon cycle, false if not.
         */
     bool explicitAbsorption() const { return _explicitAbsorption; }
@@ -461,6 +466,7 @@ private:
     double _maxFractionOfPrevious{0.03};
 
     // photon cycle
+    bool _hasNegativeExtinction{false};
     bool _explicitAbsorption{false};
     bool _forceScattering{true};
     double _minWeightReduction{1e4};

--- a/SKIRT/core/ConvergenceInfoProbe.cpp
+++ b/SKIRT/core/ConvergenceInfoProbe.cpp
@@ -24,9 +24,9 @@ namespace
         // we integrate along a small offset from the axes to avoid cell borders
         double eps = 1e-12 * ms->grid()->boundingBox().widths().norm();
         SpatialGridPath path(Position(eps, eps, eps), axis);
-        double tau = ms->getOpticalDepth(&path, lambda, type);
+        double tau = ms->getExtinctionOpticalDepth(&path, lambda, type);
         path.setDirection(Direction(-axis.x(), -axis.y(), -axis.z()));
-        tau += ms->getOpticalDepth(&path, lambda, type);
+        tau += ms->getExtinctionOpticalDepth(&path, lambda, type);
         return tau;
     }
 

--- a/SKIRT/core/FluxRecorder.cpp
+++ b/SKIRT/core/FluxRecorder.cpp
@@ -241,7 +241,7 @@ void FluxRecorder::detect(PhotonPacket* pp, int l, double distance)
             }
             else
             {
-                tau = _ms->getOpticalDepth(pp, distance);
+                tau = _ms->getExtinctionOpticalDepth(pp, distance);
                 pp->setObservedOpticalDepth(tau);
             }
             Lext *= exp(-tau);

--- a/SKIRT/core/MaterialMix.cpp
+++ b/SKIRT/core/MaterialMix.cpp
@@ -48,6 +48,13 @@ bool MaterialMix::hasResonantScattering() const
 
 ////////////////////////////////////////////////////////////////////
 
+bool MaterialMix::hasNegativeExtinction() const
+{
+    return false;
+}
+
+////////////////////////////////////////////////////////////////////
+
 bool MaterialMix::hasStochasticDustEmission() const
 {
     return false;

--- a/SKIRT/core/MaterialMix.hpp
+++ b/SKIRT/core/MaterialMix.hpp
@@ -243,6 +243,22 @@ public:
         false. */
     virtual bool hasResonantScattering() const;
 
+    /** This function returns true if the extinction cross section (the sum of the absorption and
+        scattering cross section) for this material mix can be negative, and false otherwise. The
+        default implementation in this base class returns false.
+
+        For all material mixes, the scattering cross section must always be positive or zero for
+        all wavelengths and material properties. The absorption cross section at a given wavelength
+        can be negative if the material exhibits stimulated emission at that wavelength. As long as
+        the magnitude of the absorption cross section is guaranteed to be smaller than the
+        scattering cross section, the extinction cross section (the sum of both cross sections)
+        always remains positive, and this function can safely return false. As soon as the
+        magnitude of the negative absorption cross section can be larger than the scattering cross
+        section for some wavelengths and material properties, this function must return true. This
+        allows the photon cycle machinery to properly handle negative extinction cross sections
+        and the corresponding negative optical depths. */
+    virtual bool hasNegativeExtinction() const;
+
     /** This function returns true if this material mix represents dust and supports stochastic
         heating of dust grains for the calculation of secondary emission, and false otherwise. The
         default implementation in this base class returns false. */

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -829,7 +829,6 @@ void MediumSystem::setExtinctionOpticalDepths(PhotonPacket* pp) const
 
     // calculate the cumulative optical depth and store it in the photon packet for each path segment
     double tau = 0.;
-    int i = 0;
 
     // single medium, spatially constant cross sections
     if (_config->hasSingleConstantSectionMedium())
@@ -837,8 +836,8 @@ void MediumSystem::setExtinctionOpticalDepths(PhotonPacket* pp) const
         double section = mix(0, 0)->sectionExt(pp->wavelength());
         for (auto& segment : pp->segments())
         {
-            if (segment.m >= 0) tau += section * _state.numberDensity(segment.m, 0) * segment.ds;
-            pp->setOpticalDepth(i++, tau);
+            if (segment.m() >= 0) tau += section * _state.numberDensity(segment.m(), 0) * segment.ds();
+            segment.setOpticalDepth(tau);
         }
     }
 
@@ -849,10 +848,10 @@ void MediumSystem::setExtinctionOpticalDepths(PhotonPacket* pp) const
         for (int h = 0; h != _numMedia; ++h) sectionv[h] = mix(0, h)->sectionExt(pp->wavelength());
         for (auto& segment : pp->segments())
         {
-            if (segment.m >= 0)
+            if (segment.m() >= 0)
                 for (int h = 0; h != _numMedia; ++h)
-                    tau += sectionv[h] * _state.numberDensity(segment.m, h) * segment.ds;
-            pp->setOpticalDepth(i++, tau);
+                    tau += sectionv[h] * _state.numberDensity(segment.m(), h) * segment.ds();
+            segment.setOpticalDepth(tau);
         }
     }
 
@@ -861,13 +860,13 @@ void MediumSystem::setExtinctionOpticalDepths(PhotonPacket* pp) const
     {
         for (auto& segment : pp->segments())
         {
-            if (segment.m >= 0)
+            if (segment.m() >= 0)
             {
-                double lambda =
-                    pp->perceivedWavelength(_state.bulkVelocity(segment.m), _config->hubbleExpansionRate() * segment.s);
-                tau += opacityExt(lambda, segment.m, pp) * segment.ds;
+                double lambda = pp->perceivedWavelength(_state.bulkVelocity(segment.m()),
+                                                        _config->hubbleExpansionRate() * segment.s());
+                tau += opacityExt(lambda, segment.m(), pp) * segment.ds();
             }
-            pp->setOpticalDepth(i++, tau);
+            segment.setOpticalDepth(tau);
         }
     }
 }
@@ -887,7 +886,6 @@ void MediumSystem::setScatteringAndAbsorptionOpticalDepths(PhotonPacket* pp) con
     // calculate the cumulative optical depths and store them in the photon packet for each path segment
     double tauSca = 0.;
     double tauAbs = 0.;
-    int i = 0;
 
     // single medium, spatially constant cross sections
     if (_config->hasSingleConstantSectionMedium())
@@ -896,13 +894,13 @@ void MediumSystem::setScatteringAndAbsorptionOpticalDepths(PhotonPacket* pp) con
         double sectionAbs = mix(0, 0)->sectionAbs(pp->wavelength());
         for (auto& segment : pp->segments())
         {
-            if (segment.m >= 0)
+            if (segment.m() >= 0)
             {
-                double ns = _state.numberDensity(segment.m, 0) * segment.ds;
+                double ns = _state.numberDensity(segment.m(), 0) * segment.ds();
                 tauSca += sectionSca * ns;
                 tauAbs += sectionAbs * ns;
             }
-            pp->setOpticalDepth(i++, tauSca, tauAbs);
+            segment.setOpticalDepth(tauSca, tauAbs);
         }
     }
 
@@ -918,14 +916,14 @@ void MediumSystem::setScatteringAndAbsorptionOpticalDepths(PhotonPacket* pp) con
         }
         for (auto& segment : pp->segments())
         {
-            if (segment.m >= 0)
+            if (segment.m() >= 0)
                 for (int h = 0; h != _numMedia; ++h)
                 {
-                    double ns = _state.numberDensity(segment.m, h) * segment.ds;
+                    double ns = _state.numberDensity(segment.m(), h) * segment.ds();
                     tauSca += sectionScav[h] * ns;
                     tauAbs += sectionAbsv[h] * ns;
                 }
-            pp->setOpticalDepth(i++, tauSca, tauAbs);
+            segment.setOpticalDepth(tauSca, tauAbs);
         }
     }
 
@@ -934,14 +932,14 @@ void MediumSystem::setScatteringAndAbsorptionOpticalDepths(PhotonPacket* pp) con
     {
         for (auto& segment : pp->segments())
         {
-            if (segment.m >= 0)
+            if (segment.m() >= 0)
             {
-                double lambda =
-                    pp->perceivedWavelength(_state.bulkVelocity(segment.m), _config->hubbleExpansionRate() * segment.s);
-                tauSca += opacitySca(lambda, segment.m, pp) * segment.ds;
-                tauAbs += opacityAbs(lambda, segment.m, pp) * segment.ds;
+                double lambda = pp->perceivedWavelength(_state.bulkVelocity(segment.m()),
+                                                        _config->hubbleExpansionRate() * segment.s());
+                tauSca += opacitySca(lambda, segment.m(), pp) * segment.ds();
+                tauAbs += opacityAbs(lambda, segment.m(), pp) * segment.ds();
             }
-            pp->setOpticalDepth(i++, tauSca, tauAbs);
+            segment.setOpticalDepth(tauSca, tauAbs);
         }
     }
 }

--- a/SKIRT/core/MediumSystem.hpp
+++ b/SKIRT/core/MediumSystem.hpp
@@ -341,6 +341,25 @@ public:
 
     //=============== High-level photon life cycle ===================
 
+private:
+    /** This function returns the absorption opacity \f$k^\text{abs}=\sum_h k_h^\text{abs}\f$
+        summed over all medium components at wavelength \f$\lambda\f$ in spatial cell with index
+        \f$m\f$, where applicable taking into account the properties of the specified incoming
+        photon packet (for example, its polarization state). */
+    double opacityAbs(double lambda, int m, const PhotonPacket* pp) const;
+
+    /** This function returns the scattering opacity \f$k^\text{sca}=\sum_h k_h^\text{sca}\f$
+        summed over all medium components at wavelength \f$\lambda\f$ in spatial cell with index
+        \f$m\f$, where applicable taking into account the properties of the specified incoming
+        photon packet (for example, its polarization state). */
+    double opacitySca(double lambda, int m, const PhotonPacket* pp) const;
+
+    /** This function returns the extinction opacity \f$k^\text{ext}=\sum_h k_h^\text{ext}\f$
+        summed over all medium components at wavelength \f$\lambda\f$ in spatial cell with index
+        \f$m\f$, where applicable taking into account the properties of the specified incoming
+        photon packet (for example, its polarization state). */
+    double opacityExt(double lambda, int m, const PhotonPacket* pp) const;
+
 public:
     /** This function returns the perceived wavelength of the photon packet at the scattering
         interaction distance, taking into account the bulk velocity and Hubble expansion velocity
@@ -480,7 +499,29 @@ public:
         setOpticalDepths() function, i.e. at the wavelength perceived by the medium in the cell
         being crossed and taking into account any relevant properties of the incoming photon
         packet. */
-    bool setInteractionPoint(PhotonPacket* pp, double tauscat) const;
+    bool setInteractionPoint(PhotonPacket* pp, double tauinteract) const;
+
+    /** This function calculates the cumulative scattering optical depth, the cumulative absorption
+        optical depth, and the distance at the end of each of the path segments along a path
+        through the medium system defined by the initial position and direction of the specified
+        PhotonPacket object. The calculation proceeds until the \em scattering optical depth
+        reaches the specified interaction optical depth. The function then interpolates the
+        interaction point, stores it in the photon packet along with the corresponding absorption
+        optical depth, and returns true. If the specified interaction optical depth is never
+        reached within the path, the function returns false.
+
+        This function is intended for handling random-walk photon packet paths during a photon life
+        cycle that does \em not use forced-scattering and \em does use explicit absorption. In that
+        case there is no need to calculate the complete path, substantially boosting performance in
+        high-optical depth media. Because the function is at the heart of the photon life cycle,
+        performance is important. Hence it implements optimized versions for media with spatially
+        constant cross sections.
+
+        The optical depth for each traversed path segment is calculated as described for the
+        setOpticalDepths() function, i.e. at the wavelength perceived by the medium in the cell
+        being crossed and taking into account any relevant properties of the incoming photon
+        packet. */
+    bool setExplicitAbsorptionInteractionPoint(PhotonPacket* pp, double tauinteract) const;
 
     /** This function calculates and returns the optical depth (or -1, see "High optical depth
         below") along a path through the medium system defined by the initial position and

--- a/SKIRT/core/MediumSystem.hpp
+++ b/SKIRT/core/MediumSystem.hpp
@@ -482,6 +482,40 @@ public:
         to zero by definition. */
     void setOpticalDepths(PhotonPacket* pp) const;
 
+    /** This function calculates the cumulative scattering and absorption optical depths at the end
+        of each path segment along a path through the medium system defined by the initial position
+        and direction of the specified PhotonPacket object, and stores the results of the
+        calculation into the same PhotonPacket object.
+
+        This function is intended for handling random-walk photon packet paths during a
+        forced-scattering photon life cycle that uses explicit absorption. In this case, the next
+        interaction point is determined based on the scattering optical depth (as opposed to the
+        total extinction optical depth), so we need to calculate and store the scattering and
+        absorption optical depths separately.
+
+        Because it is at the heart of the photon life cycle, performance is important. Firstly,
+        separating the geometric and optical depth calculations seems to be faster, probably due to
+        memory access and caching issues. So the function first determines and stores the path
+        segments and then calculates and stores the cumulative optical depth at the end of each
+        segment. Secondly, the function implements optimized versions for media with spatially
+        constant cross sections.
+
+        With the geometric path information given, the function calculates the optical depth for
+        each path segment \f$(\Delta s)_m\f$ as it crosses the spatial cell with index \f$m\f$ as
+        \f[ \tau_m = (\Delta s)_m \sum_h k_{m,h}^\text{ext}, \f] where \f$k_{m,h}^\text{ext}\f$ is
+        the extinction opacity corresponding to the \f$h\f$'th medium component in the cell with
+        index \f$m\f$ and the sum over \f$h\f$ runs over all medium components. The opacities
+        \f$k_{m,h}^\text{ext}\f$ are calculated at the wavelength perceived by the medium in cell
+        \f$m\f$ taking into account the bulk velocity and Hubble expansion velocity in that cell,
+        and taking into account any relevant properties of the incoming photon packet such as the
+        polarization state.
+
+        Using these optical depth values per segment, the function determines the cumulative
+        optical depth at the segment exit boundaries and stores them into the specified photon
+        packet object as well. Note that the optical depth at entry of the initial segment is equal
+        to zero by definition. */
+    void setExplicitAbsorptionOpticalDepths(PhotonPacket* pp) const;
+
     /** This function calculates the cumulative optical depth and distance at the end of path
         segments along a path through the medium system defined by the initial position and
         direction of the specified PhotonPacket object until the specified interaction optical

--- a/SKIRT/core/MonteCarloSimulation.cpp
+++ b/SKIRT/core/MonteCarloSimulation.cpp
@@ -539,7 +539,7 @@ void MonteCarloSimulation::performLifeCycle(size_t firstIndex, size_t numIndices
                             while (true)
                             {
                                 // calculate segments and optical depths for the complete path
-                                mediumSystem()->setOpticalDepths(&pp);
+                                mediumSystem()->setExtinctionOpticalDepths(&pp);
 
                                 // advance the packet
                                 if (store) storeRadiationField(&pp);
@@ -563,7 +563,7 @@ void MonteCarloSimulation::performLifeCycle(size_t firstIndex, size_t numIndices
                             while (true)
                             {
                                 // calculate segments and optical depths for the complete path
-                                mediumSystem()->setExplicitAbsorptionOpticalDepths(&pp);
+                                mediumSystem()->setScatteringAndAbsorptionOpticalDepths(&pp);
 
                                 // advance the packet
                                 if (store) storeRadiationField(&pp);
@@ -798,7 +798,7 @@ bool MonteCarloSimulation::simulateNonForcedPropagation(PhotonPacket* pp)
 
     // find the physical interaction point corresponding to this optical depth
     // if the interaction point is outside of the path, terminate the photon packet
-    if (!mediumSystem()->setInteractionPoint(pp, tauinteract)) return false;
+    if (!mediumSystem()->setInteractionPointUsingExtinction(pp, tauinteract)) return false;
 
     // calculate the albedo for the cell containing the interaction point
     double albedo = mediumSystem()->albedoForScattering(pp);
@@ -821,7 +821,7 @@ bool MonteCarloSimulation::simulateNonForcedExplicitAbsorptionPropagation(Photon
     // find the physical interaction point corresponding to this scattering optical depth
     // and calculate the absorption optical depth at the interaction point;
     // if the interaction point is outside of the path, terminate the photon packet
-    if (!mediumSystem()->setExplicitAbsorptionInteractionPoint(pp, tauinteract)) return false;
+    if (!mediumSystem()->setInteractionPointUsingScatteringAndAbsorption(pp, tauinteract)) return false;
 
     // get the cumulative absorption optical depth at the interaction point
     double tauAbs = pp->interactionOpticalDepth();

--- a/SKIRT/core/MonteCarloSimulation.cpp
+++ b/SKIRT/core/MonteCarloSimulation.cpp
@@ -556,7 +556,7 @@ void MonteCarloSimulation::performLifeCycle(size_t firstIndex, size_t numIndices
                             mediumSystem()->simulateScattering(random(), &pp);
                         }
                     }
-                    // --- no forced scattering ---
+                    // --- non-forced scattering ---
                     else
                     {
                         while (true)

--- a/SKIRT/core/MonteCarloSimulation.hpp
+++ b/SKIRT/core/MonteCarloSimulation.hpp
@@ -522,66 +522,6 @@ private:
         information). The packet is now ready to be scattered into a new direction. */
     void simulateForcedPropagation(PhotonPacket* pp);
 
-    /** This function determines the next scattering location of a photon packet in a photon life
-        cycle with forced scattering and simulates its propagation to that position. The function
-        assumes that both the geometric and optical depth information for the photon packet's path
-        have been set; if this is not the case, the behavior is undefined. This function proceeds
-        in a number of steps as outlined below.
-
-        <b>Total optical depth</b>
-
-        We first determine the total optical depth \f$\tau_\text{path}\f$ of the photon packet's
-        path. Because the path has been calculated until the edge of the simulation's spatial grid,
-        \f$\tau_\text{path}\f$ is equal to the cumulative optical depth at the end of the last
-        segment in the path.
-
-        <b>%Random optical depth</b>
-
-        We then randomly generate the optical depth \f$\tau\f$ at the interaction site from an
-        appropriate distribution. Given the total optical depth along the path of the photon packet
-        \f$\tau_\text{path}\f$, the appropriate probability distribution for the covered optical
-        depth is an exponential probability distribution cut off at \f$\tau_\text{path}\f$.
-        Properly normalized, it reads as \f[ p(\tau) = \frac{{\text{e}}^{-\tau}}
-        {1-{\text{e}}^{-\tau_\text{path}}} \f] where the range of \f$\tau\f$ is limited to the
-        interval \f$[0,\tau_\text{path}]\f$. Instead of generating a random optical depth
-        \f$\tau\f$ directly from this distribution, we use the biasing technique in order to cover
-        the entire allowed optical depth range \f$[0,\tau_\text{path}]\f$ more uniformly. As the
-        biased probability distribution, we use a linear combination between an exponential
-        distribution and a uniform distribution, with a parameter \f$\xi\f$ setting the relative
-        importance of the uniform part. In formula form, \f[ q(\tau) = (1-\xi)\, \frac{
-        {\text{e}}^{-\tau} } { 1-{\text{e}}^{-\tau_\text{path}} } + \frac{\xi}{\tau_\text{path}}.
-        \f] A random optical depth from this distribution is readily determined. Since we use
-        biasing, the weight, or correspondingly the luminosity, of the photon packet needs to be
-        adjusted with a bias factor \f$p(\tau)/q(\tau)\f$.
-
-        <b>Interaction point</b>
-
-        Now that the optical depth \f$\tau\f$ at the interaction site has been (randomly) chosen,
-        we determine the physical position of the interaction point along the path. This is
-        accomplished in two steps: a binary search among the path segments to determine the segment
-        (or cell) "containing" the given cumulative optical depth, and subsequent linear
-        interpolation within the cell assuming exponential behavior of the extinction.
-
-        <b>Albedo</b>
-
-        We calculate the scattering albedo \f$\varpi\f$ of the medium at the interaction point (or
-        more precisely, for the spatial cell containing the interaction point).
-
-        <b>Weight adjustment</b>
-
-        We adjust the weight of the photon packet to compensate for the escaped and absorbed
-        portions of the luminosity. More precisely, the weight is multiplied by the scattered
-        fraction, i.e. the fraction of the luminosity that does not escape and does not get
-        absorbed, \f[ f_\text{sca} = (1-f_\text{esc}) \,\varpi = (1-\text{e}^{-\tau_\text{path}})
-        \,\varpi. \f]
-
-        <b>Advance position</b>
-
-        Finally we advance the initial position of the photon packet to the interaction point. This
-        last step invalidates the photon packet's path (including geometric and optical depth
-        information). The packet is now ready to be scattered into a new direction. */
-    void simulateForcedExplicitAbsorptionPropagation(PhotonPacket* pp);
-
     /** This function simulates the propagation of a photon packet to the next scattering location
         in a photon life cycle without forced scattering. It proceeds in a number of steps as
         outlined below. The function returns false if the photon packet must be terminated.
@@ -656,7 +596,6 @@ private:
         Finally we advance the initial position of the photon packet to the interaction point. This
         last step invalidates the photon packet's path (including geometric and optical depth
         information). The packet is now ready to be scattered into a new direction. */
-    bool simulateNonForcedExplicitAbsorptionPropagation(PhotonPacket* pp);
 
     /** This function simulates the peel-off of a photon packet before a scattering event. This
         means that, just before a scattering event, we create a peel-off photon packet for every

--- a/SKIRT/core/MonteCarloSimulation.hpp
+++ b/SKIRT/core/MonteCarloSimulation.hpp
@@ -523,10 +523,8 @@ private:
     void simulateForcedPropagation(PhotonPacket* pp);
 
     /** This function simulates the propagation of a photon packet to the next scattering location
-        in a photon life cycle without forced scattering. The function assumes that the next
-        scattering location for the photon packet's path has already been set; if this is not the
-        case, the behavior is undefined. This function proceeds in a number of steps as outlined
-        below.
+        in a photon life cycle without forced scattering. It proceeds in a number of steps as
+        outlined below. The function returns false if the photon packet must be terminated.
 
         <b>%Random optical depth</b>
 
@@ -562,7 +560,43 @@ private:
         Finally we advance the initial position of the photon packet to the interaction point. This
         last step invalidates the photon packet's path (including geometric and optical depth
         information). The packet is now ready to be scattered into a new direction. */
-    void simulateNonForcedPropagation(PhotonPacket* pp);
+    bool simulateNonForcedPropagation(PhotonPacket* pp);
+
+    /** This function simulates the propagation of a photon packet to the next scattering location
+        in a photon life cycle without forced scattering and using explicit absorption. It proceeds
+        in a number of steps as outlined below. The function returns false if the photon packet
+        must be terminated.
+
+        <b>%Random optical depth</b>
+
+        Because the photon packet is allowed to escape the model, we randomly generate the \em
+        scattering optical depth \f$\tau_\text{sca}\f$ at the interaction site from the regular
+        exponential distribution. The current implementation does not support path length biasing.
+
+        <b>Interaction point</b>
+
+        We generate the path segments for crossed cells one by one and on the fly calculate the
+        corresponding cumulative scattering optical depth \f$\tau_\text{sca}\f$, absorption optical
+        depth \f$\tau_\text{abs}\f$, and distance \f$s\f$ covered. Once the cumulative scattering
+        optical depth at the exit point of a segment exceeds the interaction scattering optical
+        depth, we know that the interaction point must be within this segment. The physical
+        location and the absorption optical depth of the interaction point is then obtained through
+        linear interpolation within the segment, assuming exponential behavior of the extinction.
+        If the cumulative scattering optical depth of the path never exceeds the interaction
+        scattering optical depth, the photon packet escapes and is terminated.
+
+        <b>Weight adjustment</b>
+
+        We adjust the weight of the photon packet to compensate for the absorbed portion of the
+        luminosity along the path to the interaction site. More precisely, the weight is multiplied
+        by \f$\exp(-\tau_\text{abs})\f$.
+
+        <b>Advance position</b>
+
+        Finally we advance the initial position of the photon packet to the interaction point. This
+        last step invalidates the photon packet's path (including geometric and optical depth
+        information). The packet is now ready to be scattered into a new direction. */
+    bool simulateNonForcedExplicitAbsorptionPropagation(PhotonPacket* pp);
 
     /** This function simulates the peel-off of a photon packet before a scattering event. This
         means that, just before a scattering event, we create a peel-off photon packet for every

--- a/SKIRT/core/PhotonPacketOptions.hpp
+++ b/SKIRT/core/PhotonPacketOptions.hpp
@@ -14,17 +14,32 @@
     Monte Carlo photon packet life cycle. These options are relevant as soon as there is a medium
     in the configuration.
 
-    Two variations of the photon life cycle are implemented: with and without forced scattering.
-    Forced scattering is the default behavior for all simulation modes except when Lyman-alpha line
-    transfer is included (because the extra peel-offs for the many resonant scattering events tend
-    to slow down the simulation). The implementation without forced scattering does \em not support
-    storing the radiation field, which means it cannot be used when the simulation includes
-    secondary emission or dynamic state iteration. */
+    Several variations of the photon life cycle implementation can be configured:
+
+    - With or without explicit absorption. Explicit absorption allows absorption cross sections to
+    be negative, which can be the case for materials that exhibit stimulated emission. Note that
+    scattering cross sections never can be negative. The default behavior is not to use explicit
+    absorption, because the effects of this recent technique has not yet been well studied.
+
+    - With or without forced scattering. Forced scattering tends to reduce noise for simulations
+    with low to limited optical depths, such as for most dust models on galaxy-wide scales.
+    Therefore, forced scattering is the default behavior except when Lyman-alpha line transfer is
+    included, because the extra peel-offs for the many resonant scattering events tend to slow down
+    the simulation. Furthermore, the implementation without forced scattering currently does \em
+    not support storing the radiation field, which means it cannot be used when the simulation
+    includes secondary emission or dynamic state iteration.
+
+    The remaining options serve to further configure the detailed behavior of the forced scattering
+    photon cycle. */
 class PhotonPacketOptions : public SimulationItem
 {
     ITEM_CONCRETE(PhotonPacketOptions, SimulationItem, "a set of options related to the photon packet lifecycle")
 
-        PROPERTY_BOOL(forceScattering, "use forced scattering to accelerate the photon life cycle")
+        PROPERTY_BOOL(explicitAbsorption, "use explicit absorption to allow negative absorption (stimulated emission)")
+        ATTRIBUTE_DEFAULT_VALUE(explicitAbsorption, "false")
+        ATTRIBUTE_DISPLAYED_IF(explicitAbsorption, "Level3")
+
+        PROPERTY_BOOL(forceScattering, "use forced scattering to reduce noise")
         ATTRIBUTE_DEFAULT_VALUE(forceScattering, "Lya:false;true")
         ATTRIBUTE_RELEVANT_IF(forceScattering, "!(Emission|DynamicState)")
         ATTRIBUTE_DISPLAYED_IF(forceScattering, "Level3")

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -245,6 +245,7 @@
 #include "TreeSpatialGrid.hpp"
 #include "TreeSpatialGridTopologyProbe.hpp"
 #include "TriaxialGeometryDecorator.hpp"
+#include "TrivialGasMix.hpp"
 #include "TrustBenchmarkDustMix.hpp"
 #include "TrustGraphiteGrainComposition.hpp"
 #include "TrustNeutralPAHGrainComposition.hpp"
@@ -542,6 +543,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<EmittingGasMix>();
     ItemRegistry::add<SpinFlipHydrogenGasMix>();
     ///ItemRegistry::add<CarbonMonoxideGasMix>();
+    ItemRegistry::add<TrivialGasMix>();
 
     // material mix families
     ItemRegistry::add<MaterialMixFamily>();

--- a/SKIRT/core/TrivialGasMix.cpp
+++ b/SKIRT/core/TrivialGasMix.cpp
@@ -18,6 +18,14 @@ MaterialMix::MaterialType TrivialGasMix::materialType() const
 
 ////////////////////////////////////////////////////////////////////
 
+bool TrivialGasMix::hasNegativeExtinction() const
+{
+    // capture the border case where the magnitudes are nonzero and equal
+    return absorptionCrossSection() < 0. && (absorptionCrossSection() + scatteringCrossSection()) <= 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
 vector<StateVariable> TrivialGasMix::specificStateVariableInfo() const
 {
     return vector<StateVariable>{StateVariable::numberDensity()};

--- a/SKIRT/core/TrivialGasMix.cpp
+++ b/SKIRT/core/TrivialGasMix.cpp
@@ -1,0 +1,129 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "TrivialGasMix.hpp"
+#include "Constants.hpp"
+#include "MaterialState.hpp"
+#include "PhotonPacket.hpp"
+#include "Random.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+MaterialMix::MaterialType TrivialGasMix::materialType() const
+{
+    return MaterialType::Gas;
+}
+
+////////////////////////////////////////////////////////////////////
+
+vector<StateVariable> TrivialGasMix::specificStateVariableInfo() const
+{
+    return vector<StateVariable>{StateVariable::numberDensity()};
+}
+
+////////////////////////////////////////////////////////////////////
+
+double TrivialGasMix::mass() const
+{
+    return Constants::Mproton();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double TrivialGasMix::sectionAbs(double /*lambda*/) const
+{
+    return absorptionCrossSection();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double TrivialGasMix::sectionSca(double /*lambda*/) const
+{
+    return scatteringCrossSection();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double TrivialGasMix::sectionExt(double /*lambda*/) const
+{
+    return absorptionCrossSection() + scatteringCrossSection();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double TrivialGasMix::asymmpar(double /*lambda*/) const
+{
+    return asymmetryParameter();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double TrivialGasMix::opacityAbs(double /*lambda*/, const MaterialState* state, const PhotonPacket* /*pp*/) const
+{
+    return absorptionCrossSection() * state->numberDensity();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double TrivialGasMix::opacitySca(double /*lambda*/, const MaterialState* state, const PhotonPacket* /*pp*/) const
+{
+    return scatteringCrossSection() * state->numberDensity();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double TrivialGasMix::opacityExt(double /*lambda*/, const MaterialState* state, const PhotonPacket* /*pp*/) const
+{
+    return (absorptionCrossSection() + scatteringCrossSection()) * state->numberDensity();
+}
+
+////////////////////////////////////////////////////////////////////
+
+void TrivialGasMix::peeloffScattering(double& I, double& /*Q*/, double& /*U*/, double& /*V*/, double& /*lambda*/,
+                                      Direction bfkobs, Direction /*bfky*/, const MaterialState* /*state*/,
+                                      const PhotonPacket* pp) const
+{
+    // calculate the value of the Henyey-Greenstein phase function
+    double costheta = Vec::dot(pp->direction(), bfkobs);
+    double g = asymmetryParameter();
+    double t = 1. + g * g - 2. * g * costheta;
+    double value = (1. - g) * (1. + g) / sqrt(t * t * t);
+
+    // accumulate the weighted sum in the intensity
+    I += value;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void TrivialGasMix::performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const
+{
+    // determine the new propagation direction
+    // sample a scattering angle from the Henyey-Greenstein phase function
+    // handle isotropic scattering separately because the HG sampling procedure breaks down in this case
+    Direction bfknew;
+    double g = asymmetryParameter();
+    if (fabs(g) < 1e-6)
+    {
+        bfknew = random()->direction();
+    }
+    else
+    {
+        double f = ((1.0 - g) * (1.0 + g)) / (1.0 - g + 2.0 * g * random()->uniform());
+        double costheta = (1.0 + g * g - f * f) / (2.0 * g);
+        bfknew = random()->direction(pp->direction(), costheta);
+    }
+
+    // execute the scattering event in the photon packet
+    pp->scatter(bfknew, state->bulkVelocity(), lambda);
+}
+
+////////////////////////////////////////////////////////////////////
+
+double TrivialGasMix::indicativeTemperature(const MaterialState* /*state*/, const Array& /*Jv*/) const
+{
+    return 0.;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/TrivialGasMix.hpp
+++ b/SKIRT/core/TrivialGasMix.hpp
@@ -52,6 +52,11 @@ public:
         is MaterialType::Gas. */
     MaterialType materialType() const override;
 
+    /** This function returns true if the configured extinction cross section (the sum of the
+        configured absorption and scattering cross section) for this material mix is negative, and
+        false otherwise. */
+    bool hasNegativeExtinction() const override;
+
     //======== Medium state setup =======
 
 public:

--- a/SKIRT/core/TrivialGasMix.hpp
+++ b/SKIRT/core/TrivialGasMix.hpp
@@ -1,0 +1,125 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef TRIVIALGASMIX_HPP
+#define TRIVIALGASMIX_HPP
+
+#include "MaterialMix.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** The TrivialGasMix class represents a trivial gas mix defined by optical properties fully
+    specified inside the configuration file. It is provided for testing purposes, and specifically
+    for testing media with a negative absorption cross section (caused by stimulated emission).
+
+    The class is designed for use in monochromatic simulations. The gas mix properties do not
+    depend on wavelength, nor on any other property of the incoming photon packet or on any medium
+    state variable (other than the number density). The gas mix supports absorption and
+    Henyey-Greenstein scattering but no secondary emission. Each interacting entity in the gas is
+    considered to be a hydrogen atom, which sets the conversion scale from mass to number
+    normalization. If the gas distribution is normalized to a given optical depth, the values of
+    the cross sections (see below) are essentially scale free.
+
+    The following spatially-constant and wavelength-independent properties can be configured: the
+    absorption cross section per hydrogen atom, which can be negative; the scattering cross section
+    per hydrogen atom, which must be positive; and the scattering asymmetry parameter used with the
+    Henyey-Greenstein phase function. */
+class TrivialGasMix : public MaterialMix
+{
+    ITEM_CONCRETE(TrivialGasMix, MaterialMix, "A trivial gas mix for testing purposes")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(TrivialGasMix, "Level3")
+        ATTRIBUTE_TYPE_INSERT(TrivialGasMix, "GasMix")
+
+        PROPERTY_DOUBLE(absorptionCrossSection, "the absorption cross section per hydrogen atom")
+        ATTRIBUTE_QUANTITY(absorptionCrossSection, "section")
+
+        PROPERTY_DOUBLE(scatteringCrossSection, "the scattering cross section per hydrogen atom")
+        ATTRIBUTE_QUANTITY(scatteringCrossSection, "section")
+        ATTRIBUTE_MIN_VALUE(scatteringCrossSection, "[0")
+
+        PROPERTY_DOUBLE(asymmetryParameter, "the scattering asymmetry parameter")
+        ATTRIBUTE_MIN_VALUE(asymmetryParameter, "[-0.95")
+        ATTRIBUTE_MAX_VALUE(asymmetryParameter, "0.95]")
+
+    ITEM_END()
+
+    //======== Capabilities =======
+
+public:
+    /** This function returns the fundamental material type represented by this material mix, which
+        is MaterialType::Gas. */
+    MaterialType materialType() const override;
+
+    //======== Medium state setup =======
+
+public:
+    /** This function returns a list of StateVariable objects describing the specific state
+        variables used by the receiving material mix. For this class, the function returns just the
+        descriptor for the number density. */
+    vector<StateVariable> specificStateVariableInfo() const override;
+
+    //======== Low-level material properties =======
+
+public:
+    /** This function returns the mass of a hydrogen atom. */
+    double mass() const override;
+
+    /** This function returns the absorption cross section per hydrogen atom configured for this
+        material mix. The wavelength is not used. */
+    double sectionAbs(double lambda) const override;
+
+    /** This function returns the scattering cross section per hydrogen atom configured for this
+        material mix. The wavelength is not used. */
+    double sectionSca(double lambda) const override;
+
+    /** This function returns the extinction cross section per hydrogen atom, i.e. the sum of the
+        absorption and scattering cross sections per hydrogen atom configured for this material
+        mix. The wavelength is not used. */
+    double sectionExt(double lambda) const override;
+
+    /** This function returns the scattering asymmetry parameter configured for this material mix.
+        The wavelength is not used. */
+    double asymmpar(double lambda) const override;
+
+    //======== High-level photon life cycle =======
+
+public:
+    /** This function returns the absorption opacity for the number density given in the specified
+        material state. The wavelength and the photon packet properties are not used. */
+    double opacityAbs(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function returns the scattering opacity for the number density given in the specified
+        material state. The wavelength and the photon packet properties are not used. */
+    double opacitySca(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function returns the extinction opacity for the number density given in the specified
+        material state. The wavelength and the photon packet properties are not used. */
+    double opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function calculates the contribution of the medium component associated with this
+        material mix to the peel-off photon luminosity for the given observer direction. The
+        material state, wavelength and photon packet properties other than direction are not used.
+        */
+    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+                           const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function performs a scattering event for this material mix on the specified photon
+        packet. The photon packet properties other than luminosity and direction remain unchanged.
+        */
+    void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const override;
+
+    //======== Temperature =======
+
+public:
+    /** This function returns an indicative temperature of zero. The specified material state and
+        radiation field are noto used. */
+    double indicativeTemperature(const MaterialState* state, const Array& Jv) const override;
+
+    //======================== Data Members ========================
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -227,7 +227,7 @@ class XRayAtomicGasMix : public MaterialMix
 
     ITEM_CONCRETE(XRayAtomicGasMix, MaterialMix,
                   "A gas mix supporting photo-absorption and fluorescence for X-ray wavelengths")
-        ATTRIBUTE_TYPE_INSERT(EmittingGasMix, "GasMix")
+        ATTRIBUTE_TYPE_INSERT(XRayAtomicGasMix, "GasMix")
 
         PROPERTY_DOUBLE_LIST(abundancies, "the abundancies for the elements with atomic number Z = 1,...,30")
         ATTRIBUTE_MIN_VALUE(abundancies, "[0")

--- a/SKIRT/utils/SpatialGridPath.cpp
+++ b/SKIRT/utils/SpatialGridPath.cpp
@@ -208,3 +208,12 @@ void SpatialGridPath::setInteractionPoint(int m, double s)
 }
 
 ////////////////////////////////////////////////////////////////////
+
+void SpatialGridPath::setInteractionPoint(int m, double s, double tau)
+{
+    _interactionCellIndex = m;
+    _interactionDistance = s;
+    _interactionOpticalDepth = tau;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/SpatialGridPath.hpp
+++ b/SKIRT/utils/SpatialGridPath.hpp
@@ -135,6 +135,11 @@ public:
         interactionDistance() functions. */
     void setInteractionPoint(int m, double s);
 
+    /** This function stores the specified spatial cell index, distance and cumulative optical
+        depth to the initial position of the interaction point for later retrieval through the
+        interactionCellIndex(), interactionDistance(), and interactionOpticalDepth() functions. */
+    void setInteractionPoint(int m, double s, double tau);
+
     /** This function returns the spatial cell index corresponding to the interaction point most
         recently calculated by the findInteractionPoint() function or set by the
         setInteractionPoint() function, or -1 if these functions have never been called or if there
@@ -147,6 +152,11 @@ public:
         there was no interaction point within the path. */
     double interactionDistance() const { return _interactionDistance; }
 
+    /** This function returns the cumulative optical depth along the path from its initial position
+        to the interaction point most recently set by the setInteractionPoint() function, or zero
+        if this functions has never been called. */
+    double interactionOpticalDepth() const { return _interactionOpticalDepth; }
+
     // ------- Data members -------
 private:
     Position _bfr;
@@ -155,6 +165,7 @@ private:
     double _s{0.};
     int _interactionCellIndex{-1};
     double _interactionDistance{0.};
+    double _interactionOpticalDepth{0.};
 };
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
This update introduces the explicit absorption technique as an optional variation of the Monte Carlo photon packet life cycle. This allows handling materials that exhibit stimulated emission, which may lead to negative  extinction cross sections (and correspondingly, negative optical depths). To the best of our knowledge, this technique has not yet been described in the literature; we plan to rectify that situation in the coming months. At heart, the idea is to use the scattering optical depth (which is always positive) instead of the extinction optical depth (which may be negative) for locating the next interaction point along a photon packet path.

The update also adds the new `TrivialGasMix` class to help construct basic test models that include materials with stimulated emission.

The `PhotonPacketOptions` now allow configuring four basic variations of the photon packet life cycle by enabling or disabling forced scattering and/or explicit absorption. Each of these variations comes with specific advantages or drawbacks, as follows:

- With forced scattering. Forced scattering tends to reduce noise for simulations with low to
limited optical depths, such as for most dust models on galaxy-wide scales. However, for each
scattering event, it requires the calculation of the geometry and optical depth of the full
path up to the model boundary, regardless of the location of the scattering event along the
path.

- Without forced scattering. In models with very intensive scattering, such as for Lyman-alpha
line transfer, the photon cycle without forced scattering is often the better choice, because
it avoids calculating the path geometry and optical depth beyond the scattering location.
However, our implementation does not support storing the radiation field, which means this
option cannot be used when the simulation includes secondary emission or dynamic state
iteration.

- Without explicit absorption. The default technique uses the extinction (sum of scattering and
absorption) along a photon packet's path to locate the next interaction point. This requires
the cumulative extinction optical depth to be a nondecreasing function of path length. It is
thus not possible to handle negative extinction cross sections.

- With explicit absorption. This technique instead used the scattering optical depth to locate
the next interaction point. While the scattering cross section still must be nonnegative, this
allows the extinction cross section to be negative. The latter is the case for materials that
exhibit stimulated emission as soon as the magnitude of the negative absorption cross section
is larger than the scattering cross section. As a drawback, this technique requires calculating
both the scattering and absorption optical depths for the photon packet path.

**Motivation**
Support materials that exhibit stimulated emission.

**Note for developers**
Material mixes that may return negative extinction cross sections _must_ implement the `hasNegativeExtinction()` function to return `true`. This will ensure that explicit absorption is enabled, even if not explicitly requested in the user configuration file. See the `TrivialGasMix` class for an example.

**Tests**
For all pre-existing functional tests (without explicit absorption, by default), the results of the updated version are binary identical to those of the previous version. Several new basic tests have been conducted to verify the operation of explicit absorption, both in the existing regime (where all cross sections are nonnegative) and in the new regime (with negative extinction cross sections). Also, the photon packet life cycle with explicit absorption and forced scattering successfully runs the Pascucci et al. 2004 benchmark, which heavily relies on correctly registering the radiation field.
