### PR TITLE
Extra flexibility for wavelength grids loaded from file or list

### DIFF
--- a/SKIRT/core/DisjointWavelengthGrid.cpp
+++ b/SKIRT/core/DisjointWavelengthGrid.cpp
@@ -227,6 +227,7 @@ void DisjointWavelengthGrid::setWavelengthSegments(const Array& bordcharv)
     {
         if (borderv[i + 1] <= borderv[i])
             throw FATALERROR("Wavelength bin borders must be in strictly monotonous order");
+        if (std::isinf(characv[i])) characv[i] = 0.;  // handle zero frequencies
         if (characv[i] != 0. && (characv[i] <= borderv[i] || characv[i] >= borderv[i + 1]))
             throw FATALERROR("Characteristic wavelength must be within bin borders");
     }

--- a/SKIRT/core/DisjointWavelengthGrid.cpp
+++ b/SKIRT/core/DisjointWavelengthGrid.cpp
@@ -210,7 +210,6 @@ void DisjointWavelengthGrid::setWavelengthSegments(const Array& bordcharv)
         if (i == n) break;
         characv.push_back(bordcharv[i++]);
     }
-    characv.push_back(0.);  //add the "characteristic wavelength" for the final segment outside the grid
 
     // reverse the lists if required
     if (bordcharv[0] > bordcharv[n - 1])
@@ -218,6 +217,9 @@ void DisjointWavelengthGrid::setWavelengthSegments(const Array& bordcharv)
         std::reverse(borderv.begin(), borderv.end());
         std::reverse(characv.begin(), characv.end());
     }
+
+    // add the "characteristic wavelength" for the final segment outside the grid
+    characv.push_back(0.);
 
     // verify the ordering
     n = borderv.size() - 1;

--- a/SKIRT/core/DisjointWavelengthGrid.hpp
+++ b/SKIRT/core/DisjointWavelengthGrid.hpp
@@ -107,6 +107,16 @@ protected:
         logarithmic scaling (geometric mean) depending on the value of the \em logScale flag. */
     void setWavelengthBorders(const Array& borderv, bool logScale);
 
+    /** This function initializes the wavelength grid from a list of interleaved bin border points
+        and corresponding characteristic wavelengths. (i.e., borders and characteristic wavelengths
+        alternate). The number of values must be uneven and at least three. The list must be in
+        strictly increasing or decreasing order, which means duplicates are not allowed, except
+        that a zero characteristic wavelength indicates a segment that is not part of the grid,
+        i.e. that lies between two non-adjacent bins. In other words, this option allows to (1)
+        arbitrarily place characteristic wavelengths within each bin and (2) to specify
+        intermediate wavelength ranges that are not covered by any bin. */
+    void setWavelengthSegments(const Array& bordcharv);
+
     /** This function initializes the wavelength grid from a list of bin border points and a
         corresponding list of characteristic wavelengths. A zero characteristic wavelength
         indicates a segment that is not part of the grid, i.e. that lies between two non-adjacent

--- a/SKIRT/core/FileBorderWavelengthGrid.cpp
+++ b/SKIRT/core/FileBorderWavelengthGrid.cpp
@@ -22,9 +22,9 @@ void FileBorderWavelengthGrid::setupSelfBefore()
     // set the wavelength grid
     switch (_characteristic)
     {
-        case Characteristic::Linear: setWavelengthBorders(wavelengths, false);
-        case Characteristic::Logarithmic: setWavelengthBorders(wavelengths, true);
-        case Characteristic::Specified: setWavelengthSegments(wavelengths);
+        case Characteristic::Linear: setWavelengthBorders(wavelengths, false); break;
+        case Characteristic::Logarithmic: setWavelengthBorders(wavelengths, true); break;
+        case Characteristic::Specified: setWavelengthSegments(wavelengths); break;
     }
 }
 

--- a/SKIRT/core/FileBorderWavelengthGrid.cpp
+++ b/SKIRT/core/FileBorderWavelengthGrid.cpp
@@ -20,7 +20,12 @@ void FileBorderWavelengthGrid::setupSelfBefore()
     infile.close();
 
     // set the wavelength grid
-    setWavelengthBorders(wavelengths, _log);
+    switch (_characteristic)
+    {
+        case Characteristic::Linear: setWavelengthBorders(wavelengths, false);
+        case Characteristic::Logarithmic: setWavelengthBorders(wavelengths, true);
+        case Characteristic::Specified: setWavelengthSegments(wavelengths);
+    }
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/FileBorderWavelengthGrid.hpp
+++ b/SKIRT/core/FileBorderWavelengthGrid.hpp
@@ -12,25 +12,44 @@
 
 /** FileBorderWavelengthGrid is a subclass of the DisjointWavelengthGrid class representing
     wavelength grids loaded from an input file. The floating point numbers in the first column of
-    the text file specify the borders of the wavelength grid bins. The default unit is micron, but
-    this can be overridden by a column header (see TextInFile). Any additional columns in the file
-    are ignored. The order of the wavelengths in the file is not important; they will be sorted
-    anyway.
+    the text file specify the borders and possibly the characteristic wavelengths of the wavelength
+    grid bins. The default unit is micron, but this can be overridden by a column header (see
+    TextInFile). Any additional columns in the file are ignored.
 
-    The wavelengths loaded from the file represent the borders of the wavelength grid bins; there
-    must be at least two borders in the file. The characteristic wavelength for each bin is derived
-    automatically in linear or logarithmic space depending on the value of the \em log flag. For
-    more details, refer to the DisjointWavelengthGrid::setWavelengthBorder() function. */
+    The precise behavior is governed by the value of the \em characteristic configuration property.
+    If the value is \c Linear or \c Logarithmic, the wavelengths loaded from the file represent the
+    borders of the wavelength grid bins. The order of the wavelengths in the file is not important;
+    they will be sorted anyway. There must be at least two strictly positive wavelength values in
+    the file, and duplicates are not allowed. The characteristic wavelength for each bin is derived
+    automatically by linear or logarithmic interpolation depending on the value of \em
+    characteristic.
+
+    If the value of \em characteristic is \c Specified, the characteristic wavelengths for each bin
+    are included in the wavelength list loaded from the file, interleaved with the border
+    wavelengths (i.e., borders and characteristic wavelengths alternate). The number of values must
+    be uneven and at least three. The list must be in strictly increasing or decreasing order,
+    which means duplicates are not allowed, except that a zero characteristic wavelength indicates
+    a segment that is not part of the grid, i.e. that lies between two non-adjacent bins. In other
+    words, this option allows to (1) arbitrarily place characteristic wavelengths within each bin
+    and (2) to specify intermediate wavelength ranges that are not covered by any bin. */
 class FileBorderWavelengthGrid : public DisjointWavelengthGrid
 {
+    /** The enumeration type indicating how to determine the characteristic wavelength for each
+        bin. See the class header for more information. */
+    ENUM_DEF(Characteristic, Linear, Logarithmic, Specified)
+        ENUM_VAL(Characteristic, Linear, "using linear interpolation")
+        ENUM_VAL(Characteristic, Logarithmic, "using logarithmic interpolation")
+        ENUM_VAL(Characteristic, Specified, "specified in the imported wavelength list")
+    ENUM_END()
+
     ITEM_CONCRETE(FileBorderWavelengthGrid, DisjointWavelengthGrid,
                   "a wavelength grid loaded from a text file listing bin borders")
         ATTRIBUTE_TYPE_DISPLAYED_IF(FileBorderWavelengthGrid, "Level2")
 
         PROPERTY_STRING(filename, "the name of the file with the wavelength bin borders")
 
-        PROPERTY_BOOL(log, "use logarithmic scale")
-        ATTRIBUTE_DEFAULT_VALUE(log, "true")
+        PROPERTY_ENUM(characteristic, Characteristic, "determine the characteristic wavelength for each bin")
+        ATTRIBUTE_DEFAULT_VALUE(characteristic, "Logarithmic")
 
     ITEM_END()
 

--- a/SKIRT/core/ListBorderWavelengthGrid.cpp
+++ b/SKIRT/core/ListBorderWavelengthGrid.cpp
@@ -16,9 +16,9 @@ void ListBorderWavelengthGrid::setupSelfBefore()
     Array waves = NR::array(_wavelengths);
     switch (_characteristic)
     {
-        case Characteristic::Linear: setWavelengthBorders(waves, false);
-        case Characteristic::Logarithmic: setWavelengthBorders(waves, true);
-        case Characteristic::Specified: setWavelengthSegments(waves);
+        case Characteristic::Linear: setWavelengthBorders(waves, false); break;
+        case Characteristic::Logarithmic: setWavelengthBorders(waves, true); break;
+        case Characteristic::Specified: setWavelengthSegments(waves); break;
     }
 }
 

--- a/SKIRT/core/ListBorderWavelengthGrid.cpp
+++ b/SKIRT/core/ListBorderWavelengthGrid.cpp
@@ -13,7 +13,13 @@ void ListBorderWavelengthGrid::setupSelfBefore()
     DisjointWavelengthGrid::setupSelfBefore();
 
     // set the wavelength grid
-    setWavelengthBorders(NR::array(_wavelengths), _log);
+    Array waves = NR::array(_wavelengths);
+    switch (_characteristic)
+    {
+        case Characteristic::Linear: setWavelengthBorders(waves, false);
+        case Characteristic::Logarithmic: setWavelengthBorders(waves, true);
+        case Characteristic::Specified: setWavelengthSegments(waves);
+    }
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ListBorderWavelengthGrid.hpp
+++ b/SKIRT/core/ListBorderWavelengthGrid.hpp
@@ -13,15 +13,34 @@
 /** ListBorderWavelengthGrid is a subclass of the DisjointWavelengthGrid class that allows an
     arbitrary wavelength grid to be fully specified inside the configuration file (i.e. without
     referring to an input file). It is intended for use in cases where there are just a few
-    wavelengths, but nothing keeps the user from specifying a long list. The order of the specified
-    wavelengths is not important; they will be sorted anyway.
+    wavelengths, but nothing keeps the user from specifying a long list.
 
-    The wavelengths specified in the list represent the borders of the wavelength grid bins; there
-    must be at least two borders in the list. The characteristic wavelength for each bin is derived
-    automatically in linear or logarithmic space depending on the value of the \em log flag. For
-    more details, refer to the DisjointWavelengthGrid::setWavelengthBorder() function. */
+    The precise behavior is governed by the value of the \em characteristic configuration property.
+    If the value is \c Linear or \c Logarithmic, the wavelengths in the list represent the borders
+    of the wavelength grid bins. The order of the wavelengths in the list is not important; they
+    will be sorted anyway. There must be at least two strictly positive wavelength values in the
+    list, and duplicates are not allowed. The characteristic wavelength for each bin is derived
+    automatically by linear or logarithmic interpolation depending on the value of \em
+    characteristic.
+
+    If the value of \em characteristic is \c Specified, the characteristic wavelengths for each bin
+    are included in the wavelength list, interleaved with the border wavelengths (i.e., borders and
+    characteristic wavelengths alternate). The number of values must be uneven and at least three.
+    The list must be in strictly increasing or decreasing order, which means duplicates are not
+    allowed, except that a zero characteristic wavelength indicates a segment that is not part of
+    the grid, i.e. that lies between two non-adjacent bins. In other words, this option allows to
+    (1) arbitrarily place characteristic wavelengths within each bin and (2) to specify
+    intermediate wavelength ranges that are not covered by any bin. */
 class ListBorderWavelengthGrid : public DisjointWavelengthGrid
 {
+    /** The enumeration type indicating how to determine the characteristic wavelength for each
+        bin. See the class header for more information. */
+    ENUM_DEF(Characteristic, Linear, Logarithmic, Specified)
+        ENUM_VAL(Characteristic, Linear, "using linear interpolation")
+        ENUM_VAL(Characteristic, Logarithmic, "using logarithmic interpolation")
+        ENUM_VAL(Characteristic, Specified, "specified in the configured wavelength list")
+    ENUM_END()
+
     ITEM_CONCRETE(ListBorderWavelengthGrid, DisjointWavelengthGrid,
                   "a wavelength grid configured as a list of bin borders")
         ATTRIBUTE_TYPE_DISPLAYED_IF(ListBorderWavelengthGrid, "Level2")
@@ -31,8 +50,8 @@ class ListBorderWavelengthGrid : public DisjointWavelengthGrid
         ATTRIBUTE_MIN_VALUE(wavelengths, "1 pm")
         ATTRIBUTE_MAX_VALUE(wavelengths, "1 m")
 
-        PROPERTY_BOOL(log, "use logarithmic scale")
-        ATTRIBUTE_DEFAULT_VALUE(log, "true")
+        PROPERTY_ENUM(characteristic, Characteristic, "determine the characteristic wavelength for each bin")
+        ATTRIBUTE_DEFAULT_VALUE(characteristic, "Logarithmic")
 
     ITEM_END()
 

--- a/SKIRT/core/ListBorderWavelengthGrid.hpp
+++ b/SKIRT/core/ListBorderWavelengthGrid.hpp
@@ -47,7 +47,7 @@ class ListBorderWavelengthGrid : public DisjointWavelengthGrid
 
         PROPERTY_DOUBLE_LIST(wavelengths, "the wavelength bin borders")
         ATTRIBUTE_QUANTITY(wavelengths, "wavelength")
-        ATTRIBUTE_MIN_VALUE(wavelengths, "1 pm")
+        ATTRIBUTE_MIN_VALUE(wavelengths, "0 pm")
         ATTRIBUTE_MAX_VALUE(wavelengths, "1 m")
 
         PROPERTY_ENUM(characteristic, Characteristic, "determine the characteristic wavelength for each bin")


### PR DESCRIPTION
**Description**
This update provides the `FileBorderWavelengthGrid` and `ListBorderWavelengthGrid` classes with the option to 
include the characteristic wavelength for each bin in the wavelength list, interleaved with the border wavelengths (i.e., borders and characteristic wavelengths alternate). A zero characteristic wavelength indicates a segment that is not part of the grid, i.e. that lies between two non-adjacent bins. In other words, this option allows to arbitrarily place characteristic wavelengths within each bin and to specify intermediate wavelength ranges that are not covered by any bin.

**Motivation**
Simulations that include line emission often need wavelength grids with a sequence of bins for each line (and no bins in between). It is sometimes more convenient to generate such a grid from a script than to compose it in the ski file.

**Change to ski file**
Ski files using the `FileBorderWavelengthGrid` or `ListBorderWavelengthGrid` class must be adjusted: the Boolean _log_ property must be replaced by the _characteristic_ enumeration property with three possible values: `Linear`, `Logarithmic` (both indicating that the characteristic wavelengths are calculated automatically) and `Specified` (indicating that the characteristic wavelengths are explicitly included in the specified file or list. The ski file update procedure in PTS is being augmented with this capability, but in many cases it is easier to make the change manually.

**Tests**
After upgrading the ski files, all existing functional tests still run, and new ones were added.

