### PR TITLE
Fix multi-process hang in imaging form probes

### DIFF
--- a/SKIRT/core/AllSkyProjectionForm.cpp
+++ b/SKIRT/core/AllSkyProjectionForm.cpp
@@ -130,7 +130,7 @@ void AllSkyProjectionForm::writeQuantity(const ProbeFormBridge* bridge) const
             log->infoIfElapsed(progress, 1);
         }
     });
-    ProcessManager::sumToRoot(vvv.data());
+    ProcessManager::sumToRoot(vvv.data(), true);
 
     // write the file
     auto units = bridge->units();

--- a/SKIRT/core/ParallelFactory.cpp
+++ b/SKIRT/core/ParallelFactory.cpp
@@ -67,7 +67,7 @@ Parallel* ParallelFactory::parallel(TaskMode mode, int maxThreadCount)
     if (ProcessManager::isMultiProc())
     {
         if (mode == TaskMode::Distributed)
-            type = numThreads == 1 ? ParallelType::MultiProcess : ParallelType::MultiHybrid;
+            type = ParallelType::MultiHybrid;
         else if (mode == TaskMode::RootOnly && !ProcessManager::isRoot())
             type = ParallelType::Null;
         // for the other cases, the type is already set correctly by the very first assignement
@@ -82,7 +82,6 @@ Parallel* ParallelFactory::parallel(TaskMode mode, int maxThreadCount)
             case ParallelType::Null: child.reset(new NullParallel(numThreads)); break;
             case ParallelType::Serial: child.reset(new SerialParallel(numThreads)); break;
             case ParallelType::MultiThread: child.reset(new MultiThreadParallel(numThreads)); break;
-            case ParallelType::MultiProcess: child.reset(new MultiHybridParallel(1)); break;
             case ParallelType::MultiHybrid: child.reset(new MultiHybridParallel(numThreads)); break;
         }
     }

--- a/SKIRT/core/ParallelFactory.hpp
+++ b/SKIRT/core/ParallelFactory.hpp
@@ -45,8 +45,7 @@ class Parallel;
     ----------|-----------------|------------
     S | SerialParallel | Single thread in the current process; isolated from any other processes
     MT | MultiThreadParallel | Multiple coordinated threads in the current process; isolated from any other processes
-    MP | MultiProcessParallel | Single thread in each of multiple, coordinated processes
-    MTP | MultiHybridParallel | Multiple threads in each of multiple processes, all coordinated as a group
+    MTP | MultiHybridParallel | One or more threads in each of multiple processes, all coordinated as a group
     0 | NullParallel | No operation; any requests for performing tasks are ignored
 
     Depending on the requested task mode and the current run-time configuration (number of processes
@@ -55,7 +54,7 @@ class Parallel;
 
     Mode/Runtime | 1P 1T | 1P MT | MP 1T | MP MT |
     -------------|-------|-------|-------|-------|
-    Distributed  |  S    |  MT   |  MP   |  MTP  |
+    Distributed  |  S    |  MT   |  MTP  |  MTP  |
     RootOnly     |  S    |  MT   |  S/0  |  MT/0 |
 
 */
@@ -125,7 +124,7 @@ private:
     std::thread::id _parentThread{std::this_thread::get_id()};
 
     // Private enumeration of the supported Parallel subclasses
-    enum class ParallelType { Null = 0, Serial, MultiThread, MultiProcess, MultiHybrid };
+    enum class ParallelType { Null = 0, Serial, MultiThread, MultiHybrid };
 
     // The collection of our children, keyed on Parallel subclass type and number of threads; initially empty
     std::map<std::pair<ParallelType, int>, std::unique_ptr<Parallel>> _children;

--- a/SKIRT/core/ParallelProjectionForm.cpp
+++ b/SKIRT/core/ParallelProjectionForm.cpp
@@ -95,7 +95,7 @@ void ParallelProjectionForm::writeQuantity(const ProbeFormBridge* bridge) const
             log->infoIfElapsed(progress, 1);
         }
     });
-    ProcessManager::sumToRoot(vvv.data());
+    ProcessManager::sumToRoot(vvv.data(), true);
 
     // write the file
     auto units = bridge->units();

--- a/SKIRT/core/PlanarCutsForm.cpp
+++ b/SKIRT/core/PlanarCutsForm.cpp
@@ -78,7 +78,7 @@ void PlanarCutsForm::writePlanarCut(const ProbeFormBridge* bridge, bool xd, bool
             }
         }
     });
-    ProcessManager::sumToRoot(vvv.data());
+    ProcessManager::sumToRoot(vvv.data(), true);
 
     // get the name of the coordinate plane (xy, xz, or yz)
     string plane;

--- a/SKIRT/mpi/ProcessManager.cpp
+++ b/SKIRT/mpi/ProcessManager.cpp
@@ -220,7 +220,7 @@ void ProcessManager::sumToAll(Array& arr)
 
 //////////////////////////////////////////////////////////////////////
 
-void ProcessManager::sumToRoot(Array& arr)
+void ProcessManager::sumToRoot(Array& arr, bool wait)
 {
 #ifdef BUILD_WITH_MPI
     if (isMultiProc())
@@ -246,6 +246,7 @@ void ProcessManager::sumToRoot(Array& arr)
             else
                 MPI_Reduce(data, data, remaining, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
         }
+        if (wait) MPI_Barrier(MPI_COMM_WORLD);
         if (_logger) _logger("MPI END: sum to root");
     }
 #else

--- a/SKIRT/mpi/ProcessManager.hpp
+++ b/SKIRT/mpi/ProcessManager.hpp
@@ -135,8 +135,20 @@ public:
         processes. The resulting sums are then stored in the same Array passed to this function on
         the root process. The arrays on the other processes are left untouched. All processes must
         call this function for the communication to proceed. If there is only one process, or if
-        the array has zero size, the function does nothing. */
-    static void sumToRoot(Array& arr);
+        the array has zero size, the function does nothing.
+
+        If the \em wait argument is true, this function causes the processes to block until all
+        other processes have invoked it as well. This is important in case the sumToRoot() call may
+        be followed by a sequence of master-slave chunk requests without an intervening call to
+        wait(). Indeed, because nonroot processes do not receive any data in this function, if the
+        MPI implementation buffers the involved send operations, the sumToRoot() function may
+        return in nonroot processes before the root process calls it. This causes problems in case
+        the sumToRoot() call is followed by a sequence of master-slave chunk requests, because the
+        nonroot process might steal a (terminating empty) chunk from the previous sequence,
+        stalling some other non-root process indefinitely. In practice, this means \em wait should
+        be set to true when sumToRoot() is called from probes and can be left to false when it is
+        called from instruments. */
+    static void sumToRoot(Array& arr, bool wait = false);
 
     /** This function broadcasts a separate sequence of floating point values from each process to
         the other processes. The chunk of data to be sent by the calling process must be generated


### PR DESCRIPTION
**Description**
The new imaging form probes (`AllSkyProjectionForm`, `ParallelProjectionForm`, `PlanarCutsForm`, `DefaultCutsForm`, `ConvergenceCutsProbe`) use distributed parallelization (i.e. all processes cooperate) to construct the probed image(s). A problem with the synchronization between processes sometimes caused the code to "hang" indefinitely. This should now be fixed.

As an aside, a few lines of obsolete code were removed in the `ParallelFactory` class. This should not affect the operation of the code.

**Context**
The problem was related to the `ProcessManager::sumToRoot()` function, which was previously used only for instruments and now also for the probes listed above. Because nonroot processes do not receive any data in this function, if the MPI implementation buffers the involved send operations, the sumToRoot() function may return in nonroot processes before the root process calls it. This causes problems in case the sumToRoot() call is followed by a sequence of master-slave chunk requests (e.g., from the next probe in the list), because a nonroot process might steal a (terminating, empty) chunk from the previous sequence, stalling some other non-root process indefinitely.

