### PR TITLE
Add diagnostic logging for MPI operations

### DIFF
--- a/SKIRT/core/SpatialGridWhenFormProbe.hpp
+++ b/SKIRT/core/SpatialGridWhenFormProbe.hpp
@@ -25,7 +25,7 @@ class SpatialGridWhenFormProbe : public SpatialGridFormProbe
 
     ITEM_ABSTRACT(SpatialGridWhenFormProbe, SpatialGridFormProbe, "a spatial grid when form probe")
 
-        ATTRIBUTE_SUB_PROPERTIES_HERE()
+        ATTRIBUTE_SUB_PROPERTIES_HERE(SpatialGridWhenFormProbe)
 
         PROPERTY_ENUM(probeAfter, ProbeAfter, "perform the probe after")
         ATTRIBUTE_DEFAULT_VALUE(probeAfter, "Setup")

--- a/SKIRT/core/SpecialtyWhenProbe.hpp
+++ b/SKIRT/core/SpecialtyWhenProbe.hpp
@@ -22,7 +22,7 @@ class SpecialtyWhenProbe : public SpecialtyProbe
 
     ITEM_ABSTRACT(SpecialtyWhenProbe, SpecialtyProbe, "a specialty when probe")
 
-        ATTRIBUTE_SUB_PROPERTIES_HERE()
+        ATTRIBUTE_SUB_PROPERTIES_HERE(SpecialtyWhenProbe)
 
         PROPERTY_ENUM(probeAfter, ProbeAfter, "perform the probe after")
         ATTRIBUTE_DEFAULT_VALUE(probeAfter, "Setup")

--- a/SKIRT/main/SkirtCommandLineHandler.cpp
+++ b/SKIRT/main/SkirtCommandLineHandler.cpp
@@ -361,6 +361,10 @@ void SkirtCommandLineHandler::doSimulation(size_t index)
         // log a warning about problems with the installed resource packs
         reportResourceIssues(simulation->log());
 
+        // setup verbose MPI logging if requested and meaningful
+        if (ProcessManager::isMultiProc() && _args.isPresent("-v") && !_args.isPresent("-e"))
+            ProcessManager::setLogger([log](string message) { log->info(message); });
+
         // run the simulation and catch and properly report any exceptions to the simulation log file
         try
         {
@@ -377,6 +381,9 @@ void SkirtCommandLineHandler::doSimulation(size_t index)
             log->error("Standard Library Exception: " + string(except.what()), false);
             throw except;
         }
+
+        // clear verbose MPI logging
+        ProcessManager::clearLogger();
 
         // if this is the only or first simulation in the run, report memory statistics in the simulation's log file
         if (_parallelSims == 1 && index == 0) reportPeakMemory(_args.isPresent("-v") ? simulation->log() : log);

--- a/SKIRT/main/SkirtCommandLineHandler.hpp
+++ b/SKIRT/main/SkirtCommandLineHandler.hpp
@@ -40,7 +40,9 @@ simulations in the ski files specified on the command line according to the foll
   written to a file in the output directory.
 
 - The -v option enables verbose logging for simulations running with multiple processes, causing each process to
-  create its own log file (rather than relying on the root process to log all relevant information).
+  create its own log file rather than relying on the root process to log all relevant information. The individual log
+  files then also include messages bracketing each MPI operation, facilitating the diagnose of issues related to
+  communication between the processes.
 
 - The -m option causes information on current memory usage to be included in each log message.
 

--- a/SKIRT/mpi/ProcessManager.cpp
+++ b/SKIRT/mpi/ProcessManager.cpp
@@ -163,10 +163,12 @@ void ProcessManager::serveChunkRequest(int rank, size_t firstIndex, size_t numIn
 #ifdef BUILD_WITH_MPI
     if (!isMultiProc() || !isRoot()) throwInvalidChunkInvocation();
 
-    if (_logger) _logger("MPI BEGIN: serve chunk request to process " + std::to_string(rank));
+    if (_logger)
+        _logger("MPI BEGIN: serve chunk " + std::to_string(firstIndex) + ", " + std::to_string(numIndices)
+                + " to process " + std::to_string(rank));
     std::array<size_t, 2> sendbuf{{firstIndex, numIndices}};
     MPI_Send(sendbuf.begin(), sendbuf.size(), MPI_UNSIGNED_LONG, rank, 1, MPI_COMM_WORLD);
-    if (_logger) _logger("MPI END: served chunk request");
+    if (_logger) _logger("MPI END: served chunk");
 #else
     (void)rank;
     (void)firstIndex;

--- a/SKIRT/mpi/ProcessManager.hpp
+++ b/SKIRT/mpi/ProcessManager.hpp
@@ -16,8 +16,10 @@
     class must be constructed just after program startup, and before the command-line arguments are
     used by other parts of the program. The latter is important because the MPI initialization
     functions called by the ProcessManager constructor may adjust the command-line arguments to
-    remove MPI specific options. The program should not use the exit() or abort() functions, but
-    rather let the main() function run to normal completion and return an exit code.
+    remove MPI specific options. The program should let the main() function run to normal
+    completion and return an exit code rather than calling the std::exit() function. In case of
+    abnormal termination, the program should call the ProcessManager::abort() function as opposed
+    to the std::abort() function.
 
     The functions of this class should be called only from the main thread of the program.
     Violation of this rule causes undefined behavior that may differ between MPI implementations.
@@ -58,6 +60,16 @@ public:
         process. If the MPI library is not present, or the program was invoked without MPI, or
         there is only one process, this function does nothing. */
     static void abort(int exitcode);
+
+    //======== Logging  ===========
+
+    /** This function sets the specified callback function as the usage logger, which is called
+        with diagnostic messages bracketing each MPI operation. Initially, the logger is cleared.
+        */
+    static void setLogger(std::function<void(string)> logger);
+
+    /** This function clears the usage logger so that it is no longer called. */
+    static void clearLogger();
 
     //======== Environment info  ===========
 


### PR DESCRIPTION
**Description**
After this update, if SKIRT runs with multiple processes and the -v command line option is specified, the log files for each individual process will include diagnostic messages bracketing all MPI operations. This should facilitate debugging problems with inter-process communication.

**Motivation**
Sometimes, a multi-process simulation hangs indefinitely, apparently at a point where MPI communication is happening or should happen. These diagnostic messages will hopefully help us understand what is going on when this happens.

