### PR TITLE
Allow source/medium-colocated clumps in clumpy decorator

### DIFF
--- a/SKIRT/core/ClumpyGeometryDecorator.cpp
+++ b/SKIRT/core/ClumpyGeometryDecorator.cpp
@@ -15,7 +15,9 @@ void ClumpyGeometryDecorator::setupSelfAfter()
 
     // generate the random positions of the clumps
     _clumpv.resize(_numClumps);
+    if (_seed) random()->push(_seed);
     for (int i = 0; i < _numClumps; i++) _clumpv[i] = _geometry->generatePosition();
+    if (_seed) random()->pop();
 
     // sort the vector with the positions of the clumps in increasing x-coordinates
     NR::sort(_clumpv);

--- a/SKIRT/core/ClumpyGeometryDecorator.hpp
+++ b/SKIRT/core/ClumpyGeometryDecorator.hpp
@@ -11,20 +11,31 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** The ClumpyGeometryDecorator class is a geometry decorator that adds clumpiness to
-    any  geometry. It basically assigns a fraction \f$f\f$ of the mass of the original
-    geometry to compact clumps, which are distributed statistically according to the same
-    distribution. The properties of a ClumpyGeometryDecorator object are a reference
-    to the original Geometry object being decorated, and the characteristics that
-    describe the clumpiness, i.e. the fraction \f$f\f$ of the mass locked in clumps, the total
-    number \f$N\f$ of clumps, the scale radius \f$h\f$ of a single clump, and the kernel
-    \f$W({\bf{r}},h)\f$ that describes the mass distribution of a single clump. If
-    the original geometry is characterized by the density \f$\rho_{\text{orig}}({\bf{r}})\f$, the
-    new, clumpy stellar geometry is described by \f[ \rho({\bf{r}}) = (1-f)\, \rho_{\text{orig}}
-    ({\bf{r}}) + \frac{f}{N} \sum_{i=1}^N W({\bf{r}}-{\bf{r}}_i,h). \f] where \f${\bf{r}}_i\f$ is
-    the location of the centre of the \f$i\f$'th clump, each of them drawn stochastically from the
-    three-dimensional probability density \f$p({\bf{r}})\, {\text{d}}{\bf{r}} =
-    \rho_{\text{orig}}({\bf{r}})\, {\text{d}}{\bf{r}}\f$.*/
+/** The ClumpyGeometryDecorator class is a geometry decorator that adds clumpiness to any geometry.
+    It basically assigns a fraction \f$f\f$ of the mass of the original geometry to compact clumps,
+    which are distributed statistically according to the same distribution. The properties of a
+    ClumpyGeometryDecorator object are a reference to the original Geometry object being decorated,
+    and the characteristics that describe the clumpiness, i.e. the fraction \f$f\f$ of the mass
+    locked in clumps, the total number \f$N\f$ of clumps, the scale radius \f$h\f$ of a single
+    clump, and the kernel \f$W({\bf{r}},h)\f$ that describes the mass distribution of a single
+    clump. If the original geometry is characterized by the density
+    \f$\rho_{\text{orig}}({\bf{r}})\f$, the new, clumpy stellar geometry is described by \f[
+    \rho({\bf{r}}) = (1-f)\, \rho_{\text{orig}} ({\bf{r}}) + \frac{f}{N} \sum_{i=1}^N
+    W({\bf{r}}-{\bf{r}}_i,h). \f] where \f${\bf{r}}_i\f$ is the location of the centre of the
+    \f$i\f$'th clump, each of them randomly drawn from the three-dimensional probability density
+    \f$p({\bf{r}})\, {\text{d}}{\bf{r}} = \rho_{\text{orig}}({\bf{r}})\, {\text{d}}{\bf{r}}\f$.
+
+    By default, this class uses the standard random generator also used by other classes during
+    setup. Consecutive executions of the same ski file will produce the same clump positions (even
+    if the simulation is configured to have multiple parallel execution threads or processes). On
+    the other hand, multiple occurrences of the ClumpyGeometryDecorator in a given ski file will
+    always produce a different set of clump positions, because consecutive portions of the
+    pseudo-random sequence are being employed. While this is usually just fine, in some models one
+    might want to line up, for example, the clumps in a medium distribution with those in a source
+    distribution. Therefore, if a nonzero value is specified for the \em seed property, the clump
+    positions are generated using a temporary random number generator initialized with that seed.
+    Configuring the same seed for two ClumpyGeometryDecorator instances will line up the respective
+    clump positions, assuming the underlying geometry and the number of clumps are identical. */
 class ClumpyGeometryDecorator : public GenGeometry
 {
     ITEM_CONCRETE(ClumpyGeometryDecorator, GenGeometry, "a decorator that adds clumpiness to any geometry")
@@ -50,6 +61,12 @@ class ClumpyGeometryDecorator : public GenGeometry
                       "the smoothing kernel that describes the density of a single clump")
         ATTRIBUTE_DEFAULT_VALUE(smoothingKernel, "CubicSplineSmoothingKernel")
         ATTRIBUTE_DISPLAYED_IF(smoothingKernel, "Level2")
+
+        PROPERTY_INT(seed, "the seed for the random clump position generator, or zero to use the default generator")
+        ATTRIBUTE_MIN_VALUE(seed, "0")
+        ATTRIBUTE_MAX_VALUE(seed, "1000000")
+        ATTRIBUTE_DEFAULT_VALUE(seed, "0")
+        ATTRIBUTE_DISPLAYED_IF(seed, "Level3")
 
     ITEM_END()
 

--- a/SKIRT/core/Random.cpp
+++ b/SKIRT/core/Random.cpp
@@ -9,6 +9,7 @@
 #include "Position.hpp"
 #include "SpecialFunctions.hpp"
 #include <random>
+#include <stack>
 
 //////////////////////////////////////////////////////////////////////
 
@@ -48,6 +49,10 @@ namespace
 
     // allocate a random generator for each thread, constructed when the thread is created
     thread_local Rand _rng;
+
+    // allocate a random generator stack for each thread, constructed when the thread is created;
+    // this stack is used solely by the push() and pop() functions
+    thread_local std::stack<Rand> _stack;
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -190,6 +195,22 @@ double Random::cdfLogLog(const Array& xv, const Array& pv, const Array& Pv)
     int i = NR::locateClip(Pv, X);
     double alpha = log(pv[i + 1] / pv[i]) / log(xv[i + 1] / xv[i]);
     return xv[i] * SpecialFunctions::gexp(-alpha, (X - Pv[i]) / (pv[i] * xv[i]));
+}
+
+//////////////////////////////////////////////////////////////////////
+
+void Random::push(int seed)
+{
+    _stack.push(_rng);
+    _rng.setState(seed);
+}
+
+//////////////////////////////////////////////////////////////////////
+
+void Random::pop()
+{
+    _rng = _stack.top();
+    _stack.pop();
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/Random.hpp
+++ b/SKIRT/core/Random.hpp
@@ -47,6 +47,11 @@ class Vec;
     multi-processing mode, perform serial tasks in the parent thread of each process, and perform
     all parallized tasks in a child thread.
 
+    As an additional service, this class allows temporarily installing a predictable random number
+    generator with a given seed in the current execution thread through the push() and pop()
+    functions. This supports the use case where, usually during setup, the same pseudo-random
+    sequence is required in multiple places.
+
     All random number generators used in this class are based on the 64-bit Mersenne twister, which
     offers a sufficiently long period and acceptable spectral properties for most purposes. */
 class Random : public SimulationItem
@@ -69,7 +74,7 @@ protected:
         \em seed property. */
     void setupSelfBefore() override;
 
-    //======================== Other Functions =======================
+    //=================== Generating random numbers ===================
 
 public:
     /** This function generates a uniform deviate, i.e. a random double precision number in the
@@ -155,6 +160,21 @@ public:
         generalized exponential, defined in the description of respectively the
         SpecialFunctions::gln() and SpecialFunctions::gexp() functions. */
     double cdfLogLog(const Array& xv, const Array& pv, const Array& Pv);
+
+    //=================== Installing a temporary generator ===================
+
+public:
+    /** This function pushes the active random number generator for the current thread onto the
+        stack for the current thread and establishes a new predictable random number generator,
+        initialized with the specified seed, as the active random number generator for the current
+        thread. */
+    void push(int seed);
+
+    /** This function pops the most recently pushed random number generator from the stack for the
+        current thread and establishes it as the active random number generator for the current
+        thread. If the stack does not contain a random number generator, the behavior of this
+        function is undefined. */
+    void pop();
 };
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
By default, the `ClumpyGeometryDecorator` class uses the standard random generator also used by other classes during setup. Multiple occurrences of the ClumpyGeometryDecorator in a given ski file will produce a different set of clump positions, because consecutive portions of the pseudo-random sequence are being employed. While this is usually just fine, in some models one might want to line up, for example, the clumps in a medium distribution with those in a source distribution.

Therefore, this update adds a _seed_ property to the `ClumpyGeometryDecorator` . If a nonzero value is specified for this _seed_ property, the clump positions are generated using a temporary random number generator initialized with that seed. Configuring the same seed for two `ClumpyGeometryDecorator` instances will line up the respective clump positions, assuming the underlying geometry and the number of clumps are identical. Note that the size and form (kernel) of the clumps are allowed to differ between the `ClumpyGeometryDecorator` instances.

**Motivation**
This capability was suggested by users Stijn Wuyts and Junkai Zhang at the University of Bath, who would like to build simple galaxy models with colocated stellar and dust clumps.

**Tests**
A functional test has been added to test this capability; all other tests still work with binary identical output.
