### PR TITLE
Add some expert options to NonLTELineGasMix

### DIFF
--- a/SKIRT/core/NonLTELineGasMix.hpp
+++ b/SKIRT/core/NonLTELineGasMix.hpp
@@ -220,6 +220,11 @@ class NonLTELineGasMix : public EmittingGasMix
         ATTRIBUTE_DEFAULT_VALUE(numEnergyLevels, "999")
         ATTRIBUTE_DISPLAYED_IF(numEnergyLevels, "Level2")
 
+#ifdef DIAGNOSTIC
+        PROPERTY_STRING(levelPopsFilename, "the name of the file with initial relative level populations")
+        ATTRIBUTE_REQUIRED_IF(levelPopsFilename, "false")
+#endif
+
         PROPERTY_DOUBLE(defaultTemperature, "the default temperature of the gas")
         ATTRIBUTE_QUANTITY(defaultTemperature, "temperature")
         ATTRIBUTE_MIN_VALUE(defaultTemperature, "[0")
@@ -445,6 +450,10 @@ private:
     int _numWavelengths{0};  // the number of wavelength bins -- index ell
     Array _lambdav;          // characteristic wavelengths
     Array _dlambdav;         // wavelength bin widths
+
+#ifdef DIAGNOSTIC
+    vector<Array> _levelPops;  // initial relative level populations for each cell -- indices m, p
+#endif
 
 private:
     // Data members indicating custom variable indices; initialized in specificStateVariableInfo()

--- a/SKIRT/core/NonLTELineGasMix.hpp
+++ b/SKIRT/core/NonLTELineGasMix.hpp
@@ -8,9 +8,6 @@
 
 #include "EmittingGasMix.hpp"
 
-// comment or remove this line to omit diagnostic code
-#define DIAGNOSTIC 1
-
 ////////////////////////////////////////////////////////////////////
 
 /** The NonLTELineGasMix class describes the material properties related to selected transitions in
@@ -193,6 +190,49 @@
     all supported lines are superposed on top of each other. In practice, the implementation
     includes just the terms that have a significant contribution at any given wavelength.
 
+    <b>Storing mean intensities</b>
+
+    As discussed above, the mean radiation field intensity \f$J_{\lambda,ul}\f$ is determined for
+    each transition line as a prerequisite for calculating the level populations in a given cell.
+    These values are obtained by integrating the radiation field, as discretized on the
+    simulation's radiation field wavelength grid, over the appropriate Gaussian line profile. There
+    is no need to keep these values around for the regular operation of the code. However, they can
+    form a relevant diagnostic to assess the level of Monte Carlo noise in the simulation or to
+    evaluate iterative convergence. Therefore, if the \em storeMeanIntensities flag is turned on,
+    the mean radiation field intensity at each transition line is stored in the medium state for
+    each cell, so that the information can be probed using the CustomStateProbe class.
+
+    <b>Providing initial level populations</b>
+
+    By default, the level populations are initialized in each cell using a Boltzmann distribution
+    as a function of temperature (i.e., assuming LTE conditions). This may be far from the correct
+    non-LTE levels, possibly requiring many iterations to obtain a properly converged solution. It
+    might therefore be meaningful to provide customized initial conditions. If the \em
+    initialLevelPopsFilename string is nonempty, it specifies the name of a text column file with a
+    column for each energy level and a row for each spatial cell in the simulation. Specifically,
+    the first column lists a cell index that is ignored, and remaining columns list the relative
+    population for each energy level in units of number density (the values are scaled to the total
+    number density in the cell, so the specific units don't really matter). The rows must exactly
+    match the number and ordering of the cells in the simulation's spatial grid (see below).
+
+    This input format is designed such that the text file can easily be produced by a
+    CustomStateProbe instance in a previous simulation. For example, assuming 9 energy levels, one
+    could configure a probe as follows:
+
+        <CustomStateProbe probeName="populations" indices="2-10" probeAfter="Run">
+            <form type="Form">
+                <PerCellForm/>
+            </form>
+        </CustomStateProbe>
+
+    The requirement to have an identical spatial grid in both simulations is easily met for 1D, 2D
+    and 3D grids with a regular mesh in each spatial direction. For octree and binary tree grids
+    the precise cell hierarchy is usually determined based on random samples of the medium density
+    distribution, resulting in a slightly different structure for each run. To work around this
+    problem, one needs to output the topology of the hierarchical grid in the first simulation
+    using a TreeSpatialGridTopologyProbe instance, and load this topology in subsequent simulations
+    using a FileTreeSpatialGrid instance.
+
     */
 class NonLTELineGasMix : public EmittingGasMix
 {
@@ -219,11 +259,6 @@ class NonLTELineGasMix : public EmittingGasMix
         ATTRIBUTE_MAX_VALUE(numEnergyLevels, "999")
         ATTRIBUTE_DEFAULT_VALUE(numEnergyLevels, "999")
         ATTRIBUTE_DISPLAYED_IF(numEnergyLevels, "Level2")
-
-#ifdef DIAGNOSTIC
-        PROPERTY_STRING(levelPopsFilename, "the name of the file with initial relative level populations")
-        ATTRIBUTE_REQUIRED_IF(levelPopsFilename, "false")
-#endif
 
         PROPERTY_DOUBLE(defaultTemperature, "the default temperature of the gas")
         ATTRIBUTE_QUANTITY(defaultTemperature, "temperature")
@@ -259,6 +294,14 @@ class NonLTELineGasMix : public EmittingGasMix
         ATTRIBUTE_MAX_VALUE(maxFractionNotConvergedCells, "1]")
         ATTRIBUTE_DEFAULT_VALUE(maxFractionNotConvergedCells, "0.001")
         ATTRIBUTE_DISPLAYED_IF(maxFractionNotConvergedCells, "Level2")
+
+        PROPERTY_BOOL(storeMeanIntensities, "store the mean radiation field intensity at each transition line")
+        ATTRIBUTE_DEFAULT_VALUE(storeMeanIntensities, "false")
+        ATTRIBUTE_DISPLAYED_IF(storeMeanIntensities, "Level3")
+
+        PROPERTY_STRING(initialLevelPopsFilename, "the name of the file with initial level populations")
+        ATTRIBUTE_REQUIRED_IF(initialLevelPopsFilename, "false")
+        ATTRIBUTE_DISPLAYED_IF(initialLevelPopsFilename, "Level3")
 
     ITEM_END()
 
@@ -451,18 +494,15 @@ private:
     Array _lambdav;          // characteristic wavelengths
     Array _dlambdav;         // wavelength bin widths
 
-#ifdef DIAGNOSTIC
-    vector<Array> _levelPops;  // initial relative level populations for each cell -- indices m, p
-#endif
+    // imported initial level populations (technical expert option)
+    vector<Array> _initLevelPops;  // initial level populations for each cell -- indices m, p
 
 private:
     // Data members indicating custom variable indices; initialized in specificStateVariableInfo()
     int _indexKineticTemperature{0};
     int _indexFirstColPartnerDensity{0};
     int _indexFirstLevelPopulation{0};
-#ifdef DIAGNOSTIC
     int _indexFirstMeanIntensity{0};
-#endif
 };
 
 ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
This update introduces two expert options to the `NonLTELineGasMix` class:
- optionally store the mean radiation field intensities in the medium state, so that this information can be probed. 
- allows the initial level populations to be loaded from a file that is typically produced by a probe in a previous simulation.

Use these options with care; see the documentation of the `NonLTELineGasMix` class.

**Motivation**
- The mean radiation field intensities can form a relevant diagnostic to assess the level of Monte Carlo noise in the simulation or to evaluate iterative convergence. Previously, these values were always stored; this new option by default avoids the corresponding memory usage but allows enabling the capability if needed.
- By default, the level populations are initialized in each cell using a Boltzmann distribution as a function of temperature (i.e., assuming LTE conditions). This may be far from the correct non-LTE levels, possibly requiring many iterations to obtain a properly converged solution. It might therefore be meaningful to provide customized initial conditions.  

**Tests**
Functional tests still work; note however that you'll need to add the _storeMeanIntensities_ option if you want to continue probing the mean radiation field intensities.
