### PR TITLE
Random points and diagonals in spherical and cylindrical grids

### DIFF
--- a/SKIRT/core/Cylinder2DSpatialGrid.cpp
+++ b/SKIRT/core/Cylinder2DSpatialGrid.cpp
@@ -95,7 +95,7 @@ Position Cylinder2DSpatialGrid::randomPositionInCell(int m) const
 {
     int i, k;
     invertIndex(m, i, k);
-    double R = _Rv[i] + (_Rv[i + 1] - _Rv[i]) * random()->uniform();
+    double R = sqrt(_Rv[i] * _Rv[i] + (_Rv[i + 1] - _Rv[i]) * (_Rv[i + 1] + _Rv[i]) * random()->uniform());
     double phi = 2.0 * M_PI * random()->uniform();
     double z = _zv[k] + (_zv[k + 1] - _zv[k]) * random()->uniform();
     return Position(R, phi, z, Position::CoordinateSystem::CYLINDRICAL);

--- a/SKIRT/core/Cylinder2DSpatialGrid.cpp
+++ b/SKIRT/core/Cylinder2DSpatialGrid.cpp
@@ -57,6 +57,18 @@ double Cylinder2DSpatialGrid::volume(int m) const
 
 //////////////////////////////////////////////////////////////////////
 
+double Cylinder2DSpatialGrid::diagonal(int m) const
+{
+    int i, k;
+    invertIndex(m, i, k);
+    if (i < 0 || i >= _NR || k < 0 || k >= _Nz) return 0.;
+    Position p1(_Rv[i + 1], 0., _zv[k + 1], Position::CoordinateSystem::CYLINDRICAL);
+    Position p0(_Rv[i], 0., _zv[k], Position::CoordinateSystem::CYLINDRICAL);
+    return (p1 - p0).norm();
+}
+
+//////////////////////////////////////////////////////////////////////
+
 int Cylinder2DSpatialGrid::cellIndex(Position bfr) const
 {
     int i = NR::locateFail(_Rv, bfr.cylRadius());

--- a/SKIRT/core/Cylinder2DSpatialGrid.hpp
+++ b/SKIRT/core/Cylinder2DSpatialGrid.hpp
@@ -75,8 +75,8 @@ public:
         axisymmetric grid, the function first determines the radial and vertical bin indices
         \f$i\f$ and \f$k\f$ that correspond to the index \f$m\f$. Then a random radius \f$R\f$, a
         random azimuth \f$\phi\f$, and a random height \f$z\f$ are determined using \f[
-        \begin{split} R &= R_i + {\cal{X}}_1\,(R_{i+1}-R_i) \\ \phi &= 2\pi\,{\cal{X}}_2 \\ z &=
-        z_k + {\cal{X}}_3\, (z_{k+1}-z_k), \end{split} \f] with \f${\cal{X}}_1\f$,
+        \begin{split} R &= \sqrt{R_i^2 + {\cal{X}}_1\,(R_{i+1}-R_i)^2} \\ \phi &= 2\pi\,{\cal{X}}_2
+        \\ z &= z_k + {\cal{X}}_3\, (z_{k+1}-z_k), \end{split} \f] with \f${\cal{X}}_1\f$,
         \f${\cal{X}}_2\f$ and \f${\cal{X}}_3\f$ three uniform deviates. A position with these
         cylindrical coordinates is returned. */
     Position randomPositionInCell(int m) const override;

--- a/SKIRT/core/Cylinder2DSpatialGrid.hpp
+++ b/SKIRT/core/Cylinder2DSpatialGrid.hpp
@@ -53,6 +53,11 @@ public:
         \left(R_{i+1}-R_i\right)^2 \left(z_{k+1}-z_k\right). \f] */
     double volume(int m) const override;
 
+    /** This function returns the "diagonal" of the cell with index \f$m\f$. For 2D cylindrical
+        grids, it returns the distance between the outer/upper and inner/lower corners of the cell
+        in the meridional plane. */
+    double diagonal(int m) const override;
+
     /** This function returns the number of the cell that contains the position \f${\bf{r}}\f$. It
         just determines the radial and vertical bin indices and calculates the correct cell index
         based on these two numbers. */

--- a/SKIRT/core/SpatialGrid.cpp
+++ b/SKIRT/core/SpatialGrid.cpp
@@ -18,13 +18,6 @@ void SpatialGrid::setupSelfBefore()
 
 //////////////////////////////////////////////////////////////////////
 
-double SpatialGrid::diagonal(int m) const
-{
-    return cbrt(3. * volume(m));
-}
-
-//////////////////////////////////////////////////////////////////////
-
 void SpatialGrid::writeGridPlotFiles(const SimulationItem* probe) const
 {
     // For the xy plane (always)

--- a/SKIRT/core/SpatialGrid.hpp
+++ b/SKIRT/core/SpatialGrid.hpp
@@ -47,12 +47,10 @@ public:
     /** This function returns the volume of the cell with index \f$m\f$. */
     virtual double volume(int m) const = 0;
 
-    /** This function returns the actual or effective diagonal of the cell with index \f$m\f$. The
-        default implementation in this class returns \f$(3V)^(1/3)\f$ where \f$V\f$ is the volume
-        of the cell. For a cube, this returns the actual diagonal; for any other form it returns
-        some approximate, "effective" diagonal. Grids that have cuboidal cells should override this
-        function to return the actual diagional for each cell. */
-    virtual double diagonal(int m) const;
+    /** This function returns the actual or approximate diagonal of the cell with index \f$m\f$.
+        For cuboidal cells, the function returns the actual diagonal. For other geometric forms, it
+        returns some approximate diagonal. */
+    virtual double diagonal(int m) const = 0;
 
     /** This function returns the index \f$m\f$ of the cell that contains the position
         \f${\bf{r}}\f$. */

--- a/SKIRT/core/Sphere1DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.cpp
@@ -54,6 +54,15 @@ double Sphere1DSpatialGrid::volume(int m) const
 
 //////////////////////////////////////////////////////////////////////
 
+double Sphere1DSpatialGrid::diagonal(int m) const
+{
+    int i = m;
+    if (i < 0 || i >= _Nr) return 0.;
+    return _rv[i + 1] - _rv[i];
+}
+
+//////////////////////////////////////////////////////////////////////
+
 int Sphere1DSpatialGrid::cellIndex(Position bfr) const
 {
     return NR::locateFail(_rv, bfr.radius());

--- a/SKIRT/core/Sphere1DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.cpp
@@ -83,7 +83,9 @@ Position Sphere1DSpatialGrid::randomPositionInCell(int m) const
 {
     int i = m;
     Direction bfk = random()->direction();
-    double r = _rv[i] + (_rv[i + 1] - _rv[i]) * random()->uniform();
+    double r = cbrt(_rv[i] * _rv[i] * _rv[i]
+                    + (_rv[i + 1] - _rv[i]) * (_rv[i + 1] * _rv[i + 1] + _rv[i + 1] * _rv[i] + _rv[i] * _rv[i])
+                          * random()->uniform());
     return Position(r, bfk);
 }
 

--- a/SKIRT/core/Sphere1DSpatialGrid.hpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.hpp
@@ -71,9 +71,10 @@ public:
 
     /** This function returns a random location from the cell with index \f$m\f$. For a spherical
         grid, cell index \f$m\f$ corresponds to the radial bin with lower border index \f$i=m\f$,
-        and a random radius is determined using \f[ r = r_i + {\cal{X}}\,(r_{i+1}-r_i) \f] with
-        \f${\cal{X}}\f$ a random deviate. This random radius is combined with a random position on
-        the unit sphere to generate a random position from the cell. */
+        and a random radius is determined using \f[ r = \left( r_i^3 + {\cal{X}}
+        \,(r_{i+1}^3-r_i^3) \right)^{1/3} \f] with \f${\cal{X}}\f$ a random deviate. This random
+        radius is combined with a random position on the unit sphere to generate a random position
+        from the cell. */
     Position randomPositionInCell(int m) const override;
 
     /** This function creates and hands over ownership of a path segment generator (an instance of

--- a/SKIRT/core/Sphere1DSpatialGrid.hpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.hpp
@@ -54,6 +54,11 @@ public:
         and \f$r_{i+1}\f$ the inner and outer radius of the shell respectively. */
     double volume(int m) const override;
 
+    /** This function returns the "diagonal" of the cell with index \f$m\f$. For 1D spherical
+        grids, it simply returns the cell width, i.e. the difference between the outer and inner
+        cell radius. */
+    double diagonal(int m) const override;
+
     /** This function returns the number of the cell that contains the position \f${\bf{r}}\f$. It
         just determines the radial bin index and returns that number. */
     int cellIndex(Position bfr) const override;

--- a/SKIRT/core/Sphere2DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere2DSpatialGrid.cpp
@@ -99,6 +99,18 @@ double Sphere2DSpatialGrid::volume(int m) const
 
 //////////////////////////////////////////////////////////////////////
 
+double Sphere2DSpatialGrid::diagonal(int m) const
+{
+    int i, k;
+    invertIndex(m, i, k);
+    if (i < 0 || i >= _Nr || k < 0 || k >= _Ntheta) return 0.;
+    Position p1(_rv[i + 1], _thetav[k + 1], 0., Position::CoordinateSystem::SPHERICAL);
+    Position p0(_rv[i], _thetav[k], 0., Position::CoordinateSystem::SPHERICAL);
+    return (p1 - p0).norm();
+}
+
+//////////////////////////////////////////////////////////////////////
+
 int Sphere2DSpatialGrid::cellIndex(Position bfr) const
 {
     double r, theta, phi;

--- a/SKIRT/core/Sphere2DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere2DSpatialGrid.cpp
@@ -139,10 +139,10 @@ Position Sphere2DSpatialGrid::randomPositionInCell(int m) const
 {
     int i, k;
     invertIndex(m, i, k);
-    double ris = _rv[i] * _rv[i];
-    double ri1s = _rv[i + 1] * _rv[i + 1];
-    double r = sqrt(ris + (ri1s - ris) * random()->uniform());
-    double theta = _thetav[k] + (_thetav[k + 1] - _thetav[k]) * random()->uniform();
+    double r = cbrt(_rv[i] * _rv[i] * _rv[i]
+                    + (_rv[i + 1] - _rv[i]) * (_rv[i + 1] * _rv[i + 1] + _rv[i + 1] * _rv[i] + _rv[i] * _rv[i])
+                          * random()->uniform());
+    double theta = acos(cos(_thetav[k]) + (cos(_thetav[k + 1]) - cos(_thetav[k])) * random()->uniform());
     double phi = 2.0 * M_PI * random()->uniform();
     return Position(r, theta, phi, Position::CoordinateSystem::SPHERICAL);
 }

--- a/SKIRT/core/Sphere2DSpatialGrid.hpp
+++ b/SKIRT/core/Sphere2DSpatialGrid.hpp
@@ -77,9 +77,9 @@ public:
         the function first determines the radial and angular bin indices \f$i\f$ and \f$k\f$ that
         correspond to the cell index \f$m\f$. Then a random radius \f$r\f$, a random inclination
         \f$\theta\f$, and a random azimuth \f$\phi\f$ are determined using \f[ \begin{split} r &=
-        \left( r_i^2 + {\cal{X}}_1\,(r_{i+1}^2-r_i^2) \right)^{1/2} \\ \theta &= \theta_k +
-        {\cal{X}}_2\, (\theta_{k+1}-\theta_k) \\ \phi &= 2\pi\,{\cal{X}}_3, \end{split} \f] with
-        \f${\cal{X}}_1\f$, \f${\cal{X}}_2\f$ and \f${\cal{X}}_3\f$ three uniform deviates. */
+        \left( r_i^3 + {\cal{X}}_1\,(r_{i+1}^3-r_i^3) \right)^{1/3} \\ \cos\theta &= \cos\theta_k +
+        {\cal{X}}_2\, (\cos\theta_{k+1}-\cos\theta_k) \\ \phi &= 2\pi\,{\cal{X}}_3, \end{split} \f]
+        with \f${\cal{X}}_1\f$, \f${\cal{X}}_2\f$ and \f${\cal{X}}_3\f$ three uniform deviates. */
     Position randomPositionInCell(int m) const override;
 
     /** This function creates and hands over ownership of a path segment generator (an instance of

--- a/SKIRT/core/Sphere2DSpatialGrid.hpp
+++ b/SKIRT/core/Sphere2DSpatialGrid.hpp
@@ -56,6 +56,11 @@ public:
         \left(r_{i+1}^3-r_i^3\right) \left(\cos\theta_k-\cos\theta_{k+1}\right). \f] */
     double volume(int m) const override;
 
+    /** This function returns the "diagonal" of the cell with index \f$m\f$. For 2D spherical
+        grids, it returns the distance between the outer/upper and inner/lower corners of the cell
+        in the meridional plane. */
+    double diagonal(int m) const override;
+
     /** This function returns the number of the cell that contains the position \f${\bf{r}}\f$. In
         this class, the function determines the radial and angular bin indices and calculates the
         correct cell index based on these two numbers. */

--- a/SKIRT/core/VoronoiMeshSpatialGrid.cpp
+++ b/SKIRT/core/VoronoiMeshSpatialGrid.cpp
@@ -160,6 +160,13 @@ double VoronoiMeshSpatialGrid::volume(int m) const
 
 //////////////////////////////////////////////////////////////////////
 
+double VoronoiMeshSpatialGrid::diagonal(int m) const
+{
+    return cbrt(3. * _mesh->volume(m));
+}
+
+//////////////////////////////////////////////////////////////////////
+
 int VoronoiMeshSpatialGrid::cellIndex(Position bfr) const
 {
     return _mesh->cellIndex(bfr);

--- a/SKIRT/core/VoronoiMeshSpatialGrid.hpp
+++ b/SKIRT/core/VoronoiMeshSpatialGrid.hpp
@@ -80,6 +80,11 @@ public:
     /** This function returns the volume of the cell with index \f$m\f$. */
     double volume(int m) const override;
 
+    /** This function returns the approximate diagonal of the cell with index \f$m\f$. For a
+        Voronoi grid, it returns \f$(3V)^(1/3)\f$ where \f$V\f$ is the volume of the cell. This
+        corresponds to the correct diagonal only for cubical cells. */
+    double diagonal(int m) const override;
+
     /** This function returns the index of the cell that contains the position \f${\bf{r}}\f$. */
     int cellIndex(Position bfr) const override;
 


### PR DESCRIPTION
**Description**
This update addresses two issues in spherical and cylindrical spatial grids (`Sphere1DSpatialGrid`, `Sphere2DSpatialGrid`, `Cylinder2DSpatialGrid`).

- Random positions generated for these grids were located in the correct cell but were not uniformly distributed within the cell. This is now fixed. This issue affects two areas in simulations using one of these grids: sampling the input model density distribution and choosing the originating positions for photon packets during secondary emission from the medium. Although the previous behavior was incorrect, the effect is minor as long as the spatial domain is sufficiently resolved (so that each cell is small relative to the model size).

- The cell diagonal function now returns a more meaningful value for these grids. This value is used only for calculating the optical depth per cell in certain probes (`ConvergenceInfoProbe`, `SpatialCellPropertiesProbe`). The spherical 1D grid now returns the distance between the outer and inner cell radii; the spherical and cylindrical 2D grids now return the distance between the outer/upper and inner/lower corners of the cell in the meridional plane. As before, Cartesian grids with cuboidal cells return the true cell diagonal, and Voronoi grids return the diagonal of a cube with the same volume as the cell.

**Motivation**

- Random positions should be uniformly distributed within a cell for all grids.

- The new diagonals produce much more meaningful values for the optical depth in a cell, providing improved diagnostics of the discretization setup.

**Tests**
Manually verified the results for each grid type. Because the output of most simulations using a spherical or cylindrical spatial grid changes subtly, automated verification of correctness in all cases is essentially impossible. 
