### PR TITLE
Support self-consistent non-LTE line transfer for selected transitions and species

### DIFF
--- a/SKIRT/core/Configuration.hpp
+++ b/SKIRT/core/Configuration.hpp
@@ -372,7 +372,8 @@ public:
         separate data structure, and false otherwise. */
     bool hasSecondaryRadiationField() const { return _hasSecondaryRadiationField; }
 
-    /** Returns the wavelength grid to be used for storing the radiation field. */
+    /** Returns the wavelength grid to be used for storing the radiation field, or the null pointer
+        if hasRadiationField() returns false. */
     DisjointWavelengthGrid* radiationFieldWLG() const { return _radiationFieldWLG; }
 
     // ----> secondary emission

--- a/SKIRT/core/Cylinder2DSpatialGrid.cpp
+++ b/SKIRT/core/Cylinder2DSpatialGrid.cpp
@@ -57,6 +57,18 @@ double Cylinder2DSpatialGrid::volume(int m) const
 
 //////////////////////////////////////////////////////////////////////
 
+double Cylinder2DSpatialGrid::diagonal(int m) const
+{
+    int i, k;
+    invertIndex(m, i, k);
+    if (i < 0 || i >= _NR || k < 0 || k >= _Nz) return 0.;
+    Position p1(_Rv[i + 1], 0., _zv[k + 1], Position::CoordinateSystem::CYLINDRICAL);
+    Position p0(_Rv[i], 0., _zv[k], Position::CoordinateSystem::CYLINDRICAL);
+    return (p1 - p0).norm();
+}
+
+//////////////////////////////////////////////////////////////////////
+
 int Cylinder2DSpatialGrid::cellIndex(Position bfr) const
 {
     int i = NR::locateFail(_Rv, bfr.cylRadius());

--- a/SKIRT/core/Cylinder2DSpatialGrid.cpp
+++ b/SKIRT/core/Cylinder2DSpatialGrid.cpp
@@ -83,7 +83,7 @@ Position Cylinder2DSpatialGrid::randomPositionInCell(int m) const
 {
     int i, k;
     invertIndex(m, i, k);
-    double R = _Rv[i] + (_Rv[i + 1] - _Rv[i]) * random()->uniform();
+    double R = sqrt(_Rv[i] * _Rv[i] + (_Rv[i + 1] - _Rv[i]) * (_Rv[i + 1] + _Rv[i]) * random()->uniform());
     double phi = 2.0 * M_PI * random()->uniform();
     double z = _zv[k] + (_zv[k + 1] - _zv[k]) * random()->uniform();
     return Position(R, phi, z, Position::CoordinateSystem::CYLINDRICAL);

--- a/SKIRT/core/Cylinder2DSpatialGrid.hpp
+++ b/SKIRT/core/Cylinder2DSpatialGrid.hpp
@@ -70,8 +70,8 @@ public:
         axisymmetric grid, the function first determines the radial and vertical bin indices
         \f$i\f$ and \f$k\f$ that correspond to the index \f$m\f$. Then a random radius \f$R\f$, a
         random azimuth \f$\phi\f$, and a random height \f$z\f$ are determined using \f[
-        \begin{split} R &= R_i + {\cal{X}}_1\,(R_{i+1}-R_i) \\ \phi &= 2\pi\,{\cal{X}}_2 \\ z &=
-        z_k + {\cal{X}}_3\, (z_{k+1}-z_k), \end{split} \f] with \f${\cal{X}}_1\f$,
+        \begin{split} R &= \sqrt{R_i^2 + {\cal{X}}_1\,(R_{i+1}-R_i)^2} \\ \phi &= 2\pi\,{\cal{X}}_2
+        \\ z &= z_k + {\cal{X}}_3\, (z_{k+1}-z_k), \end{split} \f] with \f${\cal{X}}_1\f$,
         \f${\cal{X}}_2\f$ and \f${\cal{X}}_3\f$ three uniform deviates. A position with these
         cylindrical coordinates is returned. */
     Position randomPositionInCell(int m) const override;

--- a/SKIRT/core/Cylinder2DSpatialGrid.hpp
+++ b/SKIRT/core/Cylinder2DSpatialGrid.hpp
@@ -53,6 +53,11 @@ public:
         \left(R_{i+1}-R_i\right)^2 \left(z_{k+1}-z_k\right). \f] */
     double volume(int m) const override;
 
+    /** This function returns the "diagonal" of the cell with index \f$m\f$. For 2D cylindrical
+        grids, it returns the distance between the outer/upper and inner/lower corners of the cell
+        in the meridional plane. */
+    double diagonal(int m) const override;
+
     /** This function returns the number of the cell that contains the position \f${\bf{r}}\f$. It
         just determines the radial and vertical bin indices and calculates the correct cell index
         based on these two numbers. */

--- a/SKIRT/core/MolecularLineGasMix.cpp
+++ b/SKIRT/core/MolecularLineGasMix.cpp
@@ -279,7 +279,7 @@ void MolecularLineGasMix::initializeSpecificState(MaterialState* state, double /
 
         // set effective temperature, including imported or default micro-turbulence
         double vturb = params.size() ? params[_numColPartners] : defaultMicroTurbulenceVelocity();
-        double Teff = Tkin + vturb * vturb * mass() / Constants::k();
+        double Teff = Tkin + 0.5 * vturb * vturb * _mass / Constants::k();
         state->setTemperature(Teff);
 
         // copy collisional partner densities from import or default

--- a/SKIRT/core/MolecularLineGasMix.cpp
+++ b/SKIRT/core/MolecularLineGasMix.cpp
@@ -132,9 +132,8 @@ void MolecularLineGasMix::setupSelfBefore()
             log->info("Test molecule (" + StringUtils::toString(_indexUpRad[_indexRadTrans[i]]) + "-"
                       + StringUtils::toString(_indexLowRad[_indexRadTrans[i]]) + ") "
                       + StringUtils::toString(centers[_indexRadTrans[i]] * 1e6) + " [um]");
-            _indexLines.push_back(-1);  // initialization of the indexes of the rotational lines
-            _indexLines[i] = config->radiationFieldWLG()->bin(centers[_indexRadTrans[i]]);
-            if (_indexLines[i] < 0)
+            auto index = config->radiationFieldWLG()->bin(centers[_indexRadTrans[i]]);
+            if (index < 0)
                 throw FATALERROR("Radiation field wavelength grid does not include a transition "
                                  + StringUtils::toString(_indexRadTrans[i]) + " line");
         }

--- a/SKIRT/core/MolecularLineGasMix.cpp
+++ b/SKIRT/core/MolecularLineGasMix.cpp
@@ -359,7 +359,7 @@ namespace
     // given the line center, the effective gas temperature, and the species mass
     double sigmaForLine(double center, double temperature, double mass)
     {
-        return center / Constants::c() * sqrt(2. * Constants::k() * temperature / mass);
+        return center / Constants::c() * sqrt(Constants::k() * temperature / mass);
     }
 
     // return the value at ordinate x of a normalized Gaussian probability distribution

--- a/SKIRT/core/MolecularLineGasMix.cpp
+++ b/SKIRT/core/MolecularLineGasMix.cpp
@@ -388,8 +388,8 @@ UpdateStatus MolecularLineGasMix::updateSpecificState(MaterialState* state, cons
             int low = _indexLowRad[k];
 
             // add the Einstein Aul coefficients (spontaneous emission)
-            matrix[up][up] += _einsteinA[k];
-            matrix[low][up] -= _einsteinA[k];
+            matrix[up][up] -= _einsteinA[k];
+            matrix[low][up] += _einsteinA[k];
 
             // calculate the mean intensity of the radiation field convolved over the normalized line profile g:
             //   J_convolved = \int J_lambda(lambda) g(lambda) d lambda  /  \int g(lambda) d lambda
@@ -427,12 +427,12 @@ UpdateStatus MolecularLineGasMix::updateSpecificState(MaterialState* state, cons
             double J = Jsum / gsum;
 
             // add the Einstein Bul coefficients (stimulated emission)
-            matrix[up][up] += _einsteinBul[k] * J;
-            matrix[low][up] -= _einsteinBul[k] * J;
+            matrix[up][up] -= _einsteinBul[k] * J;
+            matrix[low][up] += _einsteinBul[k] * J;
 
             // add the Einstein Blu coefficients (absorption)
-            matrix[low][low] += _einsteinBlu[k] * J;
-            matrix[up][low] -= _einsteinBlu[k] * J;
+            matrix[low][low] -= _einsteinBlu[k] * J;
+            matrix[up][low] += _einsteinBlu[k] * J;
         }
 
         // add the terms for the collisional transitions
@@ -456,10 +456,10 @@ UpdateStatus MolecularLineGasMix::updateSpecificState(MaterialState* state, cons
 
                 // add the coefficients after multiplication by the partner number density
                 double n = state->colPartnerDensity(c);
-                matrix[up][up] += Kul * n;
-                matrix[low][low] += Klu * n;
-                matrix[up][low] -= Klu * n;
-                matrix[low][up] -= Kul * n;
+                matrix[up][up] -= Kul * n;
+                matrix[low][low] -= Klu * n;
+                matrix[up][low] += Klu * n;
+                matrix[low][up] += Kul * n;
             }
         }
 

--- a/SKIRT/core/MolecularLineGasMix.cpp
+++ b/SKIRT/core/MolecularLineGasMix.cpp
@@ -42,9 +42,9 @@ void MolecularLineGasMix::setupSelfBefore()
     // load the mass of the selected species
     {
         TextInFile infile(this, name + "_Mass.txt", "mass", true);
-        infile.addColumn("Molecular weight");
+        infile.addColumn("Mass", "mass", "amu");
         double weight;
-        if (infile.readRow(weight)) _mass = weight * Constants::Mproton();
+        if (infile.readRow(weight)) _mass = weight;
     }
 
     // load the energy levels
@@ -141,16 +141,21 @@ void MolecularLineGasMix::setupSelfBefore()
     // log summary info on the radiative lines
     auto log = find<Log>();
     auto units = find<Units>();
-    log->info("Radiative lines actually in use for " + name + ":");
+    log->info("Radiative lines for " + name + ":");
     if (_numLines == 0) throw FATALERROR("There are no radiative transitions; increase the number of energy levels");
     for (int k = 0; k != _numLines; ++k)
     {
         log->info("  (" + StringUtils::toString(_indexUpRad[k]) + "-" + StringUtils::toString(_indexLowRad[k]) + ") "
                   + StringUtils::toString(units->owavelength(_center[k])) + " " + units->uwavelength());
+    }
 
-        // verify that the radiation field wavelength grid has a bin covering the line center
+    // verify that the radiation field wavelength grid has a bin covering the line center
+    for (int k = 0; k != _numLines; ++k)
+    {
         if (config->radiationFieldWLG()->bin(_center[k]) < 0)
-            throw FATALERROR("Radiation field wavelength grid does not cover the central line for this transition");
+            throw FATALERROR("Radiation field wavelength grid does not cover the central line for transition ("
+                             + StringUtils::toString(_indexUpRad[k]) + "-" + StringUtils::toString(_indexLowRad[k])
+                             + ")");
     }
 }
 

--- a/SKIRT/core/MolecularLineGasMix.cpp
+++ b/SKIRT/core/MolecularLineGasMix.cpp
@@ -240,6 +240,14 @@ vector<StateVariable> MolecularLineGasMix::specificStateVariableInfo() const
         result.push_back(
             StateVariable::custom(index++, "population of level " + std::to_string(p), "numbervolumedensity"));
 
+#ifdef DIAGNOSTIC
+    // add custom variable for the line-profile-averaged mean intensity at each transition line
+    const_cast<MolecularLineGasMix*>(this)->_indexFirstMeanIntensity = index;
+    for (int k = 0; k != _numLines; ++k)
+        result.push_back(
+            StateVariable::custom(index++, "mean intensity at line " + std::to_string(k), "wavelengthmeanintensity"));
+#endif
+
     return result;
 }
 
@@ -253,6 +261,9 @@ vector<StateVariable> MolecularLineGasMix::specificStateVariableInfo() const
 #define colPartnerDensity(index) custom(_indexFirstColPartnerDensity + (index))
 #define setLevelPopulation(index, value) setCustom(_indexFirstLevelPopulation + (index), (value))
 #define levelPopulation(index) custom(_indexFirstLevelPopulation + (index))
+#ifdef DIAGNOSTIC
+    #define setMeanIntensity(index, value) setCustom(_indexFirstMeanIntensity + (index), (value))
+#endif
 
 ////////////////////////////////////////////////////////////////////
 
@@ -427,6 +438,9 @@ UpdateStatus MolecularLineGasMix::updateSpecificState(MaterialState* state, cons
                 for (size_t i = 1; i != message.size(); ++i) find<Log>()->info(message[i]);
             }
             double J = Jsum / gsum;
+#ifdef DIAGNOSTIC
+            state->setMeanIntensity(k, J);
+#endif
 
             // add the Einstein Bul coefficients (stimulated emission)
             matrix[up][up] -= _einsteinBul[k] * J;

--- a/SKIRT/core/MolecularLineGasMix.cpp
+++ b/SKIRT/core/MolecularLineGasMix.cpp
@@ -208,8 +208,8 @@ vector<SnapshotParameter> MolecularLineGasMix::parameterInfo() const
     for (const auto& partner : _colPartner)
         result.push_back(SnapshotParameter::custom(partner.name + " number density", "numbervolumedensity", "1/cm3"));
 
-    // add the micro turbulence velocity
-    result.push_back(SnapshotParameter::custom("Micro turbulence", "velocity", "km/s"));
+    // add the turbulence velocity
+    result.push_back(SnapshotParameter::custom("turbulence velocity", "velocity", "km/s"));
 
     return result;
 }
@@ -219,13 +219,13 @@ vector<SnapshotParameter> MolecularLineGasMix::parameterInfo() const
 vector<StateVariable> MolecularLineGasMix::specificStateVariableInfo() const
 {
     // add standard variables for the number density of the species under consideration
-    // and for the effective gas temperature (including kinetic temperature and unresolved microturbulence)
+    // and for the effective gas temperature (including kinetic temperature and unresolved turbulence)
     vector<StateVariable> result{StateVariable::numberDensity(), StateVariable::temperature()};
 
     // next available custom variable index
     int index = 0;
 
-    // add custom variable for the kinetic gas temperature (i.e. excluding microturbulence)
+    // add custom variable for the kinetic gas temperature (i.e. excluding turbulence)
     const_cast<MolecularLineGasMix*>(this)->_indexKineticTemperature = index;
     result.push_back(StateVariable::custom(index++, "kinetic gas temperature", "temperature"));
 
@@ -262,7 +262,7 @@ vector<StateVariable> MolecularLineGasMix::specificStateVariableInfo() const
 #define setLevelPopulation(index, value) setCustom(_indexFirstLevelPopulation + (index), (value))
 #define levelPopulation(index) custom(_indexFirstLevelPopulation + (index))
 #ifdef DIAGNOSTIC
-    #define setMeanIntensity(index, value) setCustom(_indexFirstMeanIntensity + (index), (value))
+#    define setMeanIntensity(index, value) setCustom(_indexFirstMeanIntensity + (index), (value))
 #endif
 
 ////////////////////////////////////////////////////////////////////
@@ -277,8 +277,8 @@ void MolecularLineGasMix::initializeSpecificState(MaterialState* state, double /
         double Tkin = temperature >= 0. ? temperature : defaultTemperature();
         state->setKineticTemperature(Tkin);
 
-        // set effective temperature, including imported or default micro-turbulence
-        double vturb = params.size() ? params[_numColPartners] : defaultMicroTurbulenceVelocity();
+        // set effective temperature, including imported or default turbulence
+        double vturb = params.size() ? params[_numColPartners] : defaultTurbulenceVelocity();
         double Teff = Tkin + 0.5 * vturb * vturb * _mass / Constants::k();
         state->setTemperature(Teff);
 

--- a/SKIRT/core/MolecularLineGasMix.hpp
+++ b/SKIRT/core/MolecularLineGasMix.hpp
@@ -154,7 +154,7 @@
     where \f$g_u\f$ and \f$g_l\f$ represent the degeneracy of the upper and lower energy levels,
     respectively. The collisional coefficients \f$C_{ul}\f$ and \f$C_{lu}\f$ depend on the number
     density of the collisional partner and on the kinetic temperature \f$T_\mathrm{kin}\f$ of the
-    gas. These coefficients are related by \f[ \frac{C_{lu}}{C_{ul}} = \frac{g_l}{g_u}
+    gas. These coefficients are related by \f[ \frac{C_{lu}}{C_{ul}} = \frac{g_u}{g_l}
     \exp(-E_{ul}/kT_\mathrm{kin}).\f]
 
     <b>Emission</b>

--- a/SKIRT/core/MolecularLineGasMix.hpp
+++ b/SKIRT/core/MolecularLineGasMix.hpp
@@ -137,7 +137,8 @@
     where \f$g_u\f$ and \f$g_l\f$ represent the degeneracy of the upper and lower energy levels,
     respectively. The collisional coefficients \f$C_{ul}\f$ and \f$C_{lu}\f$ depend on the number
     density of the collisional partner and on the kinetic temperature \f$T_\mathrm{kin}\f$ of the
-    gas.
+    gas. These coefficients are related by \f[ \frac{C_{lu}}{C_{ul}} = \frac{g_l}{g_u}
+    \exp(-E_{ul}/kT_\mathrm{kin}).\f]
 
     <b>Emission</b>
 

--- a/SKIRT/core/MolecularLineGasMix.hpp
+++ b/SKIRT/core/MolecularLineGasMix.hpp
@@ -36,7 +36,7 @@
     - \c Two-level test molecule (TT): a fictive test molecule (called TT for our purposes) that
     has just two rotational energy levels with a corresponding transition line at 1666.67
     \f$\mu\mathrm{m}\f$. The single collisional interaction partner is molecular hydrogen. The
-    properties of this molecule are defined by van Zadelhoff et al. 2002 for use with the the first
+    properties of this molecule are defined by van Zadelhoff et al. 2002 for use with the first
     benchmark problem described there.
 
     - \c Hydroxyl radical (OH): includes rotational energy levels up to \f$J=7/2\f$ including
@@ -96,16 +96,16 @@
 
     The input model must provide values for the spatial distribution of several medium properties,
     including the number density of the species under consideration, the number density of any
-    relevant collisional partner species, the kinetic gas temperature, and the microturbulence
-    level. These values remain constant during the simulation. Most often, this information will be
-    read from an input file by associating the MolecularLineGasMix with a subclass of
-    ImportedMedium. For that medium component, the ski file attribute \em importTemperature
-    <b>must</b> be set to 'true', and \em importMetallicity and \em importVariableMixParams must be
-    left at 'false'. The additional columns required by the material mix are automatically imported
-    and are expected <b>after</b> all other columns. For example, if bulk velocities are also
-    imported for this medium component (i.e. \em importVelocity is 'true'), the column order would
-    be \f[ ..., n_\mathrm{mol}, T_\mathrm{kin}, v_\mathrm{x}, v_\mathrm{y}, v_\mathrm{z},
-    n_\mathrm{col1} [, n_\mathrm{col1}, ...], v_\mathrm{turb}\f]
+    relevant collisional partner species, the kinetic gas temperature, and the turbulence velocity.
+    These values remain constant during the simulation. Most often, this information will be read
+    from an input file by associating the MolecularLineGasMix with a subclass of ImportedMedium.
+    For that medium component, the ski file attribute \em importTemperature <b>must</b> be set to
+    'true', and \em importMetallicity and \em importVariableMixParams must be left at 'false'. The
+    additional columns required by the material mix are automatically imported and are expected
+    <b>after</b> all other columns. For example, if bulk velocities are also imported for this
+    medium component (i.e. \em importVelocity is 'true'), the column order would be \f[ ...,
+    n_\mathrm{mol}, T_\mathrm{kin}, v_\mathrm{x}, v_\mathrm{y}, v_\mathrm{z}, n_\mathrm{col1} [,
+    n_\mathrm{col1}, ...], v_\mathrm{turb}\f]
 
     For basic testing purposes, the MolecularLineGasMix can also be associated with a geometric
     medium component. The geometry then defines the spatial density distribution of the species
@@ -113,6 +113,20 @@
     properties specify a fixed default value for the other properties that will be used across the
     spatial domain. In this case, the number densities of the collisional partners are defined by a
     constant multiplier relative to \f$n_\mathrm{mol}\f$.
+
+    <b>Thermal motion and turbulence</b>
+
+    The thermal velocity in a medium of particles with mass \f$m\f$ at temperature
+    \f$T_\mathrm{kin}\f$ is defined as \f[ v_\mathrm{th} = \sqrt{\frac{2kT_\mathrm{kin}}{m}}. \f]
+    This value corresponds to the most probable particle speed, i.e. the point where the
+    probability distribution of the velocity vector norm reaches its maximum value. One often
+    considers an additional source of line broadening caused by subgrid processes other than those
+    corresponding to the kinetic temperature. This motion is characterized by the turbulent
+    velocity \f$v_\mathrm{turb}\f$. Assuming a Gaussian line profile, the total velocity dispersion
+    \f$v_\mathrm{s}\f$ (the standard deviation of the Gaussian in velocity space) is then defined
+    through \f[ \sqrt{2}\,v_\mathrm{s} = \sqrt{v_\mathrm{th}^2 + v_\mathrm{turb}^2}. \f] We can
+    artificially combine the effect of both thermal motion and turbulence into an effective
+    temperature, \f[ T_\mathrm{eff} = T_\mathrm{kin} + \frac{m v_\mathrm{turb}^2}{2k}. \f]
 
     <b>Level populations</b>
 
@@ -212,12 +226,12 @@ class MolecularLineGasMix : public EmittingGasMix
         ATTRIBUTE_DEFAULT_VALUE(defaultCollisionPartnerRatios, "1e4")
         ATTRIBUTE_DISPLAYED_IF(defaultCollisionPartnerRatios, "Level2")
 
-        PROPERTY_DOUBLE(defaultMicroTurbulenceVelocity, "the default (non-thermal) micro-turbulence velocity")
-        ATTRIBUTE_QUANTITY(defaultMicroTurbulenceVelocity, "velocity")
-        ATTRIBUTE_MIN_VALUE(defaultMicroTurbulenceVelocity, "[0 km/s")
-        ATTRIBUTE_MAX_VALUE(defaultMicroTurbulenceVelocity, "100000 km/s]")
-        ATTRIBUTE_DEFAULT_VALUE(defaultMicroTurbulenceVelocity, "0 km/s")
-        ATTRIBUTE_DISPLAYED_IF(defaultMicroTurbulenceVelocity, "Level2")
+        PROPERTY_DOUBLE(defaultTurbulenceVelocity, "the default (non-thermal) turbulence velocity")
+        ATTRIBUTE_QUANTITY(defaultTurbulenceVelocity, "velocity")
+        ATTRIBUTE_MIN_VALUE(defaultTurbulenceVelocity, "[0 km/s")
+        ATTRIBUTE_MAX_VALUE(defaultTurbulenceVelocity, "100000 km/s]")
+        ATTRIBUTE_DEFAULT_VALUE(defaultTurbulenceVelocity, "0 km/s")
+        ATTRIBUTE_DISPLAYED_IF(defaultTurbulenceVelocity, "Level2")
 
         PROPERTY_DOUBLE(maxChangeInLevelPopulations,
                         "the maximum relative change for the level populations in a cell to be considered converged")
@@ -283,8 +297,8 @@ public:
 public:
     /** This function returns the number and type of import parameters required by this particular
         material mix as a list of SnapshotParameter objects. For this class, the function returns a
-        descriptor for the number densities of the collisional partners and for the microturbulence
-        level. Importing the kinetic gas temperature should be enabled through the corresponding
+        descriptor for the number densities of the collisional partners and for the turbulence
+        velocity. Importing the kinetic gas temperature should be enabled through the corresponding
         standard configuration flag. */
     vector<SnapshotParameter> parameterInfo() const override;
 

--- a/SKIRT/core/MolecularLineGasMix.hpp
+++ b/SKIRT/core/MolecularLineGasMix.hpp
@@ -126,19 +126,7 @@
     where \f$\lambda_{ij}\f$ is the transition wavelength and \f$A_{ij}\f$, \f$B_{ij}\f$,
     \f$B_{ji}\f$ are the Einstein coefficients for spontaneous emission, induced emission, and
     absorption, and \f$C_{ij}\f$, \f$C_{ji}\f$ the coefficients for collisional excitation and
-    de-excitation. These coefficients are taken from the literature (references to be provided).
-
-    \em Note
-
-    We assume that the level populations of all molecules in a given spatial cell are the same, and
-    to calculate them we use the mean intensity of the radiation field at the rest wavelength of
-    each transition. This means that the radiation field wavelength grid needs just a single bin
-    for each transition. We consider this assumption to be valid if the width of the velocity bin
-    (or wavelength bin) of the observed spectrum is larger than the velocity dispersion of each
-    cell. In reality, however, the molecules in a cell have a velocity dispersion and the perceived
-    transition wavelength is different for each molecule. Therefore, one should calculate the mean
-    intensities of each level transition at several velocity bins in the wavelength range
-    corresponding to the velocity dispersion. However, the computational cost becomes very large.
+    de-excitation. These coefficients are taken from the literature.
 
     <b>Emission</b>
 
@@ -385,22 +373,36 @@ public:
     //======================== Data Members ========================
 
 private:
-    // These data members are loaded from text files in setupSelfBefore()
-    vector<double> _energyStates;  // the column of the energy states
-    vector<double> _weights;       // the column of the weight of energy states
-    vector<int> _indexUpRad;       // the column of the index of upper energy levels for the radiational transitions
-    vector<int> _indexLowRad;      // the column of the index of lower energy levels for radiational transitions
-    vector<double> _einsteinA;     // the column of Einstein A coefficients
-    vector<int> _indexUpCol;       // the column of the index of upper energy levels for collisional transitions
-    vector<int> _indexLowCol;      // the column of the index of lower energy levels for collisional transitions
-    vector<vector<double>>
-        _collisionCul;  // the column of collisional excitation coefficients for collisional transitions
+    // All data members are loaded from text resource files and/or precalculated in setupSelfBefore()
+    // (only the energy levels and transition actually used are stored in the data members)
 
-    // These data members are precalculated in setupSelfBefore()
-    vector<double> _einsteinBul;  // the column of Einstein Bul coefficients
-    int _numLines{-1};
-    vector<int> _indexRadTrans;  // index for the radiational transitions you use in this calculation
-    vector<int> _indexColTrans;  // index for the collisional transitions you use in this calculation
+    // mass
+    double _mass{0.};  // molecular weight multiplied by proton mass
+
+    // energy levels
+    int _numLevels{0};       // the number of energy levels
+    vector<double> _energy;  // the energy of each energy level
+    vector<double> _weight;  // the weight (multiplicity) of each energy level
+
+    // radiative transitions
+    int _numLines{0};             // the number of radiative transitions
+    vector<int> _indexUpRad;      // the upper energy level index for each radiative transition
+    vector<int> _indexLowRad;     // the lower energy level index for each radiative transition
+    vector<double> _einsteinA;    // the Einstein A coefficient for each radiative transition
+    vector<double> _einsteinBul;  // the Einstein Bul coefficient for each radiative transition
+    Array _center;                // the central emission wavelength for each radiative transition
+
+    // collisional transitions -- the transitions (not the coefficients) are assumed to be identical for all partners
+    int _numColTrans{0};       // the number of collisional transitions
+    vector<int> _indexUpCol;   // the upper energy level index for collisional transitions
+    vector<int> _indexLowCol;  // the lower energy level index for collisional transitions
+    struct ColPartner          // data structure holding information on a collisional partner
+    {
+        vector<double> T;   // the temperature grid points
+        vector<Array> Kul;  // the coefficient for each collisional transition and for each temperature
+    };
+    int _numColPartners{0};          // the number of collisional interaction partners
+    vector<ColPartner> _colPartner;  // the data for each collisional partner
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/MolecularLineGasMix.hpp
+++ b/SKIRT/core/MolecularLineGasMix.hpp
@@ -8,6 +8,9 @@
 
 #include "EmittingGasMix.hpp"
 
+// comment this line to omit diagnostic code
+#define DIAGNOSTIC 1
+
 ////////////////////////////////////////////////////////////////////
 
 /** The MolecularLineGasMix class describes the material properties related to selected rotational
@@ -426,6 +429,9 @@ private:
     int _indexKineticTemperature{0};
     int _indexFirstColPartnerDensity{0};
     int _indexFirstLevelPopulation{0};
+#ifdef DIAGNOSTIC
+    int _indexFirstMeanIntensity{0};
+#endif
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/MolecularLineGasMix.hpp
+++ b/SKIRT/core/MolecularLineGasMix.hpp
@@ -10,9 +10,13 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** The MolecularLineGasMix class describes the material properties related to selected rotational,
-    vibrational and/or rovibrational transitions in selected molecules and atoms. The class
-    properties allow configuring the species and number of transitions to be considered.
+/** The MolecularLineGasMix class describes the material properties related to selected rotational
+    transitions in selected molecules and atoms. For each supported species, the current
+    implementation includes a number of rotational energy levels (quantum number \f$J\f$) at the
+    base vibrational level (quantum number \f$v=0\f$) and supports the allowed transitions between
+    these levels. Vibrational and/or rovibrational energy levels and the corresponding transitions
+    may be added later. The class properties allow configuring the species and the number of
+    transitions to be considered.
 
     For each supported transition, the emission luminosity and absorption opacity in a given cell
     are determined from the gas properties defined in the input model and the local radiation field
@@ -26,11 +30,29 @@
 
     The current implementation supports the following molecular or atomic species:
 
-    - \c TwoLevelBenchmarkMolecule: a fictive test molecule with two energy levels and a single
-    collisional partner as defined by van Zadelhoff et al. 2002 for the first benchmark problem
-    described there. The corresponding line is at 1666.67 \f$\mu\mathrm{m}\f$.
+    - \c Two-level test molecule (TT): a fictive test molecule (called TT for our purposes) that
+    has just two rotational energy levels with a corresponding transition line at 1666.67
+    \f$\mu\mathrm{m}\f$. The single collisional interaction partner is molecular hydrogen. The
+    properties of this molecule are defined by van Zadelhoff et al. 2002 for use with the the first
+    benchmark problem described there.
 
-    [TO DO]
+    - \c Hydroxyl radical (OH): includes rotational energy levels up to \f$J=7/2\f$ including
+    hyperfine splitted levels. The corresponding transition lines are at wavelengths from 16.4
+    \f$\mu\mathrm{m}\f$ to 2 \f$\mathrm{m}\f$. The single collisional interaction partner is
+    molecular hydrogen.
+
+    - \c Formyl cation (HCO+): includes rotational energy levels up to \f$J=29\f$. The
+    corresponding transition lines are at wavelengths from 7.2 to 3361 \f$\mu\mathrm{m}\f$. The
+    single collisional interaction partner is molecular hydrogen.
+
+    - \c Carbon monoxide (CO): includes rotational energy levels up to \f$J=40\f$. The
+    corresponding transition lines are at wavelengths from 3.2 to 2601 \f$\mu\mathrm{m}\f$. The
+    single collisional interaction partner is molecular hydrogen.
+
+    - \c Atomic carbon (C): includes three rotational energy levels. The corresponding transition
+    lines are at wavelengths 230.3, 370.4 and 609.1 \f$\mu\mathrm{m}\f$. The collisional
+    interaction partners include molecular hydrogen, neutral atomic hydrogen, ionized atomic
+    hydrogen, electrons, and Helium.
 
     <b>Configuring the simulation</b>
 

--- a/SKIRT/core/MolecularLineGasMix.hpp
+++ b/SKIRT/core/MolecularLineGasMix.hpp
@@ -37,16 +37,16 @@
     benchmark problem described there.
 
     - \c Hydroxyl radical (OH): includes rotational energy levels up to \f$J=7/2\f$ including
-    hyperfine splitted levels. The corresponding transition lines are at wavelengths from 16.4
+    hyperfine splitted levels. The corresponding transition lines are at wavelengths from 24.6
     \f$\mu\mathrm{m}\f$ to 2 \f$\mathrm{m}\f$. The single collisional interaction partner is
     molecular hydrogen.
 
     - \c Formyl cation (HCO+): includes rotational energy levels up to \f$J=29\f$. The
-    corresponding transition lines are at wavelengths from 7.2 to 3361 \f$\mu\mathrm{m}\f$. The
+    corresponding transition lines are at wavelengths from 112.4 to 3361 \f$\mu\mathrm{m}\f$. The
     single collisional interaction partner is molecular hydrogen.
 
     - \c Carbon monoxide (CO): includes rotational energy levels up to \f$J=40\f$. The
-    corresponding transition lines are at wavelengths from 3.2 to 2601 \f$\mu\mathrm{m}\f$. The
+    corresponding transition lines are at wavelengths from 65.7 to 2601 \f$\mu\mathrm{m}\f$. The
     single collisional interaction partner is molecular hydrogen.
 
     - \c Atomic carbon (C): includes three rotational energy levels. The corresponding transition

--- a/SKIRT/core/MolecularLineGasMix.hpp
+++ b/SKIRT/core/MolecularLineGasMix.hpp
@@ -78,10 +78,10 @@
     profiles.
 
     During the initial primary emission segment, the simulation determines the radiation field
-    resulting from the primary sources and dust attenuation (molecular line absorption is taken to
-    be zero at this stage). The resulting radiation field allows a first estimation of the level
-    populations for each spatial grid cell; this calculation happens in the updateSpecificState()
-    function.
+    resulting from the primary sources, dust attenuation (if present) and molecular line absorption
+    based on default equilibrium level populations. The resulting radiation field allows a first
+    estimation of the level populations for each spatial grid cell; this calculation happens in the
+    updateSpecificState() function.
 
     During secondary emission, the simulation takes into account emission from all configured media
     in addition to absorption by these same media, including molecular lines in both cases. The
@@ -113,62 +113,60 @@
 
     <b>Level populations</b>
 
-    The level populations \f$n_i\f$ (used later to calculate the emission luminosities and the
-    absorption opacities) are obtained by solving the statistical equilibrium equations. The
-    equation for the energy level with index \f$i\f$ (where indices increase from lowest to highest
-    energy state) is given by
+    We denote the populations for the \f$N\f$ supported energy levels as \f$n_i\f$, with indices
+    \f$i=0,N-1\f$ increasing from lowest to highest energy state, and with \f$\sum_i n_i =
+    n_\mathrm{mol}\f$. The level populations form the basis to calculate the emission luminosities
+    and the absorption opacities at later stage. Their values are obtained by solving the set of
+    statistical equilibrium equations given by
 
-    \f[ \sum^{N_\mathrm{lp}}_{j>i} n_jA_{ji} + \sum^{N_\mathrm{lp}}_{j\neq i} \Big[ (n_jB_{ji} -
-    n_iB_{ij})J_\lambda(\lambda_{ij})\Big] + \sum^{N_\mathrm{lp}}_{j\neq i}
-    \big[n_jC_{ji}(n_\mathrm{col} ,T_\mathrm{kin}) - n_iC_{ij}(n_\mathrm{col}
-    ,T_\mathrm{kin})\big]=0, \f]
+    \f[ \sum_{j>i} \Big[n_jA_{ji} + (n_jB_{ji} - n_iB_{ij})J_{\lambda,ji})\Big]
+    - \sum_{j<i} \Big[n_iA_{ij} + (n_iB_{ij} - n_jB_{ji})J_{\lambda,ij})\Big]
+    + \sum_{j\neq i} \Big[n_jC_{ji} - n_iC_{ij}\Big]=0, \quad i=0,N-1\f]
 
-    where \f$\lambda_{ij}\f$ is the transition wavelength and \f$A_{ij}\f$, \f$B_{ij}\f$,
-    \f$B_{ji}\f$ are the Einstein coefficients for spontaneous emission, induced emission, and
-    absorption, and \f$C_{ij}\f$, \f$C_{ji}\f$ the coefficients for collisional excitation and
-    de-excitation. These coefficients are taken from the literature.
+    where \f$J_{\lambda,ul}\f$ is the mean radiation field intensity integrated over the line
+    profile corresponding to the transition from upper energy level \f$u\f$ to lower energy level
+    \f$l\f$. Furthermore, \f$A_{ul}\f$, \f$B_{ul}\f$, \f$B_{lu}\f$ are the Einstein coefficients
+    for spontaneous emission, induced emission, and absorption, and \f$C_{ul}\f$, \f$C_{lu}\f$ the
+    coefficients for collisional excitation and de-excitation. These coefficients are taken from
+    the literature.
 
     The Einstein coefficients \f$A_{ul}\f$, \f$B_{ul}\f$, and \f$B_{lu}\f$ are constant for each
-    transition, and the \f$B_{ij}\f$ and \f$B_{ji}\f$ coefficients can be obtained from the
-    \f$A_{ij}\f$ coefficients through \f[ B_{ul} = \frac{\lambda_{ul}^5}{2
-    hc^2}A_{ul} \f] and \f[ B_{lu} = \frac{g_u}{g_l} B_{ul} = \frac{g_u}{g_l} \frac{\lambda_{ul}^5}{2
-    hc^2}A_{ul},  \f] where \f$g_u\f$ and \f$g_l\f$ represent the degeneracy of the
-    upper and lower energy levels, respectively.
-
-    The collisional coefficients \f$C_{ul}\f$ depend on the number density of the collisional
-    partner and on the kinetic temperature \f$T_\mathrm{kin}\f$ of the gas.
+    transition, and the \f$B_{ul}\f$ and \f$B_{lu}\f$ coefficients can be obtained from the
+    \f$A_{ul}\f$ coefficients through \f[ B_{ul} = \frac{\lambda_{ul}^5}{2 hc^2}A_{ul} \f] and \f[
+    B_{lu} = \frac{g_u}{g_l} B_{ul} = \frac{g_u}{g_l} \frac{\lambda_{ul}^5}{2 hc^2}A_{ul}, \f]
+    where \f$g_u\f$ and \f$g_l\f$ represent the degeneracy of the upper and lower energy levels,
+    respectively. The collisional coefficients \f$C_{ul}\f$ and \f$C_{lu}\f$ depend on the number
+    density of the collisional partner and on the kinetic temperature \f$T_\mathrm{kin}\f$ of the
+    gas.
 
     <b>Emission</b>
 
-    The integrated line luminosity \f$L_\ell\f$ corresponding to the transition with index
-    \f$\ell\f$ for a given spatial cell is given by
+    The integrated line luminosity \f$L_{ul}\f$ corresponding to the transition from upper energy
+    level \f$u\f$ to lower energy level \f$l\f$ for a given spatial cell is given by
 
-    \f[ L_\ell = \frac{hc}{\lambda_\ell} A_{ul} n_u V_\mathrm{cell}, \f]
+    \f[ L_{ul} = \frac{hc}{\lambda_{ul}} A_{ul} n_u V_\mathrm{cell}, \f]
 
-    where \f$\lambda_\ell\f$ is the transition wavelength, \f$u\f$ and \f$l\f$ are the indices of
-    the energy levels before and after the corresponding transition, and \f$V_\mathrm{cell}\f$ is
-    the volume of the cell. The SKIRT framework automatically adds a Gaussian line profile assuming
-    a thermal velocity corresponding to the kinetic temperature in the cell and the mass of a
-    molecule, in addition to any Doppler shifts caused by the bulk velocity in the cell.
+    where \f$\lambda_{ul}\f$ is the transition wavelength and \f$V_\mathrm{cell}\f$ is the volume
+    of the cell. The SKIRT framework automatically adds a Gaussian line profile assuming a thermal
+    velocity corresponding to the effective temperature in the cell and the mass of a molecule, in
+    addition to any Doppler shifts caused by the bulk velocity in the cell.
 
     <b>Absorption</b>
 
-    During primary emission, absorption cannot be calculated (and is taken to be zero) because the
-    level populations have not yet been established. During secondary emission, the absorption
-    opacity \f$k^\text{abs}(\lambda)\f$ as a function of wavelength \f$\lambda\f$ is given by
+    The absorption opacity \f$k^\text{abs}(\lambda)\f$ as a function of wavelength \f$\lambda\f$ is
+    given by
 
-    \f[ k^\text{abs}(\lambda) = \sum_\ell \, \frac{h c}{4\pi \lambda_\ell}(n_l\,B_{lu}-n_u\,B_{ul})
-    \,\phi_\ell(\lambda) \f]
+    \f[ k^\text{abs}(\lambda) = \sum_{ul} \, \frac{h c}{4\pi \lambda_{ul}}
+    (n_l\,B_{lu}-n_u\,B_{ul}) \,\phi_{ul}(\lambda) \f]
 
-    where the sum with index \f$\ell\f$ runs over all supported lines, \f$u\f$ and \f$l\f$ are the
-    indices of the energy levels before and after the corresponding transition, and
-    \f$\phi_\ell(\lambda)\f$ is the Gaussian profile of line \f$\ell\f$.
+    where the sum runs over all supported transitions, \f$u\f$ and \f$l\f$ are the indices of the
+    energy levels before and after the transition, and \f$\phi_{ul}(\lambda)\f$ is the Gaussian
+    profile of the line corresponding to the transition.
 
     The calculation explicitly includes the Gaussian line profile caused by thermal motion of the
     molecules in the local bulk velocity frame of the cell. Moreover, the absorption profiles of
     all supported lines are superposed on top of each other. In practice, the implementation
-    attempts to calculate just the terms that have a significant contribution at any given
-    wavelength.
+    includes just the terms that have a significant contribution at any given wavelength.
 
     */
 class MolecularLineGasMix : public EmittingGasMix
@@ -405,7 +403,7 @@ private:
     Array _center;                // the central emission wavelength for each radiative transition
 
     // collisional transitions -- the transitions (not the coefficients) are assumed to be identical for all partners
-    int _numColTrans{0};       // the number of collisional transitions -- index l
+    int _numColTrans{0};       // the number of collisional transitions -- index t
     vector<int> _indexUpCol;   // the upper energy level index for collisional transitions
     vector<int> _indexLowCol;  // the lower energy level index for collisional transitions
     struct ColPartner          // data structure holding information on a collisional partner
@@ -414,7 +412,7 @@ private:
         Array T;            // the temperature grid points
         vector<Array> Kul;  // the coefficient for each collisional transition and for each temperature
     };
-    int _numColPartners{0};          // the number of collisional interaction partners -- index q
+    int _numColPartners{0};          // the number of collisional interaction partners -- index c
     vector<ColPartner> _colPartner;  // the data for each collisional partner
 
     // the radiation field wavelength grid for this simulation

--- a/SKIRT/core/NonLTELineGasMix.cpp
+++ b/SKIRT/core/NonLTELineGasMix.cpp
@@ -35,7 +35,7 @@ void NonLTELineGasMix::setupSelfBefore()
             colNames = {"H2", "H", "H+", "e-", "He"};
             break;
         case Species::IonizedCarbon:
-            name = "C";
+            name = "C+";
             colNames = {"H2", "H", "e-"};
             break;
     }

--- a/SKIRT/core/NonLTELineGasMix.hpp
+++ b/SKIRT/core/NonLTELineGasMix.hpp
@@ -3,23 +3,23 @@
 ////       © Astronomical Observatory, Ghent University         ////
 ///////////////////////////////////////////////////////////////// */
 
-#ifndef MOLECULARLINEGASMIX_HPP
-#define MOLECULARLINEGASMIX_HPP
+#ifndef NONLTELINEGASMIX_H
+#define NONLTELINEGASMIX_H
 
 #include "EmittingGasMix.hpp"
 
-// comment this line to omit diagnostic code
+// comment or remove this line to omit diagnostic code
 #define DIAGNOSTIC 1
 
 ////////////////////////////////////////////////////////////////////
 
-/** The MolecularLineGasMix class describes the material properties related to selected rotational
-    transitions in selected molecules and atoms. For each supported species, the current
-    implementation includes a number of rotational energy levels (quantum number \f$J\f$) at the
-    base vibrational level (quantum number \f$v=0\f$) and supports the allowed transitions between
-    these levels. Vibrational energy levels and the corresponding rovibrational transitions may be
-    added later. The class properties allow configuring the species and the number of transitions
-    to be considered.
+/** The NonLTELineGasMix class describes the material properties related to selected transitions in
+    selected molecules and atoms. For each supported species, the current implementation includes a
+    number of rotational energy levels (quantum number \f$J\f$) at the base vibrational level
+    (quantum number \f$v=0\f$) for molecules and electronic energy levels and hyperfine split
+    levels for atoms, and supports the allowed transitions between these levels. Vibrational energy
+    levels and the corresponding rovibrational transitions may be added later. The class properties
+    allow configuring the species and the number of transitions to be considered.
 
     For each supported transition, the emission luminosity and absorption opacity in a given cell
     are determined from the gas properties defined in the input model and the local radiation field
@@ -52,14 +52,21 @@
     corresponding transition lines are at wavelengths from 65.7 to 2601 \f$\mu\mathrm{m}\f$. The
     single collisional interaction partner is molecular hydrogen.
 
-    - \c Atomic carbon (C): includes three rotational energy levels. The corresponding transition
-    lines are at wavelengths 230.3, 370.4 and 609.1 \f$\mu\mathrm{m}\f$. The collisional
-    interaction partners include molecular hydrogen, neutral atomic hydrogen, ionized atomic
-    hydrogen, electrons, and Helium.
+    - \c Atomic carbon (C): includes three hyperfine split levels at the electronic ground level of
+    3P. The corresponding transition lines are at wavelengths 230.3, 370.4 and 609.1
+    \f$\mu\mathrm{m}\f$. The collisional interaction partners include molecular hydrogen, neutral
+    atomic hydrogen, ionized atomic hydrogen, electrons, and Helium.
+
+    - \c Ionized carbon (C+): includes four electronic levels (2p, 4p, 2D, and 2S) and the
+    hyperfine split levels in the electronic levels of 2p and 4p. The corresponding fine-structure
+    transition lines for levels 2p and 4p are at wavelengths 157.74, 198.9, 353.57, 454.67
+    \f$\mu\mathrm{m}\f$. The electronic transition lines are at wavelengths from 0.1 to 0.23
+    \f$\mu\mathrm{m}\f$. The collisional interaction partners include molecular hydrogen, neutral
+    atomic hydrogen, and electrons.
 
     <b>Configuring the simulation</b>
 
-    Simulations that include gas represented by the MolecularLineGasMix often also include dust,
+    Simulations that include gas represented by the NonLTELineGasMix often also include dust,
     although this is not a requirement. In any case, the simulation must have one or more primary
     sources that trigger the molecular lines directly (e.g. the cosmic microwave background) or
     indirectly (e.g. by heating the dust and thus causing thermal dust emission), or both. The \em
@@ -98,7 +105,7 @@
     including the number density of the species under consideration, the number density of any
     relevant collisional partner species, the kinetic gas temperature, and the turbulence velocity.
     These values remain constant during the simulation. Most often, this information will be read
-    from an input file by associating the MolecularLineGasMix with a subclass of ImportedMedium.
+    from an input file by associating the NonLTELineGasMix with a subclass of ImportedMedium.
     For that medium component, the ski file attribute \em importTemperature <b>must</b> be set to
     'true', and \em importMetallicity and \em importVariableMixParams must be left at 'false'. The
     additional columns required by the material mix are automatically imported and are expected
@@ -107,9 +114,9 @@
     n_\mathrm{mol}, T_\mathrm{kin}, v_\mathrm{x}, v_\mathrm{y}, v_\mathrm{z}, n_\mathrm{col1} [,
     n_\mathrm{col1}, ...], v_\mathrm{turb}\f]
 
-    For basic testing purposes, the MolecularLineGasMix can also be associated with a geometric
+    For basic testing purposes, the NonLTELineGasMix can also be associated with a geometric
     medium component. The geometry then defines the spatial density distribution of the species
-    under consideration (i.e. \f$n_\mathrm{mol}\f$), and the MolecularLineGasMix configuration
+    under consideration (i.e. \f$n_\mathrm{mol}\f$), and the NonLTELineGasMix configuration
     properties specify a fixed default value for the other properties that will be used across the
     spatial domain. In this case, the number densities of the collisional partners are defined by a
     constant multiplier relative to \f$n_\mathrm{mol}\f$.
@@ -187,21 +194,22 @@
     includes just the terms that have a significant contribution at any given wavelength.
 
     */
-class MolecularLineGasMix : public EmittingGasMix
+class NonLTELineGasMix : public EmittingGasMix
 {
     /** The enumeration type indicating the molecular or atomic species represented by a given
-        MolecularLineGasMix instance. See the class header for more information. */
-    ENUM_DEF(Species, Test, Hydroxyl, Formyl, CarbonMonoxide, Carbon)
+        NonLTELineGasMix instance. See the class header for more information. */
+    ENUM_DEF(Species, Test, Hydroxyl, Formyl, CarbonMonoxide, AtomicCarbon, IonizedCarbon)
         ENUM_VAL(Species, Test, "Fictive two-level test molecule (TT)")
         ENUM_VAL(Species, Hydroxyl, "Hydroxyl radical (OH)")
         ENUM_VAL(Species, Formyl, "Formyl cation (HCO+)")
         ENUM_VAL(Species, CarbonMonoxide, "Carbon monoxide (CO)")
-        ENUM_VAL(Species, Carbon, "Atomic carbon (C)")
+        ENUM_VAL(Species, AtomicCarbon, "Atomic carbon (C)")
+        ENUM_VAL(Species, IonizedCarbon, "Ionized carbon (C+)")
     ENUM_END()
 
-    ITEM_CONCRETE(MolecularLineGasMix, EmittingGasMix,
+    ITEM_CONCRETE(NonLTELineGasMix, EmittingGasMix,
                   "A gas mix supporting rotational transitions in specific molecules and atoms")
-        ATTRIBUTE_TYPE_INSERT(MolecularLineGasMix, "CustomMediumState,DynamicState")
+        ATTRIBUTE_TYPE_INSERT(NonLTELineGasMix, "CustomMediumState,DynamicState")
 
         PROPERTY_ENUM(species, Species, "the molecular or atomic species being represented")
         ATTRIBUTE_DEFAULT_VALUE(species, "CarbonMonoxide")
@@ -404,7 +412,7 @@ private:
     // (only the energy levels and transition actually used are stored in the data members)
 
     // mass
-    double _mass{0.};  // molecular weight multiplied by proton mass
+    double _mass{0.};  // particle mass for the species under consideration
 
     // energy levels
     int _numLevels{0};       // the number of energy levels -- index p

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -544,7 +544,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<XRayAtomicGasMix>();
     ItemRegistry::add<EmittingGasMix>();
     ItemRegistry::add<SpinFlipHydrogenGasMix>();
-    //ItemRegistry::add<MolecularLineGasMix>();
+    ItemRegistry::add<MolecularLineGasMix>();
     ItemRegistry::add<TrivialGasMix>();
 
     // material mix families

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -163,13 +163,13 @@
 #include "MinSilicateGrainComposition.hpp"
 #include "ModifiedLogNormalGrainSizeDistribution.hpp"
 #include "ModifiedPowerLawGrainSizeDistribution.hpp"
-#include "MolecularLineGasMix.hpp"
 #include "MollweideProjection.hpp"
 #include "MonteCarloSimulation.hpp"
 #include "MultiGaussianExpansionGeometry.hpp"
 #include "NestedLogWavelengthGrid.hpp"
 #include "NetzerAngularDistribution.hpp"
 #include "NoPolarizationProfile.hpp"
+#include "NonLTELineGasMix.hpp"
 #include "NumberColumnMaterialNormalization.hpp"
 #include "NumberMaterialNormalization.hpp"
 #include "OffsetGeometryDecorator.hpp"
@@ -544,7 +544,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<XRayAtomicGasMix>();
     ItemRegistry::add<EmittingGasMix>();
     ItemRegistry::add<SpinFlipHydrogenGasMix>();
-    ItemRegistry::add<MolecularLineGasMix>();
+    ItemRegistry::add<NonLTELineGasMix>();
     ItemRegistry::add<TrivialGasMix>();
 
     // material mix families

--- a/SKIRT/core/SkirtUnitDef.cpp
+++ b/SKIRT/core/SkirtUnitDef.cpp
@@ -11,17 +11,18 @@
 SkirtUnitDef::SkirtUnitDef()
 {
     // get relevant constants in local variables
-    double k = Constants::k();
-    double c = Constants::c();
-    double hc = Constants::h() * Constants::c();
-    double pc = Constants::pc();
-    double AU = Constants::AU();
-    double Qel = Constants::Qelectron();
-    double Msun = Constants::Msun();
-    double Lsun = Constants::Lsun();
-    double year = Constants::year();
-    double arcsec = M_PI / (180. * 3600.);
-    double arcsec2 = arcsec * arcsec;
+    constexpr double k = Constants::k();
+    constexpr double c = Constants::c();
+    constexpr double hc = Constants::h() * Constants::c();
+    constexpr double pc = Constants::pc();
+    constexpr double AU = Constants::AU();
+    constexpr double Qel = Constants::Qelectron();
+    constexpr double Msun = Constants::Msun();
+    constexpr double amu = Constants::amu();
+    constexpr double Lsun = Constants::Lsun();
+    constexpr double year = Constants::year();
+    constexpr double arcsec = M_PI / (180. * 3600.);
+    constexpr double arcsec2 = arcsec * arcsec;
 
     // *** add units for each physical quantity
 
@@ -146,6 +147,7 @@ SkirtUnitDef::SkirtUnitDef()
     addUnit("mass", "kg", 1.);
     addUnit("mass", "g", 1e-3);
     addUnit("mass", "Msun", Msun);
+    addUnit("mass", "amu", amu);
 
     // bulk mass
     addUnit("bulkmass", "kg", 1.);

--- a/SKIRT/core/SpatialGrid.cpp
+++ b/SKIRT/core/SpatialGrid.cpp
@@ -18,13 +18,6 @@ void SpatialGrid::setupSelfBefore()
 
 //////////////////////////////////////////////////////////////////////
 
-double SpatialGrid::diagonal(int m) const
-{
-    return cbrt(3. * volume(m));
-}
-
-//////////////////////////////////////////////////////////////////////
-
 void SpatialGrid::writeGridPlotFiles(const SimulationItem* probe) const
 {
     // For the xy plane (always)

--- a/SKIRT/core/SpatialGrid.hpp
+++ b/SKIRT/core/SpatialGrid.hpp
@@ -47,12 +47,10 @@ public:
     /** This function returns the volume of the cell with index \f$m\f$. */
     virtual double volume(int m) const = 0;
 
-    /** This function returns the actual or effective diagonal of the cell with index \f$m\f$. The
-        default implementation in this class returns \f$(3V)^(1/3)\f$ where \f$V\f$ is the volume
-        of the cell. For a cube, this returns the actual diagonal; for any other form it returns
-        some approximate, "effective" diagonal. Grids that have cuboidal cells should override this
-        function to return the actual diagional for each cell. */
-    virtual double diagonal(int m) const;
+    /** This function returns the actual or approximate diagonal of the cell with index \f$m\f$.
+        For cuboidal cells, the function returns the actual diagonal. For other geometric forms, it
+        returns some approximate diagonal. */
+    virtual double diagonal(int m) const = 0;
 
     /** This function returns the index \f$m\f$ of the cell that contains the position
         \f${\bf{r}}\f$. */

--- a/SKIRT/core/Sphere1DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.cpp
@@ -54,6 +54,15 @@ double Sphere1DSpatialGrid::volume(int m) const
 
 //////////////////////////////////////////////////////////////////////
 
+double Sphere1DSpatialGrid::diagonal(int m) const
+{
+    int i = m;
+    if (i < 0 || i >= _Nr) return 0.;
+    return _rv[i + 1] - _rv[i];
+}
+
+//////////////////////////////////////////////////////////////////////
+
 int Sphere1DSpatialGrid::cellIndex(Position bfr) const
 {
     return NR::locateFail(_rv, bfr.radius());

--- a/SKIRT/core/Sphere1DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.cpp
@@ -74,7 +74,9 @@ Position Sphere1DSpatialGrid::randomPositionInCell(int m) const
 {
     int i = m;
     Direction bfk = random()->direction();
-    double r = _rv[i] + (_rv[i + 1] - _rv[i]) * random()->uniform();
+    double r = cbrt(_rv[i] * _rv[i] * _rv[i]
+                    + (_rv[i + 1] - _rv[i]) * (_rv[i + 1] * _rv[i + 1] + _rv[i + 1] * _rv[i] + _rv[i] * _rv[i])
+                          * random()->uniform());
     return Position(r, bfk);
 }
 

--- a/SKIRT/core/Sphere1DSpatialGrid.hpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.hpp
@@ -54,6 +54,11 @@ public:
         and \f$r_{i+1}\f$ the inner and outer radius of the shell respectively. */
     double volume(int m) const override;
 
+    /** This function returns the "diagonal" of the cell with index \f$m\f$. For 1D spherical
+        grids, it simply returns the cell width, i.e. the difference between the outer and inner
+        cell radius. */
+    double diagonal(int m) const override;
+
     /** This function returns the number of the cell that contains the position \f${\bf{r}}\f$. It
         just determines the radial bin index and returns that number. */
     int cellIndex(Position bfr) const override;

--- a/SKIRT/core/Sphere1DSpatialGrid.hpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.hpp
@@ -66,9 +66,10 @@ public:
 
     /** This function returns a random location from the cell with index \f$m\f$. For a spherical
         grid, cell index \f$m\f$ corresponds to the radial bin with lower border index \f$i=m\f$,
-        and a random radius is determined using \f[ r = r_i + {\cal{X}}\,(r_{i+1}-r_i) \f] with
-        \f${\cal{X}}\f$ a random deviate. This random radius is combined with a random position on
-        the unit sphere to generate a random position from the cell. */
+        and a random radius is determined using \f[ r = \left( r_i^3 + {\cal{X}}
+        \,(r_{i+1}^3-r_i^3) \right)^{1/3} \f] with \f${\cal{X}}\f$ a random deviate. This random
+        radius is combined with a random position on the unit sphere to generate a random position
+        from the cell. */
     Position randomPositionInCell(int m) const override;
 
     /** This function creates and hands over ownership of a path segment generator (an instance of

--- a/SKIRT/core/Sphere2DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere2DSpatialGrid.cpp
@@ -99,6 +99,18 @@ double Sphere2DSpatialGrid::volume(int m) const
 
 //////////////////////////////////////////////////////////////////////
 
+double Sphere2DSpatialGrid::diagonal(int m) const
+{
+    int i, k;
+    invertIndex(m, i, k);
+    if (i < 0 || i >= _Nr || k < 0 || k >= _Ntheta) return 0.;
+    Position p1(_rv[i + 1], _thetav[k + 1], 0., Position::CoordinateSystem::SPHERICAL);
+    Position p0(_rv[i], _thetav[k], 0., Position::CoordinateSystem::SPHERICAL);
+    return (p1 - p0).norm();
+}
+
+//////////////////////////////////////////////////////////////////////
+
 int Sphere2DSpatialGrid::cellIndex(Position bfr) const
 {
     double r, theta, phi;

--- a/SKIRT/core/Sphere2DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere2DSpatialGrid.cpp
@@ -127,10 +127,10 @@ Position Sphere2DSpatialGrid::randomPositionInCell(int m) const
 {
     int i, k;
     invertIndex(m, i, k);
-    double ris = _rv[i] * _rv[i];
-    double ri1s = _rv[i + 1] * _rv[i + 1];
-    double r = sqrt(ris + (ri1s - ris) * random()->uniform());
-    double theta = _thetav[k] + (_thetav[k + 1] - _thetav[k]) * random()->uniform();
+    double r = cbrt(_rv[i] * _rv[i] * _rv[i]
+                    + (_rv[i + 1] - _rv[i]) * (_rv[i + 1] * _rv[i + 1] + _rv[i + 1] * _rv[i] + _rv[i] * _rv[i])
+                          * random()->uniform());
+    double theta = acos(cos(_thetav[k]) + (cos(_thetav[k + 1]) - cos(_thetav[k])) * random()->uniform());
     double phi = 2.0 * M_PI * random()->uniform();
     return Position(r, theta, phi, Position::CoordinateSystem::SPHERICAL);
 }

--- a/SKIRT/core/Sphere2DSpatialGrid.hpp
+++ b/SKIRT/core/Sphere2DSpatialGrid.hpp
@@ -72,9 +72,9 @@ public:
         the function first determines the radial and angular bin indices \f$i\f$ and \f$k\f$ that
         correspond to the cell index \f$m\f$. Then a random radius \f$r\f$, a random inclination
         \f$\theta\f$, and a random azimuth \f$\phi\f$ are determined using \f[ \begin{split} r &=
-        \left( r_i^2 + {\cal{X}}_1\,(r_{i+1}^2-r_i^2) \right)^{1/2} \\ \theta &= \theta_k +
-        {\cal{X}}_2\, (\theta_{k+1}-\theta_k) \\ \phi &= 2\pi\,{\cal{X}}_3, \end{split} \f] with
-        \f${\cal{X}}_1\f$, \f${\cal{X}}_2\f$ and \f${\cal{X}}_3\f$ three uniform deviates. */
+        \left( r_i^3 + {\cal{X}}_1\,(r_{i+1}^3-r_i^3) \right)^{1/3} \\ \cos\theta &= \cos\theta_k +
+        {\cal{X}}_2\, (\cos\theta_{k+1}-\cos\theta_k) \\ \phi &= 2\pi\,{\cal{X}}_3, \end{split} \f]
+        with \f${\cal{X}}_1\f$, \f${\cal{X}}_2\f$ and \f${\cal{X}}_3\f$ three uniform deviates. */
     Position randomPositionInCell(int m) const override;
 
     /** This function creates and hands over ownership of a path segment generator (an instance of

--- a/SKIRT/core/Sphere2DSpatialGrid.hpp
+++ b/SKIRT/core/Sphere2DSpatialGrid.hpp
@@ -56,6 +56,11 @@ public:
         \left(r_{i+1}^3-r_i^3\right) \left(\cos\theta_k-\cos\theta_{k+1}\right). \f] */
     double volume(int m) const override;
 
+    /** This function returns the "diagonal" of the cell with index \f$m\f$. For 2D spherical
+        grids, it returns the distance between the outer/upper and inner/lower corners of the cell
+        in the meridional plane. */
+    double diagonal(int m) const override;
+
     /** This function returns the number of the cell that contains the position \f${\bf{r}}\f$. In
         this class, the function determines the radial and angular bin indices and calculates the
         correct cell index based on these two numbers. */

--- a/SKIRT/core/VoronoiMeshSpatialGrid.cpp
+++ b/SKIRT/core/VoronoiMeshSpatialGrid.cpp
@@ -160,6 +160,13 @@ double VoronoiMeshSpatialGrid::volume(int m) const
 
 //////////////////////////////////////////////////////////////////////
 
+double VoronoiMeshSpatialGrid::diagonal(int m) const
+{
+    return cbrt(3. * _mesh->volume(m));
+}
+
+//////////////////////////////////////////////////////////////////////
+
 int VoronoiMeshSpatialGrid::cellIndex(Position bfr) const
 {
     return _mesh->cellIndex(bfr);

--- a/SKIRT/core/VoronoiMeshSpatialGrid.hpp
+++ b/SKIRT/core/VoronoiMeshSpatialGrid.hpp
@@ -80,6 +80,11 @@ public:
     /** This function returns the volume of the cell with index \f$m\f$. */
     double volume(int m) const override;
 
+    /** This function returns the approximate diagonal of the cell with index \f$m\f$. For a
+        Voronoi grid, it returns \f$(3V)^(1/3)\f$ where \f$V\f$ is the volume of the cell. This
+        corresponds to the correct diagonal only for cubical cells. */
+    double diagonal(int m) const override;
+
     /** This function returns the index of the cell that contains the position \f${\bf{r}}\f$. */
     int cellIndex(Position bfr) const override;
 

--- a/SKIRT/resources/ExpectedResources.txt
+++ b/SKIRT/resources/ExpectedResources.txt
@@ -1,3 +1,3 @@
 Core 6
 BPASS 1
-AtomsMolecules 2
+AtomsMolecules 3


### PR DESCRIPTION
**Description**
This update adds the `NonLTELineGasMix` class, which describes the material properties related to selected transitions in    selected molecules and atoms. For each supported species, the current implementation includes a number of rotational energy levels (quantum number J) at the base vibrational level (quantum number v=0) for molecules and electronic energy levels and hyperfine split levels for atoms, and supports the allowed transitions between these levels. Vibrational energy levels and the corresponding rovibrational transitions may be added later. The class properties allow configuring the species and the number of transitions to be considered.

For each supported transition, the emission luminosity and absorption opacity in a given cell are determined from the gas properties defined in the input model and the local radiation field calculated by the simulation. The class performs an iterative, non-LTE calculation including the effects of collisional transitions (excitation and de-excitation with one or more types of interaction partners) and photonic transitions (spontaneous emission, absorption, and induced emission). This allows establishing the energy level distribution (population) for a wide range of material densities and radiation fields.

The current implementation supports a fictive test molecule (called TT for our purposes), the Hydroxyl radical (OH), the Formyl cation (HCO+), Carbon monoxide (CO), atomic carbon (C), and ionized carbon (C+), each with a selection of relevant energy levels and transitions.

For more information about configuring a simulation with this material mix, refer to the documentation of the `NonLTELineGasMix` class.

**Motivation**
This update allows combining non-LTE line transfer calculations with the full power of SKIRT, such as post-processing arbitrary imported 3D models that include both dust and gas.

**Tests**
With this new class, SKIRT properly reproduces the results provided by van Zadelhoff et al. 2002 for benchmark problems 1 and 2. These problems respectively employ the fictive test molecule (TT) and Formyl (HCO+).

**Important note**: the class _has not yet been tested_ for the other supported species. _**Use with extreme care!**_
