### PR TITLE
Fix bug when using XRayAtomicGasMix outside of its wavelength range

### DIFF
--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -739,14 +739,18 @@ void MediumSystem::peelOffScattering(const ShortArray& wv, double lambda, Direct
     double I = 0., Q = 0., U = 0., V = 0.;
     for (int h = 0; h != _numMedia; ++h)
     {
-        double Ih = 0., Qh = 0., Uh = 0., Vh = 0.;
-        MaterialState mst(_state, m, h);
-        pp->setScatteringComponent(h);
-        mix(m, h)->peeloffScattering(Ih, Qh, Uh, Vh, lambda, bfkobs, bfky, &mst, pp);
-        I += Ih * wv[h];
-        Q += Qh * wv[h];
-        U += Uh * wv[h];
-        V += Vh * wv[h];
+        // skip media that don't scatter this photon packet
+        if (wv[h] > 0.)
+        {
+            double Ih = 0., Qh = 0., Uh = 0., Vh = 0.;
+            MaterialState mst(_state, m, h);
+            pp->setScatteringComponent(h);
+            mix(m, h)->peeloffScattering(Ih, Qh, Uh, Vh, lambda, bfkobs, bfky, &mst, pp);
+            I += Ih * wv[h];
+            Q += Qh * wv[h];
+            U += Uh * wv[h];
+            V += Vh * wv[h];
+        }
     }
 
     // pass the result to the peel-off photon packet

--- a/SKIRT/core/MonteCarloSimulation.cpp
+++ b/SKIRT/core/MonteCarloSimulation.cpp
@@ -778,20 +778,24 @@ void MonteCarloSimulation::peelOffScattering(PhotonPacket* pp, PhotonPacket* ppp
         int numMedia = wv.size();
         for (int h = 0; h != numMedia; ++h)
         {
-            for (Instrument* instr : _instrumentSystem->instruments())
+            // skip media that don't scatter this photon packet
+            if (wv[h] > 0.)
             {
-                if (!instr->isSameObserverAsPreceding())
+                for (Instrument* instr : _instrumentSystem->instruments())
                 {
-                    // get the direction towards the instrument and (for polarization only) its Y-axis orientation
-                    Direction bfkobs = instr->bfkobs(pp->position());
-                    Direction bfky = _config->hasPolarization() ? instr->bfky(pp->position()) : Direction();
+                    if (!instr->isSameObserverAsPreceding())
+                    {
+                        // get the direction towards the instrument and (for polarization only) its Y-axis orientation
+                        Direction bfkobs = instr->bfkobs(pp->position());
+                        Direction bfky = _config->hasPolarization() ? instr->bfky(pp->position()) : Direction();
 
-                    // calculate peel-off for the current component and launch the peel-off photon packet
-                    mediumSystem()->peelOffScattering(h, wv[h], lambda, bfkobs, bfky, pp, ppp);
+                        // calculate peel-off for the current component and launch the peel-off photon packet
+                        mediumSystem()->peelOffScattering(h, wv[h], lambda, bfkobs, bfky, pp, ppp);
+                    }
+
+                    // have the peel-off photon packet detected
+                    instr->detect(ppp);
                 }
-
-                // have the peel-off photon packet detected
-                instr->detect(ppp);
             }
         }
     }


### PR DESCRIPTION
**Description**
This update fixes a bug that caused a segmentation fault when using XRayAtomicGasMix outside of its wavelength range (e.g., above 500 keV) and in combination with other media. Specifically, the framework no longer calls the material mix scattering peel-off function if the scattering cross section of the material for the photon packet's wavelength is zero.

**Tests**
A functional test was added to reproduce this particular issue.
