### PR TITLE
Imported source probes always use system aggregation

### DIFF
--- a/SKIRT/core/ImportedMediumDensityProbe.cpp
+++ b/SKIRT/core/ImportedMediumDensityProbe.cpp
@@ -18,12 +18,14 @@ void ImportedMediumDensityProbe::probeImportedMedium(string sh, const ImportedMe
     if (snapshot->holdsNumber())
     {
         bridge.writeQuantity(sh + "_n", sh + "_N", "numbervolumedensity", "numbersurfacedensity", "number density",
-                             "column density", snapshot, [snapshot](int m) { return snapshot->density(m); });
+                             "column density", vector<const Snapshot*>{snapshot},
+                             [](const Snapshot* s, int m) { return s->density(m); });
     }
     else
     {
         bridge.writeQuantity(sh + "_rho", sh + "_Sigma", "massvolumedensity", "masssurfacedensity", "mass density",
-                             "mass surface density", snapshot, [snapshot](int m) { return snapshot->density(m); });
+                             "mass surface density", vector<const Snapshot*>{snapshot},
+                             [](const Snapshot* s, int m) { return s->density(m); });
     }
 }
 

--- a/SKIRT/core/ImportedMediumMetallicityProbe.cpp
+++ b/SKIRT/core/ImportedMediumMetallicityProbe.cpp
@@ -19,8 +19,8 @@ void ImportedMediumMetallicityProbe::probeImportedMedium(string sh, const Import
         // define call-back functions to retrieve the probed quantity and corresponding weight for a given entity
         // for dust media, use the gas density rather than the dust density for weighting the probed quantity
         bool dust = medium->mix()->isDust();
-        auto getValue = [snapshot](int m) { return snapshot->metallicity(m); };
-        auto getWeight = [snapshot, dust](int m) {
+        auto getValue = [](const Snapshot* snapshot, int m) { return snapshot->metallicity(m); };
+        auto getWeight = [dust](const Snapshot* snapshot, int m) {
             double w = snapshot->density(m);
             if (dust) w /= snapshot->metallicity(m);
             return w;
@@ -28,8 +28,8 @@ void ImportedMediumMetallicityProbe::probeImportedMedium(string sh, const Import
 
         // construct a bridge and produce output
         ProbeFormBridge bridge(this, form());
-        bridge.writeQuantity(sh + "_Z", "dimensionless", "metallicity", "density-weighted metallicity", snapshot,
-                             getValue, getWeight);
+        bridge.writeQuantity(sh + "_Z", "dimensionless", "metallicity", "density-weighted metallicity",
+                             vector<const Snapshot*>{snapshot}, getValue, getWeight);
     }
 }
 

--- a/SKIRT/core/ImportedMediumTemperatureProbe.cpp
+++ b/SKIRT/core/ImportedMediumTemperatureProbe.cpp
@@ -19,8 +19,8 @@ void ImportedMediumTemperatureProbe::probeImportedMedium(string sh, const Import
         // define call-back functions to retrieve the probed quantity and corresponding weight for a given entity
         // for dust media, use the gas density rather than the dust density for weighting the probed quantity
         bool dust = medium->mix()->isDust() && snapshot->hasMetallicity();
-        auto getValue = [snapshot](int m) { return snapshot->temperature(m); };
-        auto getWeight = [snapshot, dust](int m) {
+        auto getValue = [](const Snapshot* snapshot, int m) { return snapshot->temperature(m); };
+        auto getWeight = [dust](const Snapshot* snapshot, int m) {
             double w = snapshot->density(m);
             if (dust) w /= snapshot->metallicity(m);
             return w;
@@ -28,8 +28,8 @@ void ImportedMediumTemperatureProbe::probeImportedMedium(string sh, const Import
 
         // construct a bridge and produce output
         ProbeFormBridge bridge(this, form());
-        bridge.writeQuantity(sh + "_T", "temperature", "temperature", "density-weighted temperature", snapshot,
-                             getValue, getWeight);
+        bridge.writeQuantity(sh + "_T", "temperature", "temperature", "density-weighted temperature",
+                             vector<const Snapshot*>{snapshot}, getValue, getWeight);
     }
 }
 

--- a/SKIRT/core/ImportedMediumVelocityProbe.cpp
+++ b/SKIRT/core/ImportedMediumVelocityProbe.cpp
@@ -18,8 +18,8 @@ void ImportedMediumVelocityProbe::probeImportedMedium(string sh, const ImportedM
         // define call-back functions to retrieve the probed quantity and corresponding weight for a given entity
         // for dust media, use the gas density rather than the dust density for weighting the probed quantity
         bool dust = medium->mix()->isDust() && snapshot->hasMetallicity();
-        auto getValue = [snapshot](int m) { return snapshot->velocity(m); };
-        auto getWeight = [snapshot, dust](int m) {
+        auto getValue = [](const Snapshot* snapshot, int m) { return snapshot->velocity(m); };
+        auto getWeight = [dust](const Snapshot* snapshot, int m) {
             double w = snapshot->density(m);
             if (dust) w /= snapshot->metallicity(m);
             return w;
@@ -27,8 +27,8 @@ void ImportedMediumVelocityProbe::probeImportedMedium(string sh, const ImportedM
 
         // construct a bridge and produce output
         ProbeFormBridge bridge(this, form());
-        bridge.writeQuantity(sh + "_v", "velocity", "velocity", "density-weighted velocity", snapshot, getValue,
-                             getWeight);
+        bridge.writeQuantity(sh + "_v", "velocity", "velocity", "density-weighted velocity",
+                             vector<const Snapshot*>{snapshot}, getValue, getWeight);
     }
 }
 

--- a/SKIRT/core/ImportedSourceAgeProbe.cpp
+++ b/SKIRT/core/ImportedSourceAgeProbe.cpp
@@ -10,16 +10,20 @@
 
 ////////////////////////////////////////////////////////////////////
 
-void ImportedSourceAgeProbe::probeImportedSourceWeighted(string sh, string sweight, const Snapshot* snapshot,
-                                                         std::function<double(int)> weight)
+void ImportedSourceAgeProbe::probeImportedSourceWeighted(string sweight, const vector<const Snapshot*>& snapshots,
+                                                         std::function<double(const Snapshot* snapshot, int m)> weight)
 {
-    if (snapshot->hasAge())
+    // verify that all snapshots offer the age property
+    bool haveAge = true;
+    for (auto snapshot : snapshots) haveAge &= snapshot->hasAge();
+
+    if (haveAge)
     {
         // construct a bridge and produce output
         ProbeFormBridge bridge(this, form());
         bridge.writeQuantity(
-            sh + "_t", "time", "age", sweight + "-weighted age", snapshot,
-            [snapshot](int m) { return snapshot->age(m); }, weight);
+            "t", "time", "age", sweight + "-weighted age", snapshots,
+            [](const Snapshot* snapshot, int m) { return snapshot->age(m); }, weight);
     }
 }
 

--- a/SKIRT/core/ImportedSourceAgeProbe.hpp
+++ b/SKIRT/core/ImportedSourceAgeProbe.hpp
@@ -10,13 +10,18 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** ImportedSourceAgeProbe probes the age of each imported source component in the simulation for
-    which that information is available as one of the parameters for the associated %SED family.
-    The probe uses the data as represented by the imported snapshot, without involving the spatial
-    grid of the simulation. The age is luminosity- or mass-weighted where necessary, i.e. when the
-    probe is associated with a form that projects the quantity along a path, or when two or more
-    smoothed particles in the imported data overlap. The weighting scheme can be user-configured as
-    described for the ImportedSourceWeightedProbe class, from which this class derives. */
+/** ImportedSourceAgeProbe probes the average age of the aggregated imported source components in
+    the simulation, assuming that this information is available for all sources as one of the
+    parameters of the associated %SED family. The probe uses the data as represented by the
+    imported snapshot, without involving the spatial grid of the simulation. The age is luminosity-
+    or mass-weighted where necessary, i.e. when the probe is associated with a form that projects
+    the quantity along a path, or when two or more smoothed particles in the imported data overlap.
+    The weighting scheme can be user-configured as described for the ImportedSourceWeightedProbe
+    class, from which this class derives.
+
+    The probe produces output only if the simulation has at least one source component, if all
+    sources are imported, and if all of these sources offer the age property and the properties
+    necessary to perform the requested type of weighting. */
 class ImportedSourceAgeProbe : public ImportedSourceWeightedProbe
 {
     ITEM_CONCRETE(ImportedSourceAgeProbe, ImportedSourceWeightedProbe, "imported source: age")
@@ -25,10 +30,10 @@ class ImportedSourceAgeProbe : public ImportedSourceWeightedProbe
     //======================== Other Functions =======================
 
 protected:
-    /** This function probes the imported source component with the specified snapshot and weight
+    /** This function probes the imported source components with the specified snapshots and weight
         function. */
-    void probeImportedSourceWeighted(string sh, string sweight, const Snapshot* snapshot,
-                                     std::function<double(int m)> weight) override;
+    void probeImportedSourceWeighted(string sweight, const vector<const Snapshot*>& snapshots,
+                                     std::function<double(const Snapshot* snapshot, int m)> weight) override;
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ImportedSourceDensityProbe.cpp
+++ b/SKIRT/core/ImportedSourceDensityProbe.cpp
@@ -10,14 +10,21 @@
 
 ////////////////////////////////////////////////////////////////////
 
-void ImportedSourceDensityProbe::probeImportedSource(string sh, const ImportedSource* /*source*/,
-                                                     const Snapshot* snapshot)
+void ImportedSourceDensityProbe::probeImportedSources(const vector<const ImportedSource*>& /*sources*/,
+                                                      const vector<const Snapshot*>& snapshots)
 {
-    if ((massType() == MassType::InitialMass && snapshot->hasInitialMass())
-        || (massType() == MassType::CurrentMass && snapshot->hasCurrentMass()))
+    // verify that all snapshots offer the requested mass type
+    bool haveMassType = true;
+    for (auto snapshot : snapshots)
+    {
+        haveMassType &= (massType() == MassType::InitialMass && snapshot->hasInitialMass())
+                        || (massType() == MassType::CurrentMass && snapshot->hasCurrentMass());
+    }
+
+    if (haveMassType)
     {
         // define a call-back function to retrieve the density for a given entity
-        auto densityInEntity = [snapshot, this](int m) {
+        auto densityInEntity = [this](const Snapshot* snapshot, int m) {
             double mass = massType() == MassType::CurrentMass ? snapshot->currentMass(m) : snapshot->initialMass(m);
             return mass / snapshot->volume(m);
         };
@@ -25,8 +32,8 @@ void ImportedSourceDensityProbe::probeImportedSource(string sh, const ImportedSo
         // construct a bridge and produce output
         ProbeFormBridge bridge(this, form());
         string stype = massType() == MassType::CurrentMass ? "current" : "initial";
-        bridge.writeQuantity(sh + "_rho", sh + "_Sigma", "massvolumedensity", "masssurfacedensity",
-                             stype + " mass density", stype + " mass surface density", snapshot, densityInEntity);
+        bridge.writeQuantity("rho", "Sigma", "massvolumedensity", "masssurfacedensity", stype + " mass density",
+                             stype + " mass surface density", snapshots, densityInEntity);
     }
 }
 

--- a/SKIRT/core/ImportedSourceDensityProbe.hpp
+++ b/SKIRT/core/ImportedSourceDensityProbe.hpp
@@ -10,11 +10,13 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** ImportedSourceDensityProbe probes the initial or current mass density of each imported source
-    component in the simulation for which the information is available. The probe uses the data as
-    represented by the imported snapshot, without involving the spatial grid of the simulation.
-    When associated with a form that projects the quantity along a path, the probe outputs mass
-    surface density.
+/** ImportedSourceDensityProbe probes the initial or current mass density aggregated over all
+    imported sources in the simulation. It uses the data as represented by the imported
+    snapshot(s), without involving the spatial grid of the simulation. When associated with a form
+    that projects the quantity along a path, the probe outputs mass surface density.
+
+    The probe produces output only if the simulation has at least one source component, if all
+    sources are imported, and if all of these sources offer the requested type of mass density.
 
     In most use cases, one will be interested in probing the current stellar mass of a source
     component. However, this information is usually not automatically available to the SKIRT input
@@ -28,10 +30,10 @@
     use the initial mass imported as one of the %SED family parameters as a suboptimal solution.
     However, assuming that the current mass can be obtained when preparing SKIRT's input data, a
     better solution is to provide it as a separate, additional column to the import process, enable
-    the \em importCurrentMass option for the ImportedSource component, and set the \em massType
+    the \em importCurrentMass option for the ImportedSource component(s), and set the \em massType
     option for the probe to \c CurrentMass. Now the probe will use the separately imported current
-    mass. In all cases, if a source component does not import the selected mass type, the probe
-    produces no output for that component. */
+    mass. Note that, as indicated above, the requested mass type must be available for all source
+    components for the probe to produce output. */
 class ImportedSourceDensityProbe : public InputModelFormProbe
 {
     /** The enumeration type indicating whether to use initial mass or current mass. */
@@ -52,8 +54,9 @@ class ImportedSourceDensityProbe : public InputModelFormProbe
     //======================== Other Functions =======================
 
 protected:
-    /** This function probes the specified imported source component. */
-    void probeImportedSource(string sh, const ImportedSource* source, const Snapshot* snapshot) override;
+    /** This function probes the specified imported source components. */
+    void probeImportedSources(const vector<const ImportedSource*>& sources,
+                              const vector<const Snapshot*>& snapshots) override;
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ImportedSourceLuminosityProbe.hpp
+++ b/SKIRT/core/ImportedSourceLuminosityProbe.hpp
@@ -12,11 +12,14 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** ImportedSourceLuminosityProbe probes the specific luminosity of each imported source component
-    in the simulation at the wavelengths specified by a user-configured wavelength grid. Note that
-    the specific luminosity is sampled at the characteristic wavelength of each bin; it is \em not
-    averaged or convolved over the wavelength bin. The probe uses the data as represented by the
-    imported snapshot, without involving the spatial grid of the simulation.
+/** ImportedSourceLuminosityProbe probes the specific luminosity aggregated over all imported
+    sources in the simulation at the wavelengths specified by a user-configured wavelength grid.
+    Note that the specific luminosity is sampled at the characteristic wavelength of each bin; it
+    is \em not averaged or convolved over the wavelength bin. The probe uses the data as
+    represented by the imported snapshot, without involving the spatial grid of the simulation.
+
+    The probe produces output only if the simulation has at least one source component and if all
+    sources are imported.
 
     When associated with a form that samples the luminosity at a set of positions, such as for a
     linear or planar cut, the probe outputs a monochromatic luminosity volume density (with SI
@@ -53,8 +56,9 @@ public:
     WavelengthGrid* materialWavelengthGrid() const override;
 
 protected:
-    /** This function probes the specified imported source component. */
-    void probeImportedSource(string sh, const ImportedSource* source, const Snapshot* snapshot) override;
+    /** This function probes the specified imported source components. */
+    void probeImportedSources(const vector<const ImportedSource*>& sources,
+                              const vector<const Snapshot*>& snapshots) override;
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ImportedSourceMetallicityProbe.cpp
+++ b/SKIRT/core/ImportedSourceMetallicityProbe.cpp
@@ -10,16 +10,21 @@
 
 ////////////////////////////////////////////////////////////////////
 
-void ImportedSourceMetallicityProbe::probeImportedSourceWeighted(string sh, string sweight, const Snapshot* snapshot,
-                                                                 std::function<double(int)> weight)
+void ImportedSourceMetallicityProbe::probeImportedSourceWeighted(
+    string sweight, const vector<const Snapshot*>& snapshots,
+    std::function<double(const Snapshot* snapshot, int m)> weight)
 {
-    if (snapshot->hasMetallicity())
+    // verify that all snapshots offer the metallicity property
+    bool haveMetallicity = true;
+    for (auto snapshot : snapshots) haveMetallicity &= snapshot->hasMetallicity();
+
+    if (haveMetallicity)
     {
         // construct a bridge and produce output
         ProbeFormBridge bridge(this, form());
         bridge.writeQuantity(
-            sh + "_Z", "dimensionless", "metallicity", sweight + "-weighted metallicity", snapshot,
-            [snapshot](int m) { return snapshot->metallicity(m); }, weight);
+            "Z", "dimensionless", "metallicity", sweight + "-weighted metallicity", snapshots,
+            [](const Snapshot* snapshot, int m) { return snapshot->metallicity(m); }, weight);
     }
 }
 

--- a/SKIRT/core/ImportedSourceMetallicityProbe.hpp
+++ b/SKIRT/core/ImportedSourceMetallicityProbe.hpp
@@ -10,14 +10,18 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** ImportedSourceMetallicityProbe probes the metallicity of each imported source component in the
-    simulation for which that information is available as one of the parameters for the associated
-    %SED family. The probe uses the data as represented by the imported snapshot, without involving
-    the spatial grid of the simulation. The metallicity is luminosity- or mass-weighted where
-    necessary, i.e. when the probe is associated with a form that projects the quantity along a
-    path, or when two or more smoothed particles in the imported data overlap. The weighting scheme
-    can be user-configured as described for the ImportedSourceWeightedProbe class, from which this
-    class derives. */
+/** ImportedSourceMetallicityProbe probes the average metallicity of each imported source component
+    in the simulation, assuming that this information is available for all sources as one of the
+    parameters of the associated %SED family. The probe uses the data as represented by the
+    imported snapshot, without involving the spatial grid of the simulation. The metallicity is
+    luminosity- or mass-weighted where necessary, i.e. when the probe is associated with a form
+    that projects the quantity along a path, or when two or more smoothed particles in the imported
+    data overlap. The weighting scheme can be user-configured as described for the
+    ImportedSourceWeightedProbe class, from which this class derives.
+
+    The probe produces output only if the simulation has at least one source component, if all
+    sources are imported, and if all of these sources offer the metallicity property and the
+    properties necessary to perform the requested type of weighting. */
 class ImportedSourceMetallicityProbe : public ImportedSourceWeightedProbe
 {
     ITEM_CONCRETE(ImportedSourceMetallicityProbe, ImportedSourceWeightedProbe, "imported source: metallicity")
@@ -26,10 +30,10 @@ class ImportedSourceMetallicityProbe : public ImportedSourceWeightedProbe
     //======================== Other Functions =======================
 
 protected:
-    /** This function probes the imported source component with the specified snapshot and weight
+    /** This function probes the imported source components with the specified snapshots and weight
         function. */
-    void probeImportedSourceWeighted(string sh, string sweight, const Snapshot* snapshot,
-                                     std::function<double(int m)> weight) override;
+    void probeImportedSourceWeighted(string sweight, const vector<const Snapshot*>& snapshots,
+                                     std::function<double(const Snapshot* snapshot, int m)> weight) override;
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ImportedSourceVelocityProbe.cpp
+++ b/SKIRT/core/ImportedSourceVelocityProbe.cpp
@@ -10,16 +10,21 @@
 
 ////////////////////////////////////////////////////////////////////
 
-void ImportedSourceVelocityProbe::probeImportedSourceWeighted(string sh, string sweight, const Snapshot* snapshot,
-                                                              std::function<double(int)> weight)
+void ImportedSourceVelocityProbe::probeImportedSourceWeighted(
+    string sweight, const vector<const Snapshot*>& snapshots,
+    std::function<double(const Snapshot* snapshot, int m)> weight)
 {
-    if (snapshot->hasVelocity())
+    // verify that all snapshots offer a velocity
+    bool haveVelocity = true;
+    for (auto snapshot : snapshots) haveVelocity &= snapshot->hasVelocity();
+
+    if (haveVelocity)
     {
         // construct a bridge and produce output
         ProbeFormBridge bridge(this, form());
         bridge.writeQuantity(
-            sh + "_v", "velocity", "velocity", sweight + "-weighted velocity", snapshot,
-            [snapshot](int m) { return snapshot->velocity(m); }, weight);
+            "v", "velocity", "velocity", sweight + "-weighted velocity", snapshots,
+            [](const Snapshot* snapshot, int m) { return snapshot->velocity(m); }, weight);
     }
 }
 

--- a/SKIRT/core/ImportedSourceVelocityProbe.hpp
+++ b/SKIRT/core/ImportedSourceVelocityProbe.hpp
@@ -10,14 +10,18 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** ImportedSourceVelocityProbe probes the bulk velocity of each imported source component in the
-    simulation for which that information is available as one of the parameters for the associated
-    %SED family. The probe uses the data as represented by the imported snapshot, without involving
-    the spatial grid of the simulation. The velocity is luminosity- or mass-weighted where
-    necessary, i.e. when the probe is associated with a form that projects the quantity along a
-    path, or when two or more smoothed particles in the imported data overlap. The weighting scheme
-    can be user-configured as described for the ImportedSourceWeightedProbe class, from which this
-    class derives. */
+/** ImportedSourceVelocityProbe probes the average bulk velocity of the aggregated imported source
+    components in the simulation, assuming that this information is available for all sources as
+    one of the parameters for the associated %SED family. The probe uses the data as represented by
+    the imported snapshot, without involving the spatial grid of the simulation. The velocity is
+    luminosity- or mass-weighted where necessary, i.e. when the probe is associated with a form
+    that projects the quantity along a path, or when two or more smoothed particles in the imported
+    data overlap. The weighting scheme can be user-configured as described for the
+    ImportedSourceWeightedProbe class, from which this class derives.
+
+    The probe produces output only if the simulation has at least one source component, if all
+    sources are imported, and if all of these sources offer the velocity property and the
+    properties necessary to perform the requested type of weighting. */
 class ImportedSourceVelocityProbe : public ImportedSourceWeightedProbe
 {
     ITEM_CONCRETE(ImportedSourceVelocityProbe, ImportedSourceWeightedProbe, "imported source: bulk velocity")
@@ -27,10 +31,10 @@ class ImportedSourceVelocityProbe : public ImportedSourceWeightedProbe
     //======================== Other Functions =======================
 
 protected:
-    /** This function probes the imported source component with the specified snapshot and weight
+    /** This function probes the imported source components with the specified snapshots and weight
         function. */
-    void probeImportedSourceWeighted(string sh, string sweight, const Snapshot* snapshot,
-                                     std::function<double(int m)> weight) override;
+    void probeImportedSourceWeighted(string sweight, const vector<const Snapshot*>& snapshots,
+                                     std::function<double(const Snapshot* snapshot, int m)> weight) override;
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ImportedSourceWeightedProbe.cpp
+++ b/SKIRT/core/ImportedSourceWeightedProbe.cpp
@@ -6,6 +6,7 @@
 #include "ImportedSourceWeightedProbe.hpp"
 #include "ImportedSource.hpp"
 #include "Snapshot.hpp"
+#include <unordered_map>
 
 ////////////////////////////////////////////////////////////////////
 
@@ -16,23 +17,55 @@ Range ImportedSourceWeightedProbe::wavelengthRange() const
 
 ////////////////////////////////////////////////////////////////////
 
-void ImportedSourceWeightedProbe::probeImportedSource(string sh, const ImportedSource* source, const Snapshot* snapshot)
+void ImportedSourceWeightedProbe::probeImportedSources(const vector<const ImportedSource*>& sources,
+                                                       const vector<const Snapshot*>& snapshots)
 {
-    if (weight() == Weight::Luminosity && source->wavelengthRange().containsFuzzy(wavelength()))
+    if (weight() == Weight::Luminosity)
     {
-        probeImportedSourceWeighted(sh, "luminosity", snapshot, [source, snapshot, this](int m) {
-            return source->specificLuminosity(wavelength(), m) / snapshot->volume(m);
-        });
+        // verify that all sources include the requested wavelength
+        bool haveWavelength = true;
+        for (auto source : sources) haveWavelength &= source->wavelengthRange().containsFuzzy(wavelength());
+        if (haveWavelength)
+        {
+            // construct a map from snapshot to source
+            std::unordered_map<const Snapshot*, const ImportedSource*> sourceForSnapshot;
+            int numSources = sources.size();
+            for (int h = 0; h != numSources; ++h) sourceForSnapshot.emplace(snapshots[h], sources[h]);
+
+            // define function to retrieve weight
+            auto getWeight = [sourceForSnapshot, this](const Snapshot* snapshot, int m) {
+                return sourceForSnapshot.at(snapshot)->specificLuminosity(wavelength(), m) / snapshot->volume(m);
+            };
+
+            // perform probing
+            probeImportedSourceWeighted("luminosity", snapshots, getWeight);
+        }
     }
-    if (weight() == Weight::InitialMass && snapshot->hasInitialMass())
+
+    if (weight() == Weight::InitialMass)
     {
-        probeImportedSourceWeighted(sh, "initial mass", snapshot,
-                                    [snapshot](int m) { return snapshot->initialMass(m) / snapshot->volume(m); });
+        bool haveInitialMass = true;
+        for (auto snapshot : snapshots) haveInitialMass &= snapshot->hasInitialMass();
+        if (haveInitialMass)
+        {
+            auto getWeight = [](const Snapshot* snapshot, int m) {
+                return snapshot->initialMass(m) / snapshot->volume(m);
+            };
+            probeImportedSourceWeighted("initial mass", snapshots, getWeight);
+        }
     }
-    if (weight() == Weight::CurrentMass && snapshot->hasCurrentMass())
+
+    if (weight() == Weight::CurrentMass)
     {
-        probeImportedSourceWeighted(sh, "current mass", snapshot,
-                                    [snapshot](int m) { return snapshot->currentMass(m) / snapshot->volume(m); });
+        bool haveCurrentMass = true;
+        for (auto snapshot : snapshots) haveCurrentMass &= snapshot->hasCurrentMass();
+        if (haveCurrentMass)
+        {
+            auto getWeight = [](const Snapshot* snapshot, int m) {
+                return snapshot->currentMass(m) / snapshot->volume(m);
+            };
+            probeImportedSourceWeighted("current mass", snapshots, getWeight);
+        }
     }
 }
 

--- a/SKIRT/core/ImportedSourceWeightedProbe.hpp
+++ b/SKIRT/core/ImportedSourceWeightedProbe.hpp
@@ -17,8 +17,12 @@
     that allow the user to configure the weighting mechanism. There are three choices: using the
     specific luminosity at a given wavelength, using initial mass, or using current mass.
 
-    Luminosity weighting can be accomplished for any imported source, regardless of the configured
-    %SED family, as long as the source's spectral range includes the specified wavelength.
+    The probes based on this class produce output only if the simulation has at least one source
+    component, if all sources are imported, and if all of these sources offer the properties
+    necessary to perform the requested type of weighting.
+
+    Luminosity weighting can be accomplished regardless of the configured %SED family as long as
+    the source's spectral range includes the specified wavelength.
 
     For stellar mass weighting, the situation is more complicated. The current stellar mass
     distribution of the source component is usually not automatically available to the SKIRT input
@@ -34,8 +38,7 @@
     data, a better solution is to provide it as a separate, additional column to the import
     process, enable the \em importCurrentMass option for the ImportedSource component, and set the
     \em weight option for the probe to \c CurrentMass. Now the probe will use the separately
-    imported current mass. In all cases, if a source component does not import the selected mass
-    type, the probe produces no output for that component. */
+    imported current mass. */
 class ImportedSourceWeightedProbe : public InputModelFormProbe, public MaterialWavelengthRangeInterface
 {
     /** The enumeration type specifying whether to average the probed quantity using luminosity,
@@ -72,20 +75,18 @@ public:
     //======================== Other Functions =======================
 
 protected:
-    /** This function is implemented here. It calls the probeImportedSourceWeighted() function for
-        each component of type ImportedSource that provides the data required for weighting
-        according to the user configuration. */
-    void probeImportedSource(string sh, const ImportedSource* source, const Snapshot* snapshot) override;
+    /** This function is implemented here. It defines an appropriate weight function and calls the
+        probeImportedSourceWeighted() function implemented in the subclass to implement the actual
+        probing. */
+    void probeImportedSources(const vector<const ImportedSource*>& sources,
+                              const vector<const Snapshot*>& snapshots) override;
 
-    /** This function should be implemented by each subclass. It will be called for each component
-        of type ImportedSource that provides the data required for weighting according to the user
-        configuration. The first argument is a string representation of the zero-based component
-        index (including non-imported components), and the second argument is a string
+    /** This function should be implemented by each subclass. The first argument is a string
         representation of the weighting scheme. The last argument is a call-back function that
         returns the weight for the entity with the given index in the snapshot, again according to
         the user configuration. */
-    virtual void probeImportedSourceWeighted(string sh, string sweight, const Snapshot* snapshot,
-                                             std::function<double(int m)> weight) = 0;
+    virtual void probeImportedSourceWeighted(string sweight, const vector<const Snapshot*>& snapshots,
+                                             std::function<double(const Snapshot* snapshot, int m)> weight) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/InputModelFormProbe.cpp
+++ b/SKIRT/core/InputModelFormProbe.cpp
@@ -14,13 +14,26 @@
 
 void InputModelFormProbe::probe()
 {
-    // loop over sources
+    // handle sources together
     const auto& sources = find<SourceSystem>()->sources();
-    int numSources = sources.size();
-    for (int h = 0; h != numSources; ++h)
+    if (!sources.empty())
     {
-        auto source = dynamic_cast<ImportedSource*>(sources[h]);
-        if (source) probeImportedSource(std::to_string(h), source, source->snapshot());
+        // collect snapshots for all imported sources
+        vector<const ImportedSource*> importedSources;
+        vector<const Snapshot*> snapshots;
+        for (auto source : sources)
+        {
+            auto importedSource = dynamic_cast<ImportedSource*>(source);
+            if (!importedSource) break;
+            importedSources.push_back(importedSource);
+            snapshots.push_back(importedSource->snapshot());
+        }
+
+        // if all sources are imported, call subclass
+        if (importedSources.size() == sources.size())
+        {
+            probeImportedSources(importedSources, snapshots);
+        }
     }
 
     // loop over media
@@ -30,16 +43,16 @@ void InputModelFormProbe::probe()
         int numMedia = media.size();
         for (int h = 0; h != numMedia; ++h)
         {
-            auto medium = dynamic_cast<ImportedMedium*>(media[h]);
-            if (medium) probeImportedMedium(std::to_string(h), medium, medium->snapshot());
+            auto importedMedium = dynamic_cast<ImportedMedium*>(media[h]);
+            if (importedMedium) probeImportedMedium(std::to_string(h), importedMedium, importedMedium->snapshot());
         }
     }
 }
 
 ////////////////////////////////////////////////////////////////////
 
-void InputModelFormProbe::probeImportedSource(string /*sh*/, const ImportedSource* /*source*/,
-                                              const Snapshot* /*snapshot*/)
+void InputModelFormProbe::probeImportedSources(const vector<const ImportedSource*>& /*sources*/,
+                                               const vector<const Snapshot*>& /*snapshots*/)
 {}
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/InputModelFormProbe.hpp
+++ b/SKIRT/core/InputModelFormProbe.hpp
@@ -20,9 +20,12 @@ class Snapshot;
     for more information.
 
     This class offers facilities for subclasses that probe imported source or media components.
-    Specifically, its probe() function calls distinct functions in the subclass for each imported
-    source or media component in the simulation. If probes would be developed that access other
-    aspects of the input model, then an extra layer of subclasses may be required. */
+    Imported sources are always handled together, i.e. aggregated system-wide, because it is not
+    meaningful to average properties over each source individually. Imported media are handled per
+    component, because aggregating various medium components can be ambiguous (e.g., they may be
+    defined in terms of number or mass density). If probes would be developed that access other
+    aspects of the input model, this may require additional functionality in this class or an extra
+    intermediate layer of subclasses. */
 class InputModelFormProbe : public Probe
 {
     ITEM_ABSTRACT(InputModelFormProbe, Probe, "an input model form probe")
@@ -36,19 +39,25 @@ class InputModelFormProbe : public Probe
     //======================== Other Functions =======================
 
 public:
-    /** This function is implemented here. It calls the probeImportedSource() function for each
-        component of type ImportedSource in the configured source system, and the
-        probeImportedMedium() function for each component of type ImportedMedium in the configured
-        medium system. */
+    /** This function is implemented here. It invokes functions defined in the subclass as follows
+        (see the class header form the rationale):
+
+        - if \em all source components in the simulation are of type ImportedSource (and there is
+        at least one of them), the probeImportedSources() subclass function is called to handle the
+        full set of imported sources at the same time.
+
+        - the probeImportedMedium() subclass function is called to handle each medium component of
+        type ImportedMedium in the simulation; any other medium components are skipped. */
     void probe() override;
 
 protected:
     /** This function should be implemented by subclasses that probe imported sources. It will be
-        called for each component of type ImportedSource in the configured source system, in order
-        of occurrence. The first argument is a string representation of the zero-based component
-        index (including non-imported components). The implementation in this base class does
+        called only if all source components in the configured source system are of type
+        ImportedSource and there is at least one of them. The source components and corresponding
+        snapshots are listed in order of occurrence. The implementation in this base class does
         nothing. */
-    virtual void probeImportedSource(string sh, const ImportedSource* source, const Snapshot* snapshot);
+    virtual void probeImportedSources(const vector<const ImportedSource*>& sources,
+                                      const vector<const Snapshot*>& snapshots);
 
     /** This function should be implemented by subclasses that probe imported media. It will be
         called for each component of type ImportedMedium in the configured source system, in order

--- a/SKIRT/core/ProbeFormBridge.hpp
+++ b/SKIRT/core/ProbeFormBridge.hpp
@@ -132,8 +132,9 @@ class Units;
     quantity being probed along the path starting at the specified position in the specified
     direction. Used for input model probes.
 
-    - \em snapshot: a pointer to the snapshot representing the imported source or medium component
-    being probed. Used for input model probes that probe an imported source or medium component.
+    - \em snapshots: a list of pointers to the snapshots representing the set of imported source
+    or medium components being probed. Used for input model probes that probe imported source or
+    medium components.
 
     - \em valueInEntity: the callback function that will be used to retrieve values of the quantity
     being probed in a snapshot entity with given index. Used for input model probes that probe an
@@ -216,17 +217,17 @@ public:
     /** This is the type declaration for the callback function provided by the imported model probe
         to retrieve the scalar value (in internal units) of the quantity being probed in the
         snapshot entity with index \f$m\f$. */
-    using ScalarValueInEntity = std::function<double(int m)>;
+    using ScalarValueInEntity = std::function<double(const Snapshot* snapshot, int m)>;
 
     /** This is the type declaration for the callback function provided by the imported model probe
         to retrieve the vector value (in internal units) of the quantity being probed in the
         snapshot entity with index \f$m\f$. */
-    using VectorValueInEntity = std::function<Vec(int m)>;
+    using VectorValueInEntity = std::function<Vec(const Snapshot* snapshot, int m)>;
 
     /** This is the type declaration for the callback function provided by the imported model probe
         to retrieve the weight (in arbitrary units) of the quantity being probed in the snapshot
         entity with index \f$m\f$. */
-    using WeightInEntity = std::function<double(int m)>;
+    using WeightInEntity = std::function<double(const Snapshot* snapshot, int m)>;
 
     //======== Writing: for use by spatial grid probes  =======
 
@@ -288,7 +289,7 @@ public:
         It should be called only from input model probes for imported source or media components.
         Refer to the class header for more information on the arguments. */
     void writeQuantity(string fileid, string projectedFileid, string quantity, string projectedQuantity,
-                       string description, string projectedDescription, const Snapshot* snapshot,
+                       string description, string projectedDescription, const vector<const Snapshot*>& snapshots,
                        ScalarValueInEntity valueInEntity);
 
     /** This function causes the form associated with this bridge to output a file for a scalar
@@ -296,14 +297,16 @@ public:
         should be called only from input model probes for imported source or media components.
         Refer to the class header for more information on the arguments. */
     void writeQuantity(string fileid, string quantity, string description, string projectedDescription,
-                       const Snapshot* snapshot, ScalarValueInEntity valueInEntity, WeightInEntity weightInEntity);
+                       const vector<const Snapshot*>& snapshots, ScalarValueInEntity valueInEntity,
+                       WeightInEntity weightInEntity);
 
     /** This function causes the form associated with this bridge to output a file for a vector
         quantity that needs to be averaged along a path, according to the provided information. It
         should be called only from input model probes for imported source or media components.
         Refer to the class header for more information on the arguments. */
     void writeQuantity(string fileid, string quantity, string description, string projectedDescription,
-                       const Snapshot* snapshot, VectorValueInEntity valueInEntity, WeightInEntity weightInEntity);
+                       const vector<const Snapshot*>& snapshots, VectorValueInEntity valueInEntity,
+                       WeightInEntity weightInEntity);
 
     //======== Querying: for use by all form types  =======
 

--- a/SKIRT/utils/EntityCollection.cpp
+++ b/SKIRT/utils/EntityCollection.cpp
@@ -46,56 +46,35 @@ double EntityCollection::accumulate(std::function<double(int)> value)
 
 ////////////////////////////////////////////////////////////////////
 
-double EntityCollection::average(std::function<double(int m)> value, std::function<double(int m)> weight)
+std::pair<double, double> EntityCollection::average(std::function<double(int m)> value,
+                                                    std::function<double(int m)> weight)
 {
-    if (_entities.size() > 1)
+    double sumvw = 0.;
+    double sumw = 0.;
+    for (const auto& entity : _entities)
     {
-        double sumvw = 0.;
-        double sumw = 0.;
-        for (const auto& entity : _entities)
-        {
-            double v = value(entity.first);
-            double w = weight(entity.first) * entity.second;
-            sumvw += v * w;
-            sumw += w;
-        }
-        return sumw > 0. ? sumvw / sumw : 0.;
+        double v = value(entity.first);
+        double w = weight(entity.first) * entity.second;
+        sumvw += v * w;
+        sumw += w;
     }
-    else if (_entities.size() == 1)
-    {
-        return value(_entities.cbegin()->first);
-    }
-    else
-    {
-        return 0.;
-    }
+    return std::make_pair(sumvw, sumw);
 }
 
 ////////////////////////////////////////////////////////////////////
 
-Vec EntityCollection::average(std::function<Vec(int)> value, std::function<double(int)> weight)
+std::pair<Vec, double> EntityCollection::average(std::function<Vec(int m)> value, std::function<double(int m)> weight)
 {
-    if (_entities.size() > 1)
+    Vec sumvw;
+    double sumw = 0.;
+    for (const auto& entity : _entities)
     {
-        Vec sumvw;
-        double sumw = 0.;
-        for (const auto& entity : _entities)
-        {
-            Vec v = value(entity.first);
-            double w = weight(entity.first) * entity.second;
-            sumvw += v * w;
-            sumw += w;
-        }
-        return sumw > 0. ? sumvw / sumw : Vec();
+        Vec v = value(entity.first);
+        double w = weight(entity.first) * entity.second;
+        sumvw += v * w;
+        sumw += w;
     }
-    else if (_entities.size() == 1)
-    {
-        return value(_entities.cbegin()->first);
-    }
-    else
-    {
-        return Vec();
-    }
+    return std::make_pair(sumvw, sumw);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/EntityCollection.hpp
+++ b/SKIRT/utils/EntityCollection.hpp
@@ -72,27 +72,27 @@ public:
         to a given entity index. */
     double accumulate(std::function<double(int m)> value);
 
-    /** This function returns the weighted average of a given scalar field \f$f(m)\f$ with given
-        external weight \f$\omega(m)\f$ over all entities in the collection. The arguments
-        respectively specify the scalar field \f$f(m)\f$ and the corresponding external weight
-        \f$\omega(m)\f$. These functions should return the field value respectively the external
-        weight corresponding to a given entity index.
+    /** This function returns the nominator and denominator for the weighted average of a given
+        scalar field \f$f(m)\f$ with given external weight \f$\omega(m)\f$ over all entities in the
+        collection. The arguments respectively specify the scalar field \f$f(m)\f$ and the
+        corresponding external weight \f$\omega(m)\f$. These functions should return the field
+        value respectively the external weight corresponding to a given entity index.
 
         The function combines the external weights with the weights stored internally for each
-        entity in the collection. Specifically, it calculates \f[\frac{\sum_m f(m)\,\omega(m)\,w_m}
-        {\sum_m \omega(m)\,w_m}.\f] */
-    double average(std::function<double(int m)> value, std::function<double(int m)> weight);
+        entity in the collection. Specifically, it calculates \f$\sum_m f(m)\,\omega(m)\,w_m\f$ and
+        \f$\sum_m \omega(m)\,w_m\f$. */
+    std::pair<double, double> average(std::function<double(int m)> value, std::function<double(int m)> weight);
 
-    /** This function returns the weighted average of a given vector field \f${\bf{f}}(m)\f$ with
-        given external weight \f$\omega(m)\f$ over all entities in the collection. The arguments
-        respectively specify the vector field \f${\bf{f}}(m)\f$ and the corresponding external
-        weight \f$\omega(m)\f$. These functions should return the field value respectively the
-        external weight corresponding to a given entity index.
+    /** This function returns the nominator and denominator for the weighted average of a given
+        vector field \f${\bf{f}}(m)\f$ with given external weight \f$\omega(m)\f$ over all entities
+        in the collection. The arguments respectively specify the vector field \f${\bf{f}}(m)\f$
+        and the corresponding external weight \f$\omega(m)\f$. These functions should return the
+        field value respectively the external weight corresponding to a given entity index.
 
         The function combines the external weights with the weights stored internally for each
-        entity in the collection. Specifically, it calculates \f[\frac{\sum_m
-        {\bf{f}}(m)\,\omega(m)\,w_m} {\sum_m \omega(m)\,w_m}.\f] */
-    Vec average(std::function<Vec(int m)> value, std::function<double(int m)> weight);
+        entity in the collection. Specifically, it calculates \f$\sum_m
+        {\bf{f}}(m)\,\omega(m)\,w_m\f$ and \f$\sum_m \omega(m)\,w_m\f$. */
+    std::pair<Vec, double> average(std::function<Vec(int m)> value, std::function<double(int m)> weight);
 
     // ------- Data members -------
 


### PR DESCRIPTION
**Description**
With this update, the probes for imported sources now always produce just a single output file, aggregating the requested information for all imported sources in the simulation's configuration (accumulating or averaging depending on the quantity being probed). This is an incompatible change, as detailed below.

**Motivation**
Calculating mass-averaged quantities (such as metallicity or age) over an individual source does not make any sense. Specifically, if there are multiple sources, it is impossible to calculate the overall average based on the individual averages per component. The previously produced information was thus essentially useless in this context. The issue is less annoying for accumulated quantities (such as luminosity), but it seems more meaningful to handle all imported source probes in the same way.

**Incompatibilities**
If the simulation has just a single source, and it is an imported source, the only difference is the name of the output file, in which the component index `0_` is now omitted. If there are multiple sources, the probes might now refuse to produce output, e.g., because there are geometric sources or because not all imported sources offer the properties being probed. The rules are listed in the documentation for each probe.

In most cases, this won't be a problem. Otherwise, a separate simulation can be configured that includes just the imported sources to be probed (and perhaps does not launch any photon packets).

**Tests**
The affected functional tests have been updated.

**Context**
The probes for imported medium components are not affected and continue producing output for each component separately. Aggregating multiple medium components is often ambiguous without additional information (e.g., translating between number densities and mass densities). Furthermore, as a good alternative, proper aggregated probe output is available for the discretized media properties anyway.