### PR TITLE
Fix wavelength bin widths in energy units and X-ray cross sections

### DIFF
--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -677,7 +677,7 @@ void XRayAtomicGasMix::setupSelfBefore()
     }
 
     // load the photo-absorption cross section parameters
-    auto crossSectionParams = loadStruct<CrossSectionParams, 11>(this, "XRay_PA.txt", "photo-absorption data");
+    auto crossSectionParams = loadStruct<CrossSectionParams, 12>(this, "XRay_PA.txt", "photo-absorption data");
 
     // load the fluorescence parameters
     auto fluorescenceParams = loadStruct<FluorescenceParams, 4>(this, "XRay_FL.txt", "fluorescence data");


### PR DESCRIPTION
**Description**
This update fixes two bugs:
 - In wavelength grid probes (for instruments or other wavelength grids), when using energy or frequency output units, the wavelength bin width was incorrect. 
 - In `XRayAtomicGasMix`, the photo-absorption cross section parameters were not correctly loaded from the resource file.

**Motivation**
We like fixing bugs 😄 
