### PR TITLE
Add probe for line luminosity during secondary emission

### DIFF
--- a/SKIRT/core/ProbeFormBridge.hpp
+++ b/SKIRT/core/ProbeFormBridge.hpp
@@ -246,14 +246,24 @@ public:
                        ScalarValueInCell valueInCell, WeightInCell weightInCell);
 
     /** This function causes the form associated with this bridge to output a file for a vector
-        quantity according to the provided information. It should be called only from spatial grid
-        probes. Refer to the class header for more information on the arguments. */
+        quantity (which is always averaged along a path) according to the provided information. It
+        should be called only from spatial grid probes. Refer to the class header for more
+        information on the arguments. */
     void writeQuantity(string fileid, string quantity, string description, string projectedDescription,
                        VectorValueInCell valueInCell, WeightInCell weightInCell);
 
     /** This function causes the form associated with this bridge to output a file for a compound
-        quantity according to the provided information. It should be called only from spatial grid
-        probes. Refer to the class header for more information on the arguments. */
+        quantity that needs to be accumulated along a path according to the provided information.
+        It should be called only from spatial grid probes. Refer to the class header for more
+        information on the arguments. */
+    void writeQuantity(string fileid, string projectedFileid, string quantity, string projectedQuantity,
+                       string description, string projectedDescription, const Array& axis, string axisUnit,
+                       AddColumnDefinitions addColumnDefinitions, CompoundValueInCell valueInCell);
+
+    /** This function causes the form associated with this bridge to output a file for a compound
+        quantity that needs to be averaged along a path according to the provided information. It
+        should be called only from spatial grid probes. Refer to the class header for more
+        information on the arguments. */
     void writeQuantity(string fileid, string unit, string description, string projectedDescription, const Array& axis,
                        string axisUnit, AddColumnDefinitions addColumnDefinitions, CompoundValueInCell valueInCell,
                        WeightInCell weightInCell);
@@ -433,6 +443,7 @@ private:
         GridScalarAccumulated,
         GridScalarAveraged,
         GridVectorAveraged,
+        GridCompoundAccumulated,
         GridCompoundAveraged,
         InputScalar,
         InputVector,

--- a/SKIRT/core/SecondaryLineLuminosityProbe.cpp
+++ b/SKIRT/core/SecondaryLineLuminosityProbe.cpp
@@ -1,0 +1,85 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "SecondaryLineLuminosityProbe.hpp"
+#include "Configuration.hpp"
+#include "Indices.hpp"
+#include "MediumSystem.hpp"
+#include "ProbeFormBridge.hpp"
+#include "StringUtils.hpp"
+#include "TextOutFile.hpp"
+#include "Units.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+Probe::When SecondaryLineLuminosityProbe::when() const
+{
+    switch (probeAfter())
+    {
+        case ProbeAfter::Run: return When::Run;
+        case ProbeAfter::Secondary: return When::Secondary;
+    }
+    return When::Run;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void SecondaryLineLuminosityProbe::probe()
+{
+    if (find<Configuration>()->hasGasEmission())
+    {
+        // locate the medium system and units system
+        auto ms = find<MediumSystem>();
+        auto units = find<Units>();
+
+        // loop over medium components with line emission
+        for (int h : ms->gasMediumIndices())
+        {
+            auto mix = ms->mix(0, h);
+            if (mix->hasLineEmission())
+            {
+                // get the central wavelengths
+                const Array& centers = mix->lineEmissionCenters();
+
+                // construct the wavelength axis in output units and ordering
+                Array axis(centers.size());
+                int outell = 0;
+                for (int ell : Indices(centers, units->rwavelength()))
+                {
+                    axis[outell] = units->owavelength(centers[ell]);
+                    outell++;
+                }
+
+                // define the call-back function to add column definitions
+                auto addColumnDefinitions = [centers, units](TextOutFile& outfile) {
+                    for (int ell : Indices(centers, units->rwavelength()))
+                    {
+                        outfile.addColumn("L/V for line at "
+                                              + StringUtils::toString(units->owavelength(centers[ell]), 'g') + " "
+                                              + units->uwavelength(),
+                                          units->ubolluminosityvolumedensity());
+                    }
+                };
+
+                // define the call-back function to retrieve a compound luminosity value in output ordering
+                auto valueInCell = [ms, h, units](int m) {
+                    Array Lv = ms->lineEmissionSpectrum(m, h) / ms->grid()->volume(m);
+                    if (units->rwavelength()) std::reverse(begin(Lv), end(Lv));
+                    return Lv;
+                };
+
+                // construct a bridge and tell it to output the luminosity
+                ProbeFormBridge bridge(this, form());
+                string sh = std::to_string(h);
+                bridge.writeQuantity(sh + "_L", sh + "_S", "bolluminosityvolumedensity",
+                                     "bolluminositysurfacedensity", "line luminosity volume density",
+                                     "line luminosity surface density", axis, units->uwavelength(), addColumnDefinitions,
+                                     valueInCell);
+            }
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SecondaryLineLuminosityProbe.cpp
+++ b/SKIRT/core/SecondaryLineLuminosityProbe.cpp
@@ -73,10 +73,9 @@ void SecondaryLineLuminosityProbe::probe()
                 // construct a bridge and tell it to output the luminosity
                 ProbeFormBridge bridge(this, form());
                 string sh = std::to_string(h);
-                bridge.writeQuantity(sh + "_L", sh + "_S", "bolluminosityvolumedensity",
-                                     "bolluminositysurfacedensity", "line luminosity volume density",
-                                     "line luminosity surface density", axis, units->uwavelength(), addColumnDefinitions,
-                                     valueInCell);
+                bridge.writeQuantity(sh + "_L", sh + "_S", "bolluminosityvolumedensity", "bolluminositysurfacedensity",
+                                     "line luminosity volume density", "line luminosity surface density", axis,
+                                     units->uwavelength(), addColumnDefinitions, valueInCell);
             }
         }
     }

--- a/SKIRT/core/SecondaryLineLuminosityProbe.hpp
+++ b/SKIRT/core/SecondaryLineLuminosityProbe.hpp
@@ -1,0 +1,62 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef SECONDARYLINELUMINOSITYPROBE_HPP
+#define SECONDARYLINELUMINOSITYPROBE_HPP
+
+#include "SpatialGridFormProbe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** SecondaryLineLuminosityProbe probes the line luminosities of secondary sources as discretized
+    on the spatial grid of the simulation. It produces a separate output file for each medium
+    component with an associated material mix that supports secondary line emission.
+
+    For each relevant medium component, the probe outputs a compound quantity representing the
+    intrinsic bolometric, line-profile-integrated luminosities for each of the lines from which the
+    medium emits, ignoring any kinematic effects. These luminosities are listed with the
+    corresponding central line wavelengths, frequencies, or energies, depending on the \em
+    wavelengthOutputStyle configured for the simulation.
+
+    The probe can be used with any Form subclass. When associated with a form that samples the
+    luminosity in a spatial grid cell or at a set of positions, such as for a linear or planar cut,
+    the probe outputs a bolometric luminosity volume density (with SI units of W/m3). When
+    associated with a form that projects the luminosity along a path, the probe outputs a
+    bolometric luminosity surface (or column) density (with SI units of W/m2). */
+class SecondaryLineLuminosityProbe : public SpatialGridFormProbe
+{
+    /** The enumeration type indicating when probing occurs. */
+    ENUM_DEF(ProbeAfter, Run, Secondary)
+        ENUM_VAL(ProbeAfter, Run, "after the complete simulation run")
+        ENUM_VAL(ProbeAfter, Secondary, "after each iteration over secondary emission")
+    ENUM_END()
+
+    ITEM_CONCRETE(SecondaryLineLuminosityProbe, SpatialGridFormProbe,
+                  "internal spatial grid: secondary line luminosity")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(SecondaryLineLuminosityProbe, "Level2&SpatialGrid&GasEmission")
+
+        PROPERTY_ENUM(probeAfter, ProbeAfter, "perform the probe after")
+        ATTRIBUTE_DEFAULT_VALUE(probeAfter, "Run")
+        ATTRIBUTE_DISPLAYED_IF(probeAfter, "IterateSecondary")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function returns an enumeration indicating when probing for this probe should be
+        performed corresponding to the configured value of the \em probeAfter property. */
+    When when() const override;
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function performs probing. */
+    void probe() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -209,6 +209,7 @@
 #include "SEDInstrument.hpp"
 #include "SIUnits.hpp"
 #include "ScaledGaussianSmoothingKernel.hpp"
+#include "SecondaryLineLuminosityProbe.hpp"
 #include "SelectDustMixFamily.hpp"
 #include "SersicGeometry.hpp"
 #include "ShellGeometry.hpp"
@@ -660,6 +661,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<MagneticFieldProbe>();
     ItemRegistry::add<CustomStateProbe>();
     ItemRegistry::add<RadiationFieldProbe>();
+    ItemRegistry::add<SecondaryLineLuminosityProbe>();
     //   .. properties
     ItemRegistry::add<SpatialCellPropertiesProbe>();
     ItemRegistry::add<SpatialGridPlotProbe>();

--- a/SKIRT/core/SkirtUnitDef.cpp
+++ b/SKIRT/core/SkirtUnitDef.cpp
@@ -263,12 +263,24 @@ SkirtUnitDef::SkirtUnitDef()
     addUnit("bolluminosity", "erg/s", 1e-7);
     addUnit("bolluminosity", "Lsun", Lsun);
 
+    // bolometric luminosity volume density
+    addUnit("bolluminosityvolumedensity", "W/m3", 1.);
+    addUnit("bolluminosityvolumedensity", "erg/s/cm3", 0.1);
+    addUnit("bolluminosityvolumedensity", "Lsun/AU3", Lsun / pow(AU, 3));
+    addUnit("bolluminosityvolumedensity", "Lsun/pc3", Lsun / pow(pc, 3));
+
+    // bolometric luminosity surface density
+    addUnit("bolluminositysurfacedensity", "W/m2", 1.);
+    addUnit("bolluminositysurfacedensity", "erg/s/cm2", 0.001);
+    addUnit("bolluminositysurfacedensity", "Lsun/AU2", Lsun / pow(AU, 2));
+    addUnit("bolluminositysurfacedensity", "Lsun/pc2", Lsun / pow(pc, 2));
+
     // neutral monochromatic luminosity (lambda L_lambda = nu L_nu)
     addUnit("neutralmonluminosity", "W", 1.);
     addUnit("neutralmonluminosity", "erg/s", 1e-7);
     addUnit("neutralmonluminosity", "Lsun", Lsun);
 
-    // neutral monochromatic luminosity (lambda L_lambda / V)
+    // neutral monochromatic luminosity volume density (lambda L_lambda / V)
     addUnit("neutralmonluminosityvolumedensity", "W/m3", 1.);
     addUnit("neutralmonluminosityvolumedensity", "erg/s/cm3", 0.1);
     addUnit("neutralmonluminosityvolumedensity", "Lsun/AU3", Lsun / pow(AU, 3));
@@ -520,6 +532,8 @@ SkirtUnitDef::SkirtUnitDef()
     addDefaultUnit("SIUnits", "magneticfield", "T");
     addDefaultUnit("SIUnits", "pressure", "Pa");
     addDefaultUnit("SIUnits", "bolluminosity", "W");
+    addDefaultUnit("SIUnits", "bolluminosityvolumedensity", "W/m3");
+    addDefaultUnit("SIUnits", "bolluminositysurfacedensity", "W/m2");
     addDefaultUnit("SIUnits", "neutralmonluminosity", "W");
     addDefaultUnit("SIUnits", "neutralmonluminosityvolumedensity", "W/m3");
     addDefaultUnit("SIUnits", "neutralfluxdensity", "W/m2");
@@ -574,6 +588,8 @@ SkirtUnitDef::SkirtUnitDef()
     addDefaultUnit("StellarUnits", "magneticfield", "uG");
     addDefaultUnit("StellarUnits", "pressure", "K/m3");
     addDefaultUnit("StellarUnits", "bolluminosity", "Lsun");
+    addDefaultUnit("StellarUnits", "bolluminosityvolumedensity", "Lsun/AU3");
+    addDefaultUnit("StellarUnits", "bolluminositysurfacedensity", "Lsun/AU2");
     addDefaultUnit("StellarUnits", "neutralmonluminosity", "Lsun");
     addDefaultUnit("StellarUnits", "neutralmonluminosityvolumedensity", "Lsun/AU3");
     addDefaultUnit("StellarUnits", "neutralfluxdensity", "W/m2");
@@ -628,6 +644,8 @@ SkirtUnitDef::SkirtUnitDef()
     addDefaultUnit("ExtragalacticUnits", "magneticfield", "uG");
     addDefaultUnit("ExtragalacticUnits", "pressure", "K/m3");
     addDefaultUnit("ExtragalacticUnits", "bolluminosity", "Lsun");
+    addDefaultUnit("ExtragalacticUnits", "bolluminosityvolumedensity", "Lsun/pc3");
+    addDefaultUnit("ExtragalacticUnits", "bolluminositysurfacedensity", "Lsun/pc2");
     addDefaultUnit("ExtragalacticUnits", "neutralmonluminosity", "Lsun");
     addDefaultUnit("ExtragalacticUnits", "neutralmonluminosityvolumedensity", "Lsun/pc3");
     addDefaultUnit("ExtragalacticUnits", "neutralfluxdensity", "W/m2");

--- a/SKIRT/core/Units.cpp
+++ b/SKIRT/core/Units.cpp
@@ -384,6 +384,34 @@ double Units::obolluminosity(double L) const
 
 ////////////////////////////////////////////////////////////////////
 
+string Units::ubolluminosityvolumedensity() const
+{
+    return unit("bolluminosityvolumedensity");
+}
+
+////////////////////////////////////////////////////////////////////
+
+double Units::obolluminosityvolumedensity(double L) const
+{
+    return out("bolluminosityvolumedensity", L);
+}
+
+////////////////////////////////////////////////////////////////////
+
+string Units::ubolluminositysurfacedensity() const
+{
+    return unit("bolluminositysurfacedensity");
+}
+
+////////////////////////////////////////////////////////////////////
+
+double Units::obolluminositysurfacedensity(double L) const
+{
+    return out("bolluminositysurfacedensity", L);
+}
+
+////////////////////////////////////////////////////////////////////
+
 string Units::smonluminosity() const
 {
     switch (_fluxOutputStyle)

--- a/SKIRT/core/Units.hpp
+++ b/SKIRT/core/Units.hpp
@@ -278,6 +278,22 @@ public:
         (W) to the program's output units. */
     double obolluminosity(double L) const;
 
+    /** This function returns a string containing the name of the unit of bolometric luminosity
+        volume density adopted by the program for output. */
+    string ubolluminosityvolumedensity() const;
+
+    /** This function converts the bolometric luminosity volume density \f$L\f$ from the internally
+        used SI units (W/m3) to the program's output units. */
+    double obolluminosityvolumedensity(double L) const;
+
+    /** This function returns a string containing the name of the unit of bolometric luminosity
+        surface density adopted by the program for output. */
+    string ubolluminositysurfacedensity() const;
+
+    /** This function converts the bolometric luminosity surface density \f$L\f$ from the
+        internally used SI units (W/m2) to the program's output units. */
+    double obolluminositysurfacedensity(double L) const;
+
     /** This function returns a string describing the monochromatic luminosity output style adopted
         by the program. */
     string smonluminosity() const;


### PR DESCRIPTION
**Description**
The new `SecondaryLineLuminosityProbe` class probes the line luminosities of secondary sources as discretized on the spatial grid of the simulation. For each relevant medium component, it outputs the intrinsic bolometric, line-profile-integrated luminosities for each of the lines from which the medium emits.

The probe can be used with any Form subclass. When associated with a form that samples the luminosity in a spatial grid cell or for a linear or planar cut, the probe outputs a bolometric luminosity volume density (with SI units of W/m3). When associated with a form that projects the luminosity along a path, the probe outputs a bolometric luminosity surface (or column) density (with SI units of W/m2).

**Motivation**
This functionality was suggested by @Koseimatsu for use while testing Non-LTE line transfer.
