### PR TITLE
Some very minor fixes

### DIFF
--- a/SKIRT/core/DensityTreePolicy.hpp
+++ b/SKIRT/core/DensityTreePolicy.hpp
@@ -81,12 +81,13 @@ class DensityTreePolicy : public TreePolicy, public MaterialWavelengthRangeInter
         ATTRIBUTE_MIN_VALUE(maxDustFraction, "[0")
         ATTRIBUTE_MAX_VALUE(maxDustFraction, "1e-2]")
         ATTRIBUTE_DEFAULT_VALUE(maxDustFraction, "1e-6")
+        ATTRIBUTE_DISPLAYED_IF(maxDustFraction, "DustMix")
 
         PROPERTY_DOUBLE(maxDustOpticalDepth, "the maximum diagonal dust optical depth for each cell")
         ATTRIBUTE_MIN_VALUE(maxDustOpticalDepth, "[0")
         ATTRIBUTE_MAX_VALUE(maxDustOpticalDepth, "100]")
         ATTRIBUTE_DEFAULT_VALUE(maxDustOpticalDepth, "0")
-        ATTRIBUTE_DISPLAYED_IF(maxDustOpticalDepth, "Level2")
+        ATTRIBUTE_DISPLAYED_IF(maxDustOpticalDepth, "DustMix&Level2")
 
         PROPERTY_DOUBLE(wavelength, "the wavelength at which to evaluate the optical depth")
         ATTRIBUTE_QUANTITY(wavelength, "wavelength")
@@ -105,12 +106,13 @@ class DensityTreePolicy : public TreePolicy, public MaterialWavelengthRangeInter
         ATTRIBUTE_MIN_VALUE(maxElectronFraction, "[0")
         ATTRIBUTE_MAX_VALUE(maxElectronFraction, "1e-2]")
         ATTRIBUTE_DEFAULT_VALUE(maxElectronFraction, "1e-6")
+        ATTRIBUTE_DISPLAYED_IF(maxElectronFraction, "ElectronMix")
 
         PROPERTY_DOUBLE(maxGasFraction, "the maximum fraction of gas contained in each cell")
         ATTRIBUTE_MIN_VALUE(maxGasFraction, "[0")
         ATTRIBUTE_MAX_VALUE(maxGasFraction, "1e-2]")
         ATTRIBUTE_DEFAULT_VALUE(maxGasFraction, "1e-6")
-        ATTRIBUTE_DISPLAYED_IF(maxGasFraction, "Level2")
+        ATTRIBUTE_DISPLAYED_IF(maxGasFraction, "GasMix&Level2")
 
     ITEM_END()
 

--- a/SKIRT/core/SpatialGridWhenFormProbe.hpp
+++ b/SKIRT/core/SpatialGridWhenFormProbe.hpp
@@ -28,7 +28,7 @@ class SpatialGridWhenFormProbe : public SpatialGridFormProbe
         ATTRIBUTE_SUB_PROPERTIES_HERE(SpatialGridWhenFormProbe)
 
         PROPERTY_ENUM(probeAfter, ProbeAfter, "perform the probe after")
-        ATTRIBUTE_DEFAULT_VALUE(probeAfter, "Setup")
+        ATTRIBUTE_DEFAULT_VALUE(probeAfter, "thisIsTemperatureProbe&DustMix:Run;Setup")
         ATTRIBUTE_DISPLAYED_IF(probeAfter, "DynamicState|IterateSecondary")
 
     ITEM_END()

--- a/SKIRT/core/TemperatureProbe.cpp
+++ b/SKIRT/core/TemperatureProbe.cpp
@@ -43,11 +43,13 @@ void TemperatureProbe::probe()
     // can probe dust temperature only if panchromatic radiation field is available
     if (config->hasPanRadiationField() && ms->hasDust())
     {
-        // can probe dust temperature only after the full simulation run
-        if (probeAfter() == ProbeAfter::Setup)
+        // can probe dust temperature only during or after secondary emission phase
+        // issue a warning because otherwise this is a very confusing problem for the user to locate and fix
+        if (probeAfter() == ProbeAfter::Setup || probeAfter() == ProbeAfter::Primary)
         {
-            // issue a warning because (1) the default value is Setup and (2) otherwise this is a very confusing problem
-            find<Log>()->warning("Cannot probe dust temperature after setup; set probeAfter to 'Run'");
+            find<Log>()->warning(
+                typeAndName()
+                + " can probe dust temperature only during or after secondary emission; adjust probeAfter property");
         }
         else
         {

--- a/SKIRT/core/TemperatureProbe.hpp
+++ b/SKIRT/core/TemperatureProbe.hpp
@@ -84,6 +84,7 @@ class TemperatureProbe : public SpatialGridWhenFormProbe
         PROPERTY_ENUM(aggregation, Aggregation, "how to aggregate the indicative temperature")
         ATTRIBUTE_DEFAULT_VALUE(aggregation, "Type")
         ATTRIBUTE_DISPLAYED_IF(aggregation, "Level2")
+        ATTRIBUTE_INSERT(aggregation, "thisIsTemperatureProbe")  // used to set default in SpatialGridWhenFormProbe
 
     ITEM_END()
 


### PR DESCRIPTION
**Description**
This update fixes two very minor issues discovered while writing documentation for the web site:
 - Improve default value for when the temperature probe is performed (after run for dust, after setup for other media).
 - Suppress octree subdivision options for media types that are not included in the simulation.

