### PR TITLE
No longer use unsafe function sprintf

### DIFF
--- a/SKIRT/voro/cell.cc
+++ b/SKIRT/voro/cell.cc
@@ -18,41 +18,41 @@ namespace voro {
 
 /** Constructs a Voronoi cell and sets up the initial memory. */
 voronoicell_base::voronoicell_base(double max_len_sq) :
-	current_vertices(init_vertices), current_vertex_order(init_vertex_order),
-	current_delete_size(init_delete_size), current_delete2_size(init_delete2_size),
-	current_xsearch_size(init_xsearch_size),
-	ed(new int*[current_vertices]), nu(new int[current_vertices]),
-	mask(new unsigned int[current_vertices]),
-	pts(new double[current_vertices<<2]), tol(tolerance*max_len_sq),
-	tol_cu(tol*sqrt(tol)), big_tol(big_tolerance_fac*tol), mem(new int[current_vertex_order]),
-	mec(new int[current_vertex_order]),
-	mep(new int*[current_vertex_order]), ds(new int[current_delete_size]),
-	stacke(ds+current_delete_size), ds2(new int[current_delete2_size]),
-	stacke2(ds2+current_delete2_size), xse(new int[current_xsearch_size]),
-	stacke3(xse+current_xsearch_size), maskc(0) {
-	int i;
-	for(i=0;i<current_vertices;i++) mask[i]=0;
-	for(i=0;i<3;i++) {
-		mem[i]=init_n_vertices;mec[i]=0;
-		mep[i]=new int[init_n_vertices*((i<<1)+1)];
-	}
-	mem[3]=init_3_vertices;mec[3]=0;
-	mep[3]=new int[init_3_vertices*7];
-	for(i=4;i<current_vertex_order;i++) {
-		mem[i]=init_n_vertices;mec[i]=0;
-		mep[i]=new int[init_n_vertices*((i<<1)+1)];
-	}
+    current_vertices(init_vertices), current_vertex_order(init_vertex_order),
+    current_delete_size(init_delete_size), current_delete2_size(init_delete2_size),
+    current_xsearch_size(init_xsearch_size),
+    ed(new int*[current_vertices]), nu(new int[current_vertices]),
+    mask(new unsigned int[current_vertices]),
+    pts(new double[current_vertices<<2]), tol(tolerance*max_len_sq),
+    tol_cu(tol*sqrt(tol)), big_tol(big_tolerance_fac*tol), mem(new int[current_vertex_order]),
+    mec(new int[current_vertex_order]),
+    mep(new int*[current_vertex_order]), ds(new int[current_delete_size]),
+    stacke(ds+current_delete_size), ds2(new int[current_delete2_size]),
+    stacke2(ds2+current_delete2_size), xse(new int[current_xsearch_size]),
+    stacke3(xse+current_xsearch_size), maskc(0) {
+    int i;
+    for(i=0;i<current_vertices;i++) mask[i]=0;
+    for(i=0;i<3;i++) {
+        mem[i]=init_n_vertices;mec[i]=0;
+        mep[i]=new int[init_n_vertices*((i<<1)+1)];
+    }
+    mem[3]=init_3_vertices;mec[3]=0;
+    mep[3]=new int[init_3_vertices*7];
+    for(i=4;i<current_vertex_order;i++) {
+        mem[i]=init_n_vertices;mec[i]=0;
+        mep[i]=new int[init_n_vertices*((i<<1)+1)];
+    }
 }
 
 /** The voronoicell destructor deallocates all the dynamic memory. */
 voronoicell_base::~voronoicell_base() {
-	for(int i=current_vertex_order-1;i>=0;i--) if(mem[i]>0) delete [] mep[i];
-	delete [] xse;
-	delete [] ds2;delete [] ds;
-	delete [] mep;delete [] mec;
-	delete [] mem;delete [] pts;
-	delete [] mask;
-	delete [] nu;delete [] ed;
+    for(int i=current_vertex_order-1;i>=0;i--) if(mem[i]>0) delete [] mep[i];
+    delete [] xse;
+    delete [] ds2;delete [] ds;
+    delete [] mep;delete [] mec;
+    delete [] mem;delete [] pts;
+    delete [] mask;
+    delete [] nu;delete [] ed;
 }
 
 /** Ensures that enough memory is allocated prior to carrying out a copy.
@@ -60,60 +60,60 @@ voronoicell_base::~voronoicell_base() {
  * \param[in] vb a pointered to the class to be copied. */
 template<class vc_class>
 void voronoicell_base::check_memory_for_copy(vc_class &vc,voronoicell_base* vb) {
-	while(current_vertex_order<vb->current_vertex_order) add_memory_vorder(vc);
-	for(int i=0;i<current_vertex_order;i++) while(mem[i]<vb->mec[i]) add_memory(vc,i);
-	while(current_vertices<vb->p) add_memory_vertices(vc);
+    while(current_vertex_order<vb->current_vertex_order) add_memory_vorder(vc);
+    for(int i=0;i<current_vertex_order;i++) while(mem[i]<vb->mec[i]) add_memory(vc,i);
+    while(current_vertices<vb->p) add_memory_vertices(vc);
 }
 
 /** Copies the vertex and edge information from another class. The routine
  * assumes that enough memory is available for the copy.
  * \param[in] vb a pointer to the class to copy. */
 void voronoicell_base::copy(voronoicell_base* vb) {
-	int i,j;
-	p=vb->p;up=0;
-	for(i=0;i<current_vertex_order;i++) {
-		mec[i]=vb->mec[i];
-		for(j=0;j<mec[i]*(2*i+1);j++) mep[i][j]=vb->mep[i][j];
-		for(j=0;j<mec[i]*(2*i+1);j+=2*i+1) ed[mep[i][j+2*i]]=mep[i]+j;
-	}
-	for(i=0;i<p;i++) nu[i]=vb->nu[i];
-	for(i=0;i<(p<<2);i++) pts[i]=vb->pts[i];
+    int i,j;
+    p=vb->p;up=0;
+    for(i=0;i<current_vertex_order;i++) {
+        mec[i]=vb->mec[i];
+        for(j=0;j<mec[i]*(2*i+1);j++) mep[i][j]=vb->mep[i][j];
+        for(j=0;j<mec[i]*(2*i+1);j+=2*i+1) ed[mep[i][j+2*i]]=mep[i]+j;
+    }
+    for(i=0;i<p;i++) nu[i]=vb->nu[i];
+    for(i=0;i<(p<<2);i++) pts[i]=vb->pts[i];
 }
 
 /** Copies the information from another voronoicell class into this
  * class, extending memory allocation if necessary.
  * \param[in] c the class to copy. */
 void voronoicell_neighbor::operator=(voronoicell &c) {
-	voronoicell_base *vb=((voronoicell_base*) &c);
-	check_memory_for_copy(*this,vb);copy(vb);
-	int i,j;
-	for(i=0;i<c.current_vertex_order;i++) {
-		for(j=0;j<c.mec[i]*i;j++) mne[i][j]=0;
-		for(j=0;j<c.mec[i];j++) ne[c.mep[i][(2*i+1)*j+2*i]]=mne[i]+(j*i);
-	}
+    voronoicell_base *vb=((voronoicell_base*) &c);
+    check_memory_for_copy(*this,vb);copy(vb);
+    int i,j;
+    for(i=0;i<c.current_vertex_order;i++) {
+        for(j=0;j<c.mec[i]*i;j++) mne[i][j]=0;
+        for(j=0;j<c.mec[i];j++) ne[c.mep[i][(2*i+1)*j+2*i]]=mne[i]+(j*i);
+    }
 }
 
 /** Copies the information from another voronoicell_neighbor class into this
  * class, extending memory allocation if necessary.
  * \param[in] c the class to copy. */
 void voronoicell_neighbor::operator=(voronoicell_neighbor &c) {
-	voronoicell_base *vb=((voronoicell_base*) &c);
-	check_memory_for_copy(*this,vb);copy(vb);
-	int i,j;
-	for(i=0;i<c.current_vertex_order;i++) {
-		for(j=0;j<c.mec[i]*i;j++) mne[i][j]=c.mne[i][j];
-		for(j=0;j<c.mec[i];j++) ne[c.mep[i][(2*i+1)*j+2*i]]=mne[i]+(j*i);
-	}
+    voronoicell_base *vb=((voronoicell_base*) &c);
+    check_memory_for_copy(*this,vb);copy(vb);
+    int i,j;
+    for(i=0;i<c.current_vertex_order;i++) {
+        for(j=0;j<c.mec[i]*i;j++) mne[i][j]=c.mne[i][j];
+        for(j=0;j<c.mec[i];j++) ne[c.mep[i][(2*i+1)*j+2*i]]=mne[i]+(j*i);
+    }
 }
 
 /** Translates the vertices of the Voronoi cell by a given vector.
  * \param[in] (x,y,z) the coordinates of the vector. */
 void voronoicell_base::translate(double x,double y,double z) {
-	x*=2;y*=2;z*=2;
-	double *ptsp=pts;
-	while(ptsp<pts+(p<<2)) {
-		*(ptsp++)+=x;*(ptsp++)+=y;*ptsp+=z;ptsp+=2;
-	}
+    x*=2;y*=2;z*=2;
+    double *ptsp=pts;
+    while(ptsp<pts+(p<<2)) {
+        *(ptsp++)+=x;*(ptsp++)+=y;*ptsp+=z;ptsp+=2;
+    }
 }
 
 /** Increases the memory storage for a particular vertex order, by increasing
@@ -129,59 +129,59 @@ void voronoicell_base::translate(double x,double y,double z) {
  * \param[in] i the order of the vertex memory to be increased. */
 template<class vc_class>
 void voronoicell_base::add_memory(vc_class &vc,int i) {
-	int s=(i<<1)+1;
-	if(mem[i]==0) {
-		vc.n_allocate(i,init_n_vertices);
-		mep[i]=new int[init_n_vertices*s];
-		mem[i]=init_n_vertices;
+    int s=(i<<1)+1;
+    if(mem[i]==0) {
+        vc.n_allocate(i,init_n_vertices);
+        mep[i]=new int[init_n_vertices*s];
+        mem[i]=init_n_vertices;
 #if VOROPP_VERBOSE >=2
-		fprintf(stderr,"Order %d vertex memory created\n",i);
+        fprintf(stderr,"Order %d vertex memory created\n",i);
 #endif
-	} else {
-		int j=0,k,*l;
-		mem[i]<<=1;
-		if(mem[i]>max_n_vertices) voro_fatal_error("Point memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
+    } else {
+        int j=0,k,*l;
+        mem[i]<<=1;
+        if(mem[i]>max_n_vertices) voro_fatal_error("Point memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
 #if VOROPP_VERBOSE >=2
-		fprintf(stderr,"Order %d vertex memory scaled up to %d\n",i,mem[i]);
+        fprintf(stderr,"Order %d vertex memory scaled up to %d\n",i,mem[i]);
 #endif
-		l=new int[s*mem[i]];
-		int m=0;
-		vc.n_allocate_aux1(i);
-		while(j<s*mec[i]) {
-			k=mep[i][j+(i<<1)];
-			if(k>=0) {
-				ed[k]=l+j;
-				vc.n_set_to_aux1_offset(k,m);
-			} else {
-				int *dsp;
-				for(dsp=ds2;dsp<stackp2;dsp++) {
-					if(ed[*dsp]==mep[i]+j) {
-						ed[*dsp]=l+j;
-						vc.n_set_to_aux1_offset(*dsp,m);
-						break;
-					}
-				}
-				if(dsp==stackp2) {
-					for(dsp=xse;dsp<stackp3;dsp++) {
-						if(ed[*dsp]==mep[i]+j) {
-							ed[*dsp]=l+j;
-							vc.n_set_to_aux1_offset(*dsp,m);
-							break;
-						}
-					}
-					if(dsp==stackp3) voro_fatal_error("Couldn't relocate dangling pointer",VOROPP_INTERNAL_ERROR);
-				}
+        l=new int[s*mem[i]];
+        int m=0;
+        vc.n_allocate_aux1(i);
+        while(j<s*mec[i]) {
+            k=mep[i][j+(i<<1)];
+            if(k>=0) {
+                ed[k]=l+j;
+                vc.n_set_to_aux1_offset(k,m);
+            } else {
+                int *dsp;
+                for(dsp=ds2;dsp<stackp2;dsp++) {
+                    if(ed[*dsp]==mep[i]+j) {
+                        ed[*dsp]=l+j;
+                        vc.n_set_to_aux1_offset(*dsp,m);
+                        break;
+                    }
+                }
+                if(dsp==stackp2) {
+                    for(dsp=xse;dsp<stackp3;dsp++) {
+                        if(ed[*dsp]==mep[i]+j) {
+                            ed[*dsp]=l+j;
+                            vc.n_set_to_aux1_offset(*dsp,m);
+                            break;
+                        }
+                    }
+                    if(dsp==stackp3) voro_fatal_error("Couldn't relocate dangling pointer",VOROPP_INTERNAL_ERROR);
+                }
 #if VOROPP_VERBOSE >=3
-				fputs("Relocated dangling pointer",stderr);
+                fputs("Relocated dangling pointer",stderr);
 #endif
-			}
-			for(k=0;k<s;k++,j++) l[j]=mep[i][j];
-			for(k=0;k<i;k++,m++) vc.n_copy_to_aux1(i,m);
-		}
-		delete [] mep[i];
-		mep[i]=l;
-		vc.n_switch_to_aux1(i);
-	}
+            }
+            for(k=0;k<s;k++,j++) l[j]=mep[i][j];
+            for(k=0;k<i;k++,m++) vc.n_copy_to_aux1(i,m);
+        }
+        delete [] mep[i];
+        mep[i]=l;
+        vc.n_switch_to_aux1(i);
+    }
 }
 
 /** Doubles the maximum number of vertices allowed, by reallocating the ed, nu,
@@ -191,28 +191,28 @@ void voronoicell_base::add_memory(vc_class &vc,int i) {
  * also reallocates the ne array. */
 template<class vc_class>
 void voronoicell_base::add_memory_vertices(vc_class &vc) {
-	int i=(current_vertices<<1),j,**pp,*pnu;
-	unsigned int* pmask;
-	if(i>max_vertices) voro_fatal_error("Vertex memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
+    int i=(current_vertices<<1),j,**pp,*pnu;
+    unsigned int* pmask;
+    if(i>max_vertices) voro_fatal_error("Vertex memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
 #if VOROPP_VERBOSE >=2
-	fprintf(stderr,"Vertex memory scaled up to %d\n",i);
+    fprintf(stderr,"Vertex memory scaled up to %d\n",i);
 #endif
-	double *ppts;
-	pp=new int*[i];
-	for(j=0;j<current_vertices;j++) pp[j]=ed[j];
-	delete [] ed;ed=pp;
-	vc.n_add_memory_vertices(i);
-	pnu=new int[i];
-	for(j=0;j<current_vertices;j++) pnu[j]=nu[j];
-	delete [] nu;nu=pnu;
-	pmask=new unsigned int[i];
-	for(j=0;j<current_vertices;j++) pmask[j]=mask[j];
-	while(j<i) pmask[j++]=0;
-	delete [] mask;mask=pmask;
-	ppts=new double[i<<2];
-	for(j=0;j<(current_vertices<<2);j++) ppts[j]=pts[j];
-	delete [] pts;pts=ppts;
-	current_vertices=i;
+    double *ppts;
+    pp=new int*[i];
+    for(j=0;j<current_vertices;j++) pp[j]=ed[j];
+    delete [] ed;ed=pp;
+    vc.n_add_memory_vertices(i);
+    pnu=new int[i];
+    for(j=0;j<current_vertices;j++) pnu[j]=nu[j];
+    delete [] nu;nu=pnu;
+    pmask=new unsigned int[i];
+    for(j=0;j<current_vertices;j++) pmask[j]=mask[j];
+    while(j<i) pmask[j++]=0;
+    delete [] mask;mask=pmask;
+    ppts=new double[i<<2];
+    for(j=0;j<(current_vertices<<2);j++) ppts[j]=pts[j];
+    delete [] pts;pts=ppts;
+    current_vertices=i;
 }
 
 /** Doubles the maximum allowed vertex order, by reallocating mem, mep, and mec
@@ -222,69 +222,69 @@ void voronoicell_base::add_memory_vertices(vc_class &vc) {
  * also reallocates the mne array. */
 template<class vc_class>
 void voronoicell_base::add_memory_vorder(vc_class &vc) {
-	int i=(current_vertex_order<<1),j,*p1,**p2;
-	if(i>max_vertex_order) voro_fatal_error("Vertex order memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
+    int i=(current_vertex_order<<1),j,*p1,**p2;
+    if(i>max_vertex_order) voro_fatal_error("Vertex order memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
 #if VOROPP_VERBOSE >=2
-	fprintf(stderr,"Vertex order memory scaled up to %d\n",i);
+    fprintf(stderr,"Vertex order memory scaled up to %d\n",i);
 #endif
-	p1=new int[i];
-	for(j=0;j<current_vertex_order;j++) p1[j]=mem[j];
-	while(j<i) p1[j++]=0;
-	delete [] mem;mem=p1;
-	p2=new int*[i];
-	for(j=0;j<current_vertex_order;j++) p2[j]=mep[j];
-	delete [] mep;mep=p2;
-	p1=new int[i];
-	for(j=0;j<current_vertex_order;j++) p1[j]=mec[j];
-	while(j<i) p1[j++]=0;
-	delete [] mec;mec=p1;
-	vc.n_add_memory_vorder(i);
-	current_vertex_order=i;
+    p1=new int[i];
+    for(j=0;j<current_vertex_order;j++) p1[j]=mem[j];
+    while(j<i) p1[j++]=0;
+    delete [] mem;mem=p1;
+    p2=new int*[i];
+    for(j=0;j<current_vertex_order;j++) p2[j]=mep[j];
+    delete [] mep;mep=p2;
+    p1=new int[i];
+    for(j=0;j<current_vertex_order;j++) p1[j]=mec[j];
+    while(j<i) p1[j++]=0;
+    delete [] mec;mec=p1;
+    vc.n_add_memory_vorder(i);
+    current_vertex_order=i;
 }
 
 /** Doubles the size allocation of the main delete stack. If the allocation
  * exceeds the absolute maximum set in max_delete_size, then routine causes a
  * fatal error. */
 void voronoicell_base::add_memory_ds() {
-	current_delete_size<<=1;
-	if(current_delete_size>max_delete_size) voro_fatal_error("Delete stack 1 memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
+    current_delete_size<<=1;
+    if(current_delete_size>max_delete_size) voro_fatal_error("Delete stack 1 memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
 #if VOROPP_VERBOSE >=2
-	fprintf(stderr,"Delete stack 1 memory scaled up to %d\n",current_delete_size);
+    fprintf(stderr,"Delete stack 1 memory scaled up to %d\n",current_delete_size);
 #endif
-	int *dsn=new int[current_delete_size],*dsnp=dsn,*dsp=ds;
-	while(dsp<stackp) *(dsnp++)=*(dsp++);
-	delete [] ds;ds=dsn;stackp=dsnp;
-	stacke=ds+current_delete_size;
+    int *dsn=new int[current_delete_size],*dsnp=dsn,*dsp=ds;
+    while(dsp<stackp) *(dsnp++)=*(dsp++);
+    delete [] ds;ds=dsn;stackp=dsnp;
+    stacke=ds+current_delete_size;
 }
 
 /** Doubles the size allocation of the auxiliary delete stack. If the
  * allocation exceeds the absolute maximum set in max_delete2_size, then the
  * routine causes a fatal error. */
 void voronoicell_base::add_memory_ds2() {
-	current_delete2_size<<=1;
-	if(current_delete2_size>max_delete2_size) voro_fatal_error("Delete stack 2 memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
+    current_delete2_size<<=1;
+    if(current_delete2_size>max_delete2_size) voro_fatal_error("Delete stack 2 memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
 #if VOROPP_VERBOSE >=2
-	fprintf(stderr,"Delete stack 2 memory scaled up to %d\n",current_delete2_size);
+    fprintf(stderr,"Delete stack 2 memory scaled up to %d\n",current_delete2_size);
 #endif
-	int *dsn=new int[current_delete2_size],*dsnp=dsn,*dsp=ds2;
-	while(dsp<stackp2) *(dsnp++)=*(dsp++);
-	delete [] ds2;ds2=dsn;stackp2=dsnp;
-	stacke2=ds2+current_delete2_size;
+    int *dsn=new int[current_delete2_size],*dsnp=dsn,*dsp=ds2;
+    while(dsp<stackp2) *(dsnp++)=*(dsp++);
+    delete [] ds2;ds2=dsn;stackp2=dsnp;
+    stacke2=ds2+current_delete2_size;
 }
 
 /** Doubles the size allocation of the auxiliary delete stack. If the
  * allocation exceeds the absolute maximum set in max_delete2_size, then the
  * routine causes a fatal error. */
 void voronoicell_base::add_memory_xse() {
-	current_xsearch_size<<=1;
-	if(current_xsearch_size>max_xsearch_size) voro_fatal_error("Extra search stack memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
+    current_xsearch_size<<=1;
+    if(current_xsearch_size>max_xsearch_size) voro_fatal_error("Extra search stack memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
 #if VOROPP_VERBOSE >=2
-	fprintf(stderr,"Extra search stack memory scaled up to %d\n",current_xsearch_size);
+    fprintf(stderr,"Extra search stack memory scaled up to %d\n",current_xsearch_size);
 #endif
-	int *dsn=new int[current_xsearch_size],*dsnp=dsn,*dsp=xse;
-	while(dsp<stackp3) *(dsnp++)=*(dsp++);
-	delete [] xse;xse=dsn;stackp3=dsnp;
-	stacke3=xse+current_xsearch_size;
+    int *dsn=new int[current_xsearch_size],*dsnp=dsn,*dsp=xse;
+    while(dsp<stackp3) *(dsnp++)=*(dsp++);
+    delete [] xse;xse=dsn;stackp3=dsnp;
+    stacke3=xse+current_xsearch_size;
 }
 
 /** Initializes a Voronoi cell as a rectangular box with the given dimensions.
@@ -292,67 +292,67 @@ void voronoicell_base::add_memory_xse() {
  * \param[in] (ymin,ymax) the minimum and maximum y coordinates.
  * \param[in] (zmin,zmax) the minimum and maximum z coordinates. */
 void voronoicell_base::init_base(double xmin,double xmax,double ymin,double ymax,double zmin,double zmax) {
-	for(int i=0;i<current_vertex_order;i++) mec[i]=0;
-	up=0;
-	mec[3]=p=8;xmin*=2;xmax*=2;ymin*=2;ymax*=2;zmin*=2;zmax*=2;
-	*pts=xmin;pts[1]=ymin;pts[2]=zmin;
-	pts[4]=xmax;pts[5]=ymin;pts[6]=zmin;
-	pts[8]=xmin;pts[9]=ymax;pts[10]=zmin;
-	pts[12]=xmax;pts[13]=ymax;pts[14]=zmin;
-	pts[16]=xmin;pts[17]=ymin;pts[18]=zmax;
-	pts[20]=xmax;pts[21]=ymin;pts[22]=zmax;
-	pts[24]=xmin;pts[25]=ymax;pts[26]=zmax;
-	pts[28]=xmax;pts[29]=ymax;pts[30]=zmax;
-	int *q=mep[3];
-	*q=1;q[1]=4;q[2]=2;q[3]=2;q[4]=1;q[5]=0;q[6]=0;
-	q[7]=3;q[8]=5;q[9]=0;q[10]=2;q[11]=1;q[12]=0;q[13]=1;
-	q[14]=0;q[15]=6;q[16]=3;q[17]=2;q[18]=1;q[19]=0;q[20]=2;
-	q[21]=2;q[22]=7;q[23]=1;q[24]=2;q[25]=1;q[26]=0;q[27]=3;
-	q[28]=6;q[29]=0;q[30]=5;q[31]=2;q[32]=1;q[33]=0;q[34]=4;
-	q[35]=4;q[36]=1;q[37]=7;q[38]=2;q[39]=1;q[40]=0;q[41]=5;
-	q[42]=7;q[43]=2;q[44]=4;q[45]=2;q[46]=1;q[47]=0;q[48]=6;
-	q[49]=5;q[50]=3;q[51]=6;q[52]=2;q[53]=1;q[54]=0;q[55]=7;
-	*ed=q;ed[1]=q+7;ed[2]=q+14;ed[3]=q+21;
-	ed[4]=q+28;ed[5]=q+35;ed[6]=q+42;ed[7]=q+49;
-	*nu=nu[1]=nu[2]=nu[3]=nu[4]=nu[5]=nu[6]=nu[7]=3;
+    for(int i=0;i<current_vertex_order;i++) mec[i]=0;
+    up=0;
+    mec[3]=p=8;xmin*=2;xmax*=2;ymin*=2;ymax*=2;zmin*=2;zmax*=2;
+    *pts=xmin;pts[1]=ymin;pts[2]=zmin;
+    pts[4]=xmax;pts[5]=ymin;pts[6]=zmin;
+    pts[8]=xmin;pts[9]=ymax;pts[10]=zmin;
+    pts[12]=xmax;pts[13]=ymax;pts[14]=zmin;
+    pts[16]=xmin;pts[17]=ymin;pts[18]=zmax;
+    pts[20]=xmax;pts[21]=ymin;pts[22]=zmax;
+    pts[24]=xmin;pts[25]=ymax;pts[26]=zmax;
+    pts[28]=xmax;pts[29]=ymax;pts[30]=zmax;
+    int *q=mep[3];
+    *q=1;q[1]=4;q[2]=2;q[3]=2;q[4]=1;q[5]=0;q[6]=0;
+    q[7]=3;q[8]=5;q[9]=0;q[10]=2;q[11]=1;q[12]=0;q[13]=1;
+    q[14]=0;q[15]=6;q[16]=3;q[17]=2;q[18]=1;q[19]=0;q[20]=2;
+    q[21]=2;q[22]=7;q[23]=1;q[24]=2;q[25]=1;q[26]=0;q[27]=3;
+    q[28]=6;q[29]=0;q[30]=5;q[31]=2;q[32]=1;q[33]=0;q[34]=4;
+    q[35]=4;q[36]=1;q[37]=7;q[38]=2;q[39]=1;q[40]=0;q[41]=5;
+    q[42]=7;q[43]=2;q[44]=4;q[45]=2;q[46]=1;q[47]=0;q[48]=6;
+    q[49]=5;q[50]=3;q[51]=6;q[52]=2;q[53]=1;q[54]=0;q[55]=7;
+    *ed=q;ed[1]=q+7;ed[2]=q+14;ed[3]=q+21;
+    ed[4]=q+28;ed[5]=q+35;ed[6]=q+42;ed[7]=q+49;
+    *nu=nu[1]=nu[2]=nu[3]=nu[4]=nu[5]=nu[6]=nu[7]=3;
 }
 
 /** Initializes an L-shaped Voronoi cell of a fixed size for testing the
  * convexity robustness. */
 void voronoicell::init_l_shape() {
-	for(int i=0;i<current_vertex_order;i++) mec[i]=0;
-	up=0;
-	mec[3]=p=12;
-	const double j=0;
-	*pts=-2;pts[1]=-2;pts[2]=-2;
-	pts[4]=2;pts[5]=-2;pts[6]=-2;
-	pts[8]=-2;pts[9]=0;pts[10]=-2;
-	pts[12]=-j;pts[13]=j;pts[14]=-2;
-	pts[16]=0;pts[17]=2;pts[18]=-2;
-	pts[20]=2;pts[21]=2;pts[22]=-2;
-	pts[24]=-2;pts[25]=-2;pts[26]=2;
-	pts[28]=2;pts[29]=-2;pts[30]=2;
-	pts[32]=-2;pts[33]=0;pts[34]=2;
-	pts[36]=-j;pts[37]=j;pts[38]=2;
-	pts[40]=0;pts[41]=2;pts[42]=2;
-	pts[44]=2;pts[45]=2;pts[46]=2;
-	int *q=mep[3];
-	*q=1;q[1]=6;q[2]=2;q[6]=0;
-	q[7]=5;q[8]=7;q[9]=0;q[13]=1;
-	q[14]=0;q[15]=8;q[16]=3;q[20]=2;
-	q[21]=2;q[22]=9;q[23]=4;q[27]=3;
-	q[28]=3;q[29]=10;q[30]=5;q[34]=4;
-	q[35]=4;q[36]=11;q[37]=1;q[41]=5;
-	q[42]=8;q[43]=0;q[44]=7;q[48]=6;
-	q[49]=6;q[50]=1;q[51]=11;q[55]=7;
-	q[56]=9;q[57]=2;q[58]=6;q[62]=8;
-	q[63]=10;q[64]=3;q[65]=8;q[69]=9;
-	q[70]=11;q[71]=4;q[72]=9;q[76]=10;
-	q[77]=7;q[78]=5;q[79]=10;q[83]=11;
-	*ed=q;ed[1]=q+7;ed[2]=q+14;ed[3]=q+21;ed[4]=q+28;ed[5]=q+35;
-	ed[6]=q+42;ed[7]=q+49;ed[8]=q+56;ed[9]=q+63;ed[10]=q+70;ed[11]=q+77;
-	for(int i=0;i<12;i++) nu[i]=3;
-	construct_relations();
+    for(int i=0;i<current_vertex_order;i++) mec[i]=0;
+    up=0;
+    mec[3]=p=12;
+    const double j=0;
+    *pts=-2;pts[1]=-2;pts[2]=-2;
+    pts[4]=2;pts[5]=-2;pts[6]=-2;
+    pts[8]=-2;pts[9]=0;pts[10]=-2;
+    pts[12]=-j;pts[13]=j;pts[14]=-2;
+    pts[16]=0;pts[17]=2;pts[18]=-2;
+    pts[20]=2;pts[21]=2;pts[22]=-2;
+    pts[24]=-2;pts[25]=-2;pts[26]=2;
+    pts[28]=2;pts[29]=-2;pts[30]=2;
+    pts[32]=-2;pts[33]=0;pts[34]=2;
+    pts[36]=-j;pts[37]=j;pts[38]=2;
+    pts[40]=0;pts[41]=2;pts[42]=2;
+    pts[44]=2;pts[45]=2;pts[46]=2;
+    int *q=mep[3];
+    *q=1;q[1]=6;q[2]=2;q[6]=0;
+    q[7]=5;q[8]=7;q[9]=0;q[13]=1;
+    q[14]=0;q[15]=8;q[16]=3;q[20]=2;
+    q[21]=2;q[22]=9;q[23]=4;q[27]=3;
+    q[28]=3;q[29]=10;q[30]=5;q[34]=4;
+    q[35]=4;q[36]=11;q[37]=1;q[41]=5;
+    q[42]=8;q[43]=0;q[44]=7;q[48]=6;
+    q[49]=6;q[50]=1;q[51]=11;q[55]=7;
+    q[56]=9;q[57]=2;q[58]=6;q[62]=8;
+    q[63]=10;q[64]=3;q[65]=8;q[69]=9;
+    q[70]=11;q[71]=4;q[72]=9;q[76]=10;
+    q[77]=7;q[78]=5;q[79]=10;q[83]=11;
+    *ed=q;ed[1]=q+7;ed[2]=q+14;ed[3]=q+21;ed[4]=q+28;ed[5]=q+35;
+    ed[6]=q+42;ed[7]=q+49;ed[8]=q+56;ed[9]=q+63;ed[10]=q+70;ed[11]=q+77;
+    for(int i=0;i<12;i++) nu[i]=3;
+    construct_relations();
 }
 
 /** Initializes a Voronoi cell as a regular octahedron.
@@ -360,24 +360,24 @@ void voronoicell::init_l_shape() {
  *              vertices are initialized at (-l,0,0), (l,0,0), (0,-l,0),
  *              (0,l,0), (0,0,-l), and (0,0,l). */
 void voronoicell_base::init_octahedron_base(double l) {
-	for(int i=0;i<current_vertex_order;i++) mec[i]=0;
-	up=0;
-	mec[4]=p=6;l*=2;
-	*pts=-l;pts[1]=0;pts[2]=0;
-	pts[4]=l;pts[5]=0;pts[6]=0;
-	pts[8]=0;pts[9]=-l;pts[10]=0;
-	pts[12]=0;pts[13]=l;pts[14]=0;
-	pts[16]=0;pts[17]=0;pts[18]=-l;
-	pts[20]=0;pts[21]=0;pts[22]=l;
-	int *q=mep[4];
-	*q=2;q[1]=5;q[2]=3;q[3]=4;q[4]=0;q[5]=0;q[6]=0;q[7]=0;q[8]=0;
-	q[9]=2;q[10]=4;q[11]=3;q[12]=5;q[13]=2;q[14]=2;q[15]=2;q[16]=2;q[17]=1;
-	q[18]=0;q[19]=4;q[20]=1;q[21]=5;q[22]=0;q[23]=3;q[24]=0;q[25]=1;q[26]=2;
-	q[27]=0;q[28]=5;q[29]=1;q[30]=4;q[31]=2;q[32]=3;q[33]=2;q[34]=1;q[35]=3;
-	q[36]=0;q[37]=3;q[38]=1;q[39]=2;q[40]=3;q[41]=3;q[42]=1;q[43]=1;q[44]=4;
-	q[45]=0;q[46]=2;q[47]=1;q[48]=3;q[49]=1;q[50]=3;q[51]=3;q[52]=1;q[53]=5;
-	*ed=q;ed[1]=q+9;ed[2]=q+18;ed[3]=q+27;ed[4]=q+36;ed[5]=q+45;
-	*nu=nu[1]=nu[2]=nu[3]=nu[4]=nu[5]=4;
+    for(int i=0;i<current_vertex_order;i++) mec[i]=0;
+    up=0;
+    mec[4]=p=6;l*=2;
+    *pts=-l;pts[1]=0;pts[2]=0;
+    pts[4]=l;pts[5]=0;pts[6]=0;
+    pts[8]=0;pts[9]=-l;pts[10]=0;
+    pts[12]=0;pts[13]=l;pts[14]=0;
+    pts[16]=0;pts[17]=0;pts[18]=-l;
+    pts[20]=0;pts[21]=0;pts[22]=l;
+    int *q=mep[4];
+    *q=2;q[1]=5;q[2]=3;q[3]=4;q[4]=0;q[5]=0;q[6]=0;q[7]=0;q[8]=0;
+    q[9]=2;q[10]=4;q[11]=3;q[12]=5;q[13]=2;q[14]=2;q[15]=2;q[16]=2;q[17]=1;
+    q[18]=0;q[19]=4;q[20]=1;q[21]=5;q[22]=0;q[23]=3;q[24]=0;q[25]=1;q[26]=2;
+    q[27]=0;q[28]=5;q[29]=1;q[30]=4;q[31]=2;q[32]=3;q[33]=2;q[34]=1;q[35]=3;
+    q[36]=0;q[37]=3;q[38]=1;q[39]=2;q[40]=3;q[41]=3;q[42]=1;q[43]=1;q[44]=4;
+    q[45]=0;q[46]=2;q[47]=1;q[48]=3;q[49]=1;q[50]=3;q[51]=3;q[52]=1;q[53]=5;
+    *ed=q;ed[1]=q+9;ed[2]=q+18;ed[3]=q+27;ed[4]=q+36;ed[5]=q+45;
+    *nu=nu[1]=nu[2]=nu[3]=nu[4]=nu[5]=4;
 }
 
 /** Initializes a Voronoi cell as a tetrahedron. It assumes that the normal to
@@ -387,29 +387,29 @@ void voronoicell_base::init_octahedron_base(double l) {
  * \param (x2,y2,z2) a position vector for the third vertex.
  * \param (x3,y3,z3) a position vector for the fourth vertex. */
 void voronoicell_base::init_tetrahedron_base(double x0,double y0,double z0,double x1,double y1,double z1,double x2,double y2,double z2,double x3,double y3,double z3) {
-	for(int i=0;i<current_vertex_order;i++) mec[i]=0;
-	up=0;
-	mec[3]=p=4;
-	*pts=x0*2;pts[1]=y0*2;pts[2]=z0*2;
-	pts[4]=x1*2;pts[5]=y1*2;pts[6]=z1*2;
-	pts[8]=x2*2;pts[9]=y2*2;pts[10]=z2*2;
-	pts[12]=x3*2;pts[13]=y3*2;pts[14]=z3*2;
-	int *q=mep[3];
-	*q=1;q[1]=3;q[2]=2;q[3]=0;q[4]=0;q[5]=0;q[6]=0;
-	q[7]=0;q[8]=2;q[9]=3;q[10]=0;q[11]=2;q[12]=1;q[13]=1;
-	q[14]=0;q[15]=3;q[16]=1;q[17]=2;q[18]=2;q[19]=1;q[20]=2;
-	q[21]=0;q[22]=1;q[23]=2;q[24]=1;q[25]=2;q[26]=1;q[27]=3;
-	*ed=q;ed[1]=q+7;ed[2]=q+14;ed[3]=q+21;
-	*nu=nu[1]=nu[2]=nu[3]=3;
+    for(int i=0;i<current_vertex_order;i++) mec[i]=0;
+    up=0;
+    mec[3]=p=4;
+    *pts=x0*2;pts[1]=y0*2;pts[2]=z0*2;
+    pts[4]=x1*2;pts[5]=y1*2;pts[6]=z1*2;
+    pts[8]=x2*2;pts[9]=y2*2;pts[10]=z2*2;
+    pts[12]=x3*2;pts[13]=y3*2;pts[14]=z3*2;
+    int *q=mep[3];
+    *q=1;q[1]=3;q[2]=2;q[3]=0;q[4]=0;q[5]=0;q[6]=0;
+    q[7]=0;q[8]=2;q[9]=3;q[10]=0;q[11]=2;q[12]=1;q[13]=1;
+    q[14]=0;q[15]=3;q[16]=1;q[17]=2;q[18]=2;q[19]=1;q[20]=2;
+    q[21]=0;q[22]=1;q[23]=2;q[24]=1;q[25]=2;q[26]=1;q[27]=3;
+    *ed=q;ed[1]=q+7;ed[2]=q+14;ed[3]=q+21;
+    *nu=nu[1]=nu[2]=nu[3]=3;
 }
 
 /** Checks that the relational table of the Voronoi cell is accurate, and
  * prints out any errors. This algorithm is O(p), so running it every time the
  * plane routine is called will result in a significant slowdown. */
 void voronoicell_base::check_relations() {
-	int i,j;
-	for(i=0;i<p;i++) for(j=0;j<nu[i];j++) if(ed[ed[i][j]][ed[i][nu[i]+j]]!=i)
-		printf("Relational error at point %d, edge %d.\n",i,j);
+    int i,j;
+    for(i=0;i<p;i++) for(j=0;j<nu[i];j++) if(ed[ed[i][j]][ed[i][nu[i]+j]]!=i)
+        printf("Relational error at point %d, edge %d.\n",i,j);
 }
 
 /** This routine checks for any two vertices that are connected by more than
@@ -418,23 +418,23 @@ void voronoicell_base::check_relations() {
  * running it every time the plane routine is called will result in a
  * significant slowdown. */
 void voronoicell_base::check_duplicates() {
-	int i,j,k;
-	for(i=0;i<p;i++) for(j=1;j<nu[i];j++) for(k=0;k<j;k++) if(ed[i][j]==ed[i][k])
-		printf("Duplicate edges: (%d,%d) and (%d,%d) [%d]\n",i,j,i,k,ed[i][j]);
+    int i,j,k;
+    for(i=0;i<p;i++) for(j=1;j<nu[i];j++) for(k=0;k<j;k++) if(ed[i][j]==ed[i][k])
+        printf("Duplicate edges: (%d,%d) and (%d,%d) [%d]\n",i,j,i,k,ed[i][j]);
 }
 
 /** Constructs the relational table if the edges have been specified. */
 void voronoicell_base::construct_relations() {
-	int i,j,k,l;
-	for(i=0;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		l=0;
-		while(ed[k][l]!=i) {
-			l++;
-			if(l==nu[k]) voro_fatal_error("Relation table construction failed",VOROPP_INTERNAL_ERROR);
-		}
-		ed[i][nu[i]+j]=l;
-	}
+    int i,j,k,l;
+    for(i=0;i<p;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        l=0;
+        while(ed[k][l]!=i) {
+            l++;
+            if(l==nu[k]) voro_fatal_error("Relation table construction failed",VOROPP_INTERNAL_ERROR);
+        }
+        ed[i][nu[i]+j]=l;
+    }
 }
 
 /** Starting from a point within the current cutting plane, this routine attempts
@@ -442,23 +442,23 @@ void voronoicell_base::construct_relations() {
  * routine from .
  * \param[in,out] up */
 inline bool voronoicell_base::search_for_outside_edge(int &up) {
-	int i,lp,lw,*j=stackp2,sc2=stackp2-ds2;
-	double l;
-	*(stackp2++)=up;
-	while(j<stackp2) {
-		up=*(j++);
-		for(i=0;i<nu[up];i++) {
-			lp=ed[up][i];
-			lw=m_test(lp,l);
-			if(lw==0) {
-				stackp2=ds2+sc2;
-				return true;
-			}
-			else if(lw==1) add_to_stack(sc2,lp);
-		}
-	}
-	stackp2=ds2+sc2;
-	return false;
+    int i,lp,lw,*j=stackp2,sc2=stackp2-ds2;
+    double l;
+    *(stackp2++)=up;
+    while(j<stackp2) {
+        up=*(j++);
+        for(i=0;i<nu[up];i++) {
+            lp=ed[up][i];
+            lw=m_test(lp,l);
+            if(lw==0) {
+                stackp2=ds2+sc2;
+                return true;
+            }
+            else if(lw==1) add_to_stack(sc2,lp);
+        }
+    }
+    stackp2=ds2+sc2;
+    return false;
 }
 
 /** Adds a point to the auxiliary delete stack if it is not already there.
@@ -466,9 +466,9 @@ inline bool voronoicell_base::search_for_outside_edge(int &up) {
  * \param[in] lp the index of the point to add.
  * \param[in,out] stackp2 a pointer to the end of the stack entries. */
 inline void voronoicell_base::add_to_stack(int sc2,int lp) {
-	for(int *k=ds2+sc2;k<stackp2;k++) if(*k==lp) return;
-	if(stackp2==stacke2) add_memory_ds2();
-	*(stackp2++)=lp;
+    for(int *k=ds2+sc2;k<stackp2;k++) if(*k==lp) return;
+    if(stackp2==stacke2) add_memory_ds2();
+    *(stackp2++)=lp;
 }
 
 /** Assuming that the point up is outside the cutting plane, this routine
@@ -478,233 +478,233 @@ inline void voronoicell_base::add_to_stack(int sc2,int lp) {
  * \param[in,out] u the dot product of point up with the normal.
  * \return True if the cutting plane was reached, false otherwise. */
 inline bool voronoicell_base::search_upward(unsigned int &uw,int &lp,int &ls,int &us,double &l,double &u) {
-	int vs;
-	lp=up;l=u;
+    int vs;
+    lp=up;l=u;
 
-	// The test point is outside of the cutting space
-	for(ls=0;ls<nu[lp];ls++) {
-		up=ed[lp][ls];
-		uw=m_test(up,u);
-		if(u>l) break;
-	}
-	if(ls==nu[lp]) if(definite_max(lp,ls,l,u,uw)) {
-		up=lp;
-		return false;
-	}
+    // The test point is outside of the cutting space
+    for(ls=0;ls<nu[lp];ls++) {
+        up=ed[lp][ls];
+        uw=m_test(up,u);
+        if(u>l) break;
+    }
+    if(ls==nu[lp]) if(definite_max(lp,ls,l,u,uw)) {
+        up=lp;
+        return false;
+    }
 
-	while(uw==0) {
-		//if(++count>=p) failsafe_find(lp,ls,us,l,u);
+    while(uw==0) {
+        //if(++count>=p) failsafe_find(lp,ls,us,l,u);
 
-		// Test all the neighbors of the current point
-		// and find the one which is closest to the
-		// plane
-		vs=ed[lp][nu[lp]+ls];lp=up;l=u;
-		for(ls=0;ls<nu[lp];ls++) {
-			if(ls==vs) continue;
-			up=ed[lp][ls];
-			uw=m_test(up,u);
-			if(u>l) break;
-		}
-		if(ls==nu[lp]&&definite_max(lp,ls,l,u,uw)) {
-			up=lp;
-			return false;
-		}
-	}
-	us=ed[lp][nu[lp]+ls];
-	return true;
+        // Test all the neighbors of the current point
+        // and find the one which is closest to the
+        // plane
+        vs=ed[lp][nu[lp]+ls];lp=up;l=u;
+        for(ls=0;ls<nu[lp];ls++) {
+            if(ls==vs) continue;
+            up=ed[lp][ls];
+            uw=m_test(up,u);
+            if(u>l) break;
+        }
+        if(ls==nu[lp]&&definite_max(lp,ls,l,u,uw)) {
+            up=lp;
+            return false;
+        }
+    }
+    us=ed[lp][nu[lp]+ls];
+    return true;
 }
 
 /** Checks whether a particular point lp is a definite maximum, searching
  * through any possible minor non-convexities, for a better maximum.
  * \param[in] (x,y,z) the normal vector to the plane. */
 bool voronoicell_base::definite_max(int &lp,int &ls,double &l,double &u,unsigned int &uw) {
-	int tp=lp,ts,qp=0;
-	unsigned int qw;
-	double q;
+    int tp=lp,ts,qp=0;
+    unsigned int qw;
+    double q;
 
-	// Check to see whether point up is a well-defined maximum. Otherwise
-	// any neighboring vertices of up that are marginal need to be
-	// followed, to see if they lead to a better maximum.
-	for(ts=0;ts<nu[tp];ts++) {
-		qp=ed[tp][ts];
-		m_test(qp,q);
-		if(q>l-big_tol) break;
-	}
-	if(ts==nu[tp]) return true;
+    // Check to see whether point up is a well-defined maximum. Otherwise
+    // any neighboring vertices of up that are marginal need to be
+    // followed, to see if they lead to a better maximum.
+    for(ts=0;ts<nu[tp];ts++) {
+        qp=ed[tp][ts];
+        m_test(qp,q);
+        if(q>l-big_tol) break;
+    }
+    if(ts==nu[tp]) return true;
 
-	// The point tp is marginal, so it will be necessary to do the
-	// flood-fill search. Mark the point tp and the point qp, and search
-	// any remaining neighbors of the point tp.
-	int *stackp=ds+1;
-	flip(lp);
-	flip(qp);
-	*ds=qp;
-	ts++;
-	while(ts<nu[tp]) {
-		qp=ed[tp][ts];
-		m_test(qp,q);
-		if(q>l-big_tol) {
-			if(stackp==stacke) add_memory_ds();
-			*(stackp++)=up;
-			flip(up);
-		}
-		ts++;
-	}
+    // The point tp is marginal, so it will be necessary to do the
+    // flood-fill search. Mark the point tp and the point qp, and search
+    // any remaining neighbors of the point tp.
+    int *stackp=ds+1;
+    flip(lp);
+    flip(qp);
+    *ds=qp;
+    ts++;
+    while(ts<nu[tp]) {
+        qp=ed[tp][ts];
+        m_test(qp,q);
+        if(q>l-big_tol) {
+            if(stackp==stacke) add_memory_ds();
+            *(stackp++)=up;
+            flip(up);
+        }
+        ts++;
+    }
 
-	// Consider additional marginal points, starting with the original
-	// point qp
-	int *spp=ds;
-	while(spp<stackp) {
-		tp=*(spp++);
-		for(ts=0;ts<nu[tp];ts++) {
-			qp=ed[tp][ts];
+    // Consider additional marginal points, starting with the original
+    // point qp
+    int *spp=ds;
+    while(spp<stackp) {
+        tp=*(spp++);
+        for(ts=0;ts<nu[tp];ts++) {
+            qp=ed[tp][ts];
 
-			// Skip the point if it's already marked
-			if(ed[qp][nu[qp]<<1]<0) continue;
-			qw=m_test(qp,q);
+            // Skip the point if it's already marked
+            if(ed[qp][nu[qp]<<1]<0) continue;
+            qw=m_test(qp,q);
 
-			// This point is a better maximum. Reset markers and
-			// return true.
-			if(q>l) {
-				flip(lp);
-				lp=tp;
-				ls=ts;
-				m_test(lp,l);
-				up=qp;
-				uw=qw;
-				u=q;
-				while(stackp>ds) flip(*(--stackp));
-				return false;
-			}
+            // This point is a better maximum. Reset markers and
+            // return true.
+            if(q>l) {
+                flip(lp);
+                lp=tp;
+                ls=ts;
+                m_test(lp,l);
+                up=qp;
+                uw=qw;
+                u=q;
+                while(stackp>ds) flip(*(--stackp));
+                return false;
+            }
 
-			// The point is marginal and therefore must also be
-			// considered
-			if(q>l-big_tol) {
-				if(stackp==stacke) {
-					int nn=stackp-spp;
-					add_memory_ds();
-					spp=stackp-nn;
-				}
-				*(stackp++)=qp;
-				flip(qp);
-			}
-		}
-	}
+            // The point is marginal and therefore must also be
+            // considered
+            if(q>l-big_tol) {
+                if(stackp==stacke) {
+                    int nn=stackp-spp;
+                    add_memory_ds();
+                    spp=stackp-nn;
+                }
+                *(stackp++)=qp;
+                flip(qp);
+            }
+        }
+    }
 
-	// Reset markers and return false
-	flip(lp);
-	while(stackp>ds) flip(*(--stackp));
-	return true;
+    // Reset markers and return false
+    flip(lp);
+    while(stackp>ds) flip(*(--stackp));
+    return true;
 }
 
 inline bool voronoicell_base::search_downward(unsigned int &lw,int &lp,int &ls,int &us,double &l,double &u) {
-	int vs;
+    int vs;
 
-	// The test point is outside of the cutting space
-	for(us=0;us<nu[up];us++) {
-		lp=ed[up][us];
-		lw=m_test(lp,l);
-		if(u>l) break;
-	}
-	if(us==nu[up]) if(definite_min(lp,us,l,u,lw)) return false;
+    // The test point is outside of the cutting space
+    for(us=0;us<nu[up];us++) {
+        lp=ed[up][us];
+        lw=m_test(lp,l);
+        if(u>l) break;
+    }
+    if(us==nu[up]) if(definite_min(lp,us,l,u,lw)) return false;
 
-	while(lw==2) {
-		//if(++count>=p) failsafe_find(lp,ls,us,l,u);
+    while(lw==2) {
+        //if(++count>=p) failsafe_find(lp,ls,us,l,u);
 
-		// Test all the neighbors of the current point
-		// and find the one which is closest to the
-		// plane
-		vs=ed[up][nu[up]+us];up=lp;u=l;
-		for(us=0;us<nu[up];us++) {
-			if(us==vs) continue;
-			lp=ed[up][us];
-			lw=m_test(lp,l);
-			if(u>l) break;
-		}
-		if(us==nu[up]&&definite_min(lp,us,l,u,lw)) return false;
-	}
-	ls=ed[up][nu[up]+us];
-	return true;
+        // Test all the neighbors of the current point
+        // and find the one which is closest to the
+        // plane
+        vs=ed[up][nu[up]+us];up=lp;u=l;
+        for(us=0;us<nu[up];us++) {
+            if(us==vs) continue;
+            lp=ed[up][us];
+            lw=m_test(lp,l);
+            if(u>l) break;
+        }
+        if(us==nu[up]&&definite_min(lp,us,l,u,lw)) return false;
+    }
+    ls=ed[up][nu[up]+us];
+    return true;
 }
 
 bool voronoicell_base::definite_min(int &lp,int &us,double &l,double &u,unsigned int &lw) {
-	int tp=up,ts,qp=0;
-	unsigned int qw;
-	double q;
+    int tp=up,ts,qp=0;
+    unsigned int qw;
+    double q;
 
-	// Check to see whether point up is a well-defined maximum. Otherwise
-	// any neighboring vertices of up that are marginal need to be
-	// followed, to see if they lead to a better maximum.
-	for(ts=0;ts<nu[tp];ts++) {
-		qp=ed[tp][ts];
-		m_test(qp,q);
-		if(q<u+big_tol) break;
-	}
-	if(ts==nu[tp]) return true;
+    // Check to see whether point up is a well-defined maximum. Otherwise
+    // any neighboring vertices of up that are marginal need to be
+    // followed, to see if they lead to a better maximum.
+    for(ts=0;ts<nu[tp];ts++) {
+        qp=ed[tp][ts];
+        m_test(qp,q);
+        if(q<u+big_tol) break;
+    }
+    if(ts==nu[tp]) return true;
 
-	// The point tp is marginal, so it will be necessary to do the
-	// flood-fill search. Mark the point tp and the point qp, and search
-	// any remaining neighbors of the point tp.
-	int *stackp=ds+1;
-	flip(up);
-	flip(qp);
-	*ds=qp;
-	ts++;
-	while(ts<nu[tp]) {
-		qp=ed[tp][ts];
-		m_test(qp,q);
-		if(q<u+big_tol) {
-			if(stackp==stacke) add_memory_ds();
-			*(stackp++)=lp;
-			flip(lp);
-		}
-		ts++;
-	}
+    // The point tp is marginal, so it will be necessary to do the
+    // flood-fill search. Mark the point tp and the point qp, and search
+    // any remaining neighbors of the point tp.
+    int *stackp=ds+1;
+    flip(up);
+    flip(qp);
+    *ds=qp;
+    ts++;
+    while(ts<nu[tp]) {
+        qp=ed[tp][ts];
+        m_test(qp,q);
+        if(q<u+big_tol) {
+            if(stackp==stacke) add_memory_ds();
+            *(stackp++)=lp;
+            flip(lp);
+        }
+        ts++;
+    }
 
-	// Consider additional marginal points, starting with the original
-	// point qp
-	int *spp=ds;
-	while(spp<stackp) {
-		tp=*(spp++);
-		for(ts=0;ts<nu[tp];ts++) {
-			qp=ed[tp][ts];
+    // Consider additional marginal points, starting with the original
+    // point qp
+    int *spp=ds;
+    while(spp<stackp) {
+        tp=*(spp++);
+        for(ts=0;ts<nu[tp];ts++) {
+            qp=ed[tp][ts];
 
-			// Skip the point if it's already marked
-			if(ed[qp][nu[qp]<<1]<0) continue;
-			qw=m_test(qp,q);
+            // Skip the point if it's already marked
+            if(ed[qp][nu[qp]<<1]<0) continue;
+            qw=m_test(qp,q);
 
-			// This point is a better minimum. Reset markers and
-			// return true.
-			if(q<u) {
-				flip(up);
-				up=tp;
-				us=ts;
-				m_test(up,u);
-				lp=qp;
-				lw=qw;
-				l=q;
-				while(stackp>ds) flip(*(--stackp));
-				return false;
-			}
+            // This point is a better minimum. Reset markers and
+            // return true.
+            if(q<u) {
+                flip(up);
+                up=tp;
+                us=ts;
+                m_test(up,u);
+                lp=qp;
+                lw=qw;
+                l=q;
+                while(stackp>ds) flip(*(--stackp));
+                return false;
+            }
 
-			// The point is marginal and therefore must also be
-			// considered
-			if(q<u+big_tol) {
-				if(stackp==stacke) {
-					int nn=stackp-spp;
-					add_memory_ds();
-					spp=stackp-nn;
-				}
-				*(stackp++)=qp;
-				flip(qp);
-			}
-		}
-	}
+            // The point is marginal and therefore must also be
+            // considered
+            if(q<u+big_tol) {
+                if(stackp==stacke) {
+                    int nn=stackp-spp;
+                    add_memory_ds();
+                    spp=stackp-nn;
+                }
+                *(stackp++)=qp;
+                flip(qp);
+            }
+        }
+    }
 
-	// Reset markers and return false
-	flip(up);
-	while(stackp>ds) flip(*(--stackp));
-	return true;
+    // Reset markers and return false
+    flip(up);
+    while(stackp>ds) flip(*(--stackp));
+    return true;
 }
 
 /** Cuts the Voronoi cell by a particle whose center is at a separation of
@@ -717,650 +717,650 @@ bool voronoicell_base::definite_min(int &lp,int &us,double &l,double &u,unsigned
  * \return False if the plane cut deleted the cell entirely, true otherwise. */
 template<class vc_class>
 bool voronoicell_base::nplane(vc_class &vc,double x,double y,double z,double rsq,int p_id) {
-	int i,j,lp=up,cp,qp,*dsp;
-	int us=0,ls=0;
-	unsigned int uw,lw;
-	int *edp,*edd;stackp=ds;
-	double u,l=0;up=0;
+    int i,j,lp=up,cp,qp,*dsp;
+    int us=0,ls=0;
+    unsigned int uw,lw;
+    int *edp,*edd;stackp=ds;
+    double u,l=0;up=0;
 
-	// Initialize the safe testing routine
-	px=x;py=y;pz=z;prsq=rsq;
-	maskc+=4;
-	if(maskc<4) reset_mask();
+    // Initialize the safe testing routine
+    px=x;py=y;pz=z;prsq=rsq;
+    maskc+=4;
+    if(maskc<4) reset_mask();
 
-	uw=m_test(up,u);
-	if(uw==2) {
-		if(!search_downward(lw,lp,ls,us,l,u)) return false;
-		if(lw==1) {up=lp;lp=-1;}
-	} else if(uw==0) {
-		if(!search_upward(uw,lp,ls,us,l,u)) return true;
-		if(uw==1) lp=-1;
-	} else {
-		lp=-1;
-	}
+    uw=m_test(up,u);
+    if(uw==2) {
+        if(!search_downward(lw,lp,ls,us,l,u)) return false;
+        if(lw==1) {up=lp;lp=-1;}
+    } else if(uw==0) {
+        if(!search_upward(uw,lp,ls,us,l,u)) return true;
+        if(uw==1) lp=-1;
+    } else {
+        lp=-1;
+    }
 
-	// Set stack pointers
-	stackp=ds;stackp2=ds2;stackp3=xse;
+    // Set stack pointers
+    stackp=ds;stackp2=ds2;stackp3=xse;
 
-	// Store initial number of vertices
-	int op=p;
+    // Store initial number of vertices
+    int op=p;
 
-	if(create_facet(vc,lp,ls,l,us,u,p_id)) return false;
-	int k=0;int xtra=0;
-	while(xse+k<stackp3) {
-		lp=xse[k++];
-		uw=m_test(lp,l);
-		for(ls=0;ls<nu[lp];ls++) {
-			up=ed[lp][ls];
+    if(create_facet(vc,lp,ls,l,us,u,p_id)) return false;
+    int k=0;int xtra=0;
+    while(xse+k<stackp3) {
+        lp=xse[k++];
+        uw=m_test(lp,l);
+        for(ls=0;ls<nu[lp];ls++) {
+            up=ed[lp][ls];
 
-			// Skip if this is a new vertex
-			uw=m_test(up,u);
-			if(up>=op) continue;
+            // Skip if this is a new vertex
+            uw=m_test(up,u);
+            if(up>=op) continue;
 
-			if(uw==0) {
-				if(u>-big_tol&&ed[up][nu[up]<<1]!=-1) {
-					ed[up][nu[up]<<1]=-1;
-					if(stackp3==stacke3) add_memory_xse();
-					*(stackp3++)=up;
-				}
-			} else if(uw==1) {
+            if(uw==0) {
+                if(u>-big_tol&&ed[up][nu[up]<<1]!=-1) {
+                    ed[up][nu[up]<<1]=-1;
+                    if(stackp3==stacke3) add_memory_xse();
+                    *(stackp3++)=up;
+                }
+            } else if(uw==1) {
 
-				// This is a possible facet starting
-				// from a vertex on the cutting plane
-				if(create_facet(vc,-1,0,0,0,u,p_id)) return false;
-			} else {
+                // This is a possible facet starting
+                // from a vertex on the cutting plane
+                if(create_facet(vc,-1,0,0,0,u,p_id)) return false;
+            } else {
 
-				// This is a new facet
-				us=ed[lp][nu[lp]+ls];
-				m_test(lp,l);
-				if(create_facet(vc,lp,ls,l,us,u,p_id)) return false;
-			}
-		}
-		xtra++;
-	}
+                // This is a new facet
+                us=ed[lp][nu[lp]+ls];
+                m_test(lp,l);
+                if(create_facet(vc,lp,ls,l,us,u,p_id)) return false;
+            }
+        }
+        xtra++;
+    }
 
-	// Reset back pointers on extra search stack
-	for(dsp=xse;dsp<stackp3;dsp++) {
-		j=*dsp;
-		ed[j][nu[j]<<1]=j;
-	}
+    // Reset back pointers on extra search stack
+    for(dsp=xse;dsp<stackp3;dsp++) {
+        j=*dsp;
+        ed[j][nu[j]<<1]=j;
+    }
 
-	// Delete points: first, remove any duplicates
-	dsp=ds;
-	while(dsp<stackp) {
-		j=*dsp;
-		if(ed[j][nu[j]]!=-1) {
-			ed[j][nu[j]]=-1;
-			dsp++;
-		} else *dsp=*(--stackp);
-	}
+    // Delete points: first, remove any duplicates
+    dsp=ds;
+    while(dsp<stackp) {
+        j=*dsp;
+        if(ed[j][nu[j]]!=-1) {
+            ed[j][nu[j]]=-1;
+            dsp++;
+        } else *dsp=*(--stackp);
+    }
 
-	// Add the points in the auxiliary delete stack,
-	// and reset their back pointers
-	for(dsp=ds2;dsp<stackp2;dsp++) {
-		j=*dsp;
-		ed[j][nu[j]<<1]=j;
-		if(ed[j][nu[j]]!=-1) {
-			ed[j][nu[j]]=-1;
-			if(stackp==stacke) add_memory_ds();
-			*(stackp++)=j;
-		}
-	}
+    // Add the points in the auxiliary delete stack,
+    // and reset their back pointers
+    for(dsp=ds2;dsp<stackp2;dsp++) {
+        j=*dsp;
+        ed[j][nu[j]<<1]=j;
+        if(ed[j][nu[j]]!=-1) {
+            ed[j][nu[j]]=-1;
+            if(stackp==stacke) add_memory_ds();
+            *(stackp++)=j;
+        }
+    }
 
-	// Scan connections and add in extras
-	for(dsp=ds;dsp<stackp;dsp++) {
-		cp=*dsp;
-		for(edp=ed[cp];edp<ed[cp]+nu[cp];edp++) {
-			qp=*edp;
-			if(qp!=-1&&ed[qp][nu[qp]]!=-1) {
-				if(stackp==stacke) {
-					int dis=stackp-dsp;
-					add_memory_ds();
-					dsp=ds+dis;
-				}
-				*(stackp++)=qp;
-				ed[qp][nu[qp]]=-1;
-			}
-		}
-	}
-	up=0;
+    // Scan connections and add in extras
+    for(dsp=ds;dsp<stackp;dsp++) {
+        cp=*dsp;
+        for(edp=ed[cp];edp<ed[cp]+nu[cp];edp++) {
+            qp=*edp;
+            if(qp!=-1&&ed[qp][nu[qp]]!=-1) {
+                if(stackp==stacke) {
+                    int dis=stackp-dsp;
+                    add_memory_ds();
+                    dsp=ds+dis;
+                }
+                *(stackp++)=qp;
+                ed[qp][nu[qp]]=-1;
+            }
+        }
+    }
+    up=0;
 
-	// Delete them from the array structure
-	while(stackp>ds) {
-		--p;
-		while(ed[p][nu[p]]==-1) {
-			j=nu[p];
-			edp=ed[p];edd=(mep[j]+((j<<1)+1)*--mec[j]);
-			while(edp<ed[p]+(j<<1)+1) *(edp++)=*(edd++);
-			vc.n_set_aux2_copy(p,j);
-			vc.n_copy_pointer(ed[p][(j<<1)],p);
-			ed[ed[p][(j<<1)]]=ed[p];
-			--p;
-		}
-		up=*(--stackp);
-		if(up<p) {
+    // Delete them from the array structure
+    while(stackp>ds) {
+        --p;
+        while(ed[p][nu[p]]==-1) {
+            j=nu[p];
+            edp=ed[p];edd=(mep[j]+((j<<1)+1)*--mec[j]);
+            while(edp<ed[p]+(j<<1)+1) *(edp++)=*(edd++);
+            vc.n_set_aux2_copy(p,j);
+            vc.n_copy_pointer(ed[p][(j<<1)],p);
+            ed[ed[p][(j<<1)]]=ed[p];
+            --p;
+        }
+        up=*(--stackp);
+        if(up<p) {
 
-			// Vertex management
-			pts[(up<<2)]=pts[(p<<2)];
-			pts[(up<<2)+1]=pts[(p<<2)+1];
-			pts[(up<<2)+2]=pts[(p<<2)+2];
+            // Vertex management
+            pts[(up<<2)]=pts[(p<<2)];
+            pts[(up<<2)+1]=pts[(p<<2)+1];
+            pts[(up<<2)+2]=pts[(p<<2)+2];
 
-			// Memory management
-			j=nu[up];
-			edp=ed[up];edd=(mep[j]+((j<<1)+1)*--mec[j]);
-			while(edp<ed[up]+(j<<1)+1) *(edp++)=*(edd++);
-			vc.n_set_aux2_copy(up,j);
-			vc.n_copy_pointer(ed[up][j<<1],up);
-			vc.n_copy_pointer(up,p);
-			ed[ed[up][j<<1]]=ed[up];
+            // Memory management
+            j=nu[up];
+            edp=ed[up];edd=(mep[j]+((j<<1)+1)*--mec[j]);
+            while(edp<ed[up]+(j<<1)+1) *(edp++)=*(edd++);
+            vc.n_set_aux2_copy(up,j);
+            vc.n_copy_pointer(ed[up][j<<1],up);
+            vc.n_copy_pointer(up,p);
+            ed[ed[up][j<<1]]=ed[up];
 
-			// Edge management
-			ed[up]=ed[p];
-			nu[up]=nu[p];
-			for(i=0;i<nu[up];i++) ed[ed[up][i]][ed[up][nu[up]+i]]=up;
-			ed[up][nu[up]<<1]=up;
-		} else up=p++;
-	}
+            // Edge management
+            ed[up]=ed[p];
+            nu[up]=nu[p];
+            for(i=0;i<nu[up];i++) ed[ed[up][i]][ed[up][nu[up]+i]]=up;
+            ed[up][nu[up]<<1]=up;
+        } else up=p++;
+    }
 
-	// Check for any vertices of zero order
-	if(*mec>0) voro_fatal_error("Zero order vertex formed",VOROPP_INTERNAL_ERROR);
+    // Check for any vertices of zero order
+    if(*mec>0) voro_fatal_error("Zero order vertex formed",VOROPP_INTERNAL_ERROR);
 
-	// Collapse any order 2 vertices and exit
-	return collapse_order2(vc);
+    // Collapse any order 2 vertices and exit
+    return collapse_order2(vc);
 }
 
 /** Creates a new facet.
  * \return True if cell deleted, false otherwise. */
 template<class vc_class>
 bool voronoicell_base::create_facet(vc_class &vc,int lp,int ls,double l,int us,double u,int p_id) {
-	int i,j,k,qp,qs,iqs,cp,cs,rp,*edp,*edd;
-	unsigned int lw,qw;
-	bool new_double_edge=false,double_edge=false;
-	double q,r;
+    int i,j,k,qp,qs,iqs,cp,cs,rp,*edp,*edd;
+    unsigned int lw,qw;
+    bool new_double_edge=false,double_edge=false;
+    double q,r;
 
-	// We're about to add the first point of the new facet. In either
-	// routine, we have to add a point, so first check there's space for
-	// it.
-	if(p==current_vertices) add_memory_vertices(vc);
+    // We're about to add the first point of the new facet. In either
+    // routine, we have to add a point, so first check there's space for
+    // it.
+    if(p==current_vertices) add_memory_vertices(vc);
 
-	if(lp==-1) {
+    if(lp==-1) {
 
-		// We want to be strict about reaching the conclusion that the
-		// cell is entirely within the cutting plane. It's not enough
-		// to find a vertex that has edges which are all inside or on
-		// the plane. If the vertex has neighbors that are also on the
-		// plane, we should check those too.
-		if(!search_for_outside_edge(up)) return true;
+        // We want to be strict about reaching the conclusion that the
+        // cell is entirely within the cutting plane. It's not enough
+        // to find a vertex that has edges which are all inside or on
+        // the plane. If the vertex has neighbors that are also on the
+        // plane, we should check those too.
+        if(!search_for_outside_edge(up)) return true;
 
-		// The search algorithm found a point which is on the cutting
-		// plane. We leave that point in place, and create a new one at
-		// the same location.
-		pts[(p<<2)]=pts[(up<<2)];
-		pts[(p<<2)+1]=pts[(up<<2)+1];
-		pts[(p<<2)+2]=pts[(up<<2)+2];
+        // The search algorithm found a point which is on the cutting
+        // plane. We leave that point in place, and create a new one at
+        // the same location.
+        pts[(p<<2)]=pts[(up<<2)];
+        pts[(p<<2)+1]=pts[(up<<2)+1];
+        pts[(p<<2)+2]=pts[(up<<2)+2];
 
-		// Search for a collection of edges of the test vertex which
-		// are outside of the cutting space. Begin by testing the
-		// zeroth edge.
-		i=0;
-		lp=*ed[up];
-		lw=m_testx(lp,l);
-		if(lw!=0) {
+        // Search for a collection of edges of the test vertex which
+        // are outside of the cutting space. Begin by testing the
+        // zeroth edge.
+        i=0;
+        lp=*ed[up];
+        lw=m_testx(lp,l);
+        if(lw!=0) {
 
-			// The first edge is either inside the cutting space,
-			// or lies within the cutting plane. Test the edges
-			// sequentially until we find one that is outside.
-			unsigned int rw=lw;
-			do {
-				i++;
+            // The first edge is either inside the cutting space,
+            // or lies within the cutting plane. Test the edges
+            // sequentially until we find one that is outside.
+            unsigned int rw=lw;
+            do {
+                i++;
 
-				// If we reached the last edge with no luck
-				// then all of the vertices are inside
-				// or on the plane, so the cell is completely
-				// deleted
-				if(i==nu[up]) return true;
-				lp=ed[up][i];
-				lw=m_testx(lp,l);
-			} while (lw!=0);
-			j=i+1;
+                // If we reached the last edge with no luck
+                // then all of the vertices are inside
+                // or on the plane, so the cell is completely
+                // deleted
+                if(i==nu[up]) return true;
+                lp=ed[up][i];
+                lw=m_testx(lp,l);
+            } while (lw!=0);
+            j=i+1;
 
-			// We found an edge outside the cutting space. Keep
-			// moving through these edges until we find one that's
-			// inside or on the plane.
-			while(j<nu[up]) {
-				lp=ed[up][j];
-				lw=m_testx(lp,l);
-				if(lw!=0) break;
-				j++;
-			}
+            // We found an edge outside the cutting space. Keep
+            // moving through these edges until we find one that's
+            // inside or on the plane.
+            while(j<nu[up]) {
+                lp=ed[up][j];
+                lw=m_testx(lp,l);
+                if(lw!=0) break;
+                j++;
+            }
 
-			// Compute the number of edges for the new vertex. In
-			// general it will be the number of outside edges
-			// found, plus two. But we need to recognize the
-			// special case when all but one edge is outside, and
-			// the remaining one is on the plane. For that case we
-			// have to reduce the edge count by one to prevent
-			// doubling up.
-			if(j==nu[up]&&i==1&&rw==1) {
-				nu[p]=nu[up];
-				double_edge=true;
-			} else nu[p]=j-i+2;
-			k=1;
+            // Compute the number of edges for the new vertex. In
+            // general it will be the number of outside edges
+            // found, plus two. But we need to recognize the
+            // special case when all but one edge is outside, and
+            // the remaining one is on the plane. For that case we
+            // have to reduce the edge count by one to prevent
+            // doubling up.
+            if(j==nu[up]&&i==1&&rw==1) {
+                nu[p]=nu[up];
+                double_edge=true;
+            } else nu[p]=j-i+2;
+            k=1;
 
-			// Add memory for the new vertex if needed, and
-			// initialize
-			while (nu[p]>=current_vertex_order) add_memory_vorder(vc);
-			if(mec[nu[p]]==mem[nu[p]]) add_memory(vc,nu[p]);
-			vc.n_set_pointer(p,nu[p]);
-			ed[p]=mep[nu[p]]+((nu[p]<<1)+1)*mec[nu[p]]++;
-			ed[p][nu[p]<<1]=p;
+            // Add memory for the new vertex if needed, and
+            // initialize
+            while (nu[p]>=current_vertex_order) add_memory_vorder(vc);
+            if(mec[nu[p]]==mem[nu[p]]) add_memory(vc,nu[p]);
+            vc.n_set_pointer(p,nu[p]);
+            ed[p]=mep[nu[p]]+((nu[p]<<1)+1)*mec[nu[p]]++;
+            ed[p][nu[p]<<1]=p;
 
-			// Copy the edges of the original vertex into the new
-			// one. Delete the edges of the original vertex, and
-			// update the relational table.
-			us=cycle_down(i,up);
-			while(i<j) {
-				qp=ed[up][i];
-				qs=ed[up][nu[up]+i];
-				vc.n_copy(p,k,up,i);
-				ed[p][k]=qp;
-				ed[p][nu[p]+k]=qs;
-				ed[qp][qs]=p;
-				ed[qp][nu[qp]+qs]=k;
-				ed[up][i]=-1;
-				i++;k++;
-			}
-			qs=i==nu[up]?0:i;
-		} else {
+            // Copy the edges of the original vertex into the new
+            // one. Delete the edges of the original vertex, and
+            // update the relational table.
+            us=cycle_down(i,up);
+            while(i<j) {
+                qp=ed[up][i];
+                qs=ed[up][nu[up]+i];
+                vc.n_copy(p,k,up,i);
+                ed[p][k]=qp;
+                ed[p][nu[p]+k]=qs;
+                ed[qp][qs]=p;
+                ed[qp][nu[qp]+qs]=k;
+                ed[up][i]=-1;
+                i++;k++;
+            }
+            qs=i==nu[up]?0:i;
+        } else {
 
-			// In this case, the zeroth edge is outside the cutting
-			// plane. Begin by searching backwards from the last
-			// edge until we find an edge which isn't outside.
-			i=nu[up]-1;
-			lp=ed[up][i];
-			lw=m_testx(lp,l);
-			while(lw==0) {
-				i--;
+            // In this case, the zeroth edge is outside the cutting
+            // plane. Begin by searching backwards from the last
+            // edge until we find an edge which isn't outside.
+            i=nu[up]-1;
+            lp=ed[up][i];
+            lw=m_testx(lp,l);
+            while(lw==0) {
+                i--;
 
-				// If i reaches zero, then we have a point in
-				// the plane all of whose edges are outside
-				// the cutting space, so we just exit
-				if(i==0) return false;
-				lp=ed[up][i];
-				lw=m_testx(lp,l);
-			}
+                // If i reaches zero, then we have a point in
+                // the plane all of whose edges are outside
+                // the cutting space, so we just exit
+                if(i==0) return false;
+                lp=ed[up][i];
+                lw=m_testx(lp,l);
+            }
 
-			// Now search forwards from zero
-			j=1;
-			qp=ed[up][j];
-			qw=m_testx(qp,q);
-			while(qw==0) {
-				j++;
-				qp=ed[up][j];
-				qw=m_testx(qp,l);
-			}
+            // Now search forwards from zero
+            j=1;
+            qp=ed[up][j];
+            qw=m_testx(qp,q);
+            while(qw==0) {
+                j++;
+                qp=ed[up][j];
+                qw=m_testx(qp,l);
+            }
 
-			// Compute the number of edges for the new vertex. In
-			// general it will be the number of outside edges
-			// found, plus two. But we need to recognize the
-			// special case when all but one edge is outside, and
-			// the remaining one is on the plane. For that case we
-			// have to reduce the edge count by one to prevent
-			// doubling up.
-			if(i==j&&qw==1) {
-				double_edge=true;
-				nu[p]=nu[up];
-			} else {
-				nu[p]=nu[up]-i+j+1;
-			}
+            // Compute the number of edges for the new vertex. In
+            // general it will be the number of outside edges
+            // found, plus two. But we need to recognize the
+            // special case when all but one edge is outside, and
+            // the remaining one is on the plane. For that case we
+            // have to reduce the edge count by one to prevent
+            // doubling up.
+            if(i==j&&qw==1) {
+                double_edge=true;
+                nu[p]=nu[up];
+            } else {
+                nu[p]=nu[up]-i+j+1;
+            }
 
-			// Add memory to store the vertex if it doesn't exist
-			// already
-			k=1;
-			while(nu[p]>=current_vertex_order) add_memory_vorder(vc);
-			if(mec[nu[p]]==mem[nu[p]]) add_memory(vc,nu[p]);
+            // Add memory to store the vertex if it doesn't exist
+            // already
+            k=1;
+            while(nu[p]>=current_vertex_order) add_memory_vorder(vc);
+            if(mec[nu[p]]==mem[nu[p]]) add_memory(vc,nu[p]);
 
-			// Copy the edges of the original vertex into the new
-			// one. Delete the edges of the original vertex, and
-			// update the relational table.
-			vc.n_set_pointer(p,nu[p]);
-			ed[p]=mep[nu[p]]+((nu[p]<<1)+1)*mec[nu[p]]++;
-			ed[p][nu[p]<<1]=p;
-			us=i++;
-			while(i<nu[up]) {
-				qp=ed[up][i];
-				qs=ed[up][nu[up]+i];
-				vc.n_copy(p,k,up,i);
-				ed[p][k]=qp;
-				ed[p][nu[p]+k]=qs;
-				ed[qp][qs]=p;
-				ed[qp][nu[qp]+qs]=k;
-				ed[up][i]=-1;
-				i++;k++;
-			}
-			i=0;
-			while(i<j) {
-				qp=ed[up][i];
-				qs=ed[up][nu[up]+i];
-				vc.n_copy(p,k,up,i);
-				ed[p][k]=qp;
-				ed[p][nu[p]+k]=qs;
-				ed[qp][qs]=p;
-				ed[qp][nu[qp]+qs]=k;
-				ed[up][i]=-1;
-				i++;k++;
-			}
-			qs=j;
-		}
-		if(!double_edge) {
-			vc.n_copy(p,k,up,qs);
-			vc.n_set(p,0,p_id);
-		} else vc.n_copy(p,0,up,qs);
+            // Copy the edges of the original vertex into the new
+            // one. Delete the edges of the original vertex, and
+            // update the relational table.
+            vc.n_set_pointer(p,nu[p]);
+            ed[p]=mep[nu[p]]+((nu[p]<<1)+1)*mec[nu[p]]++;
+            ed[p][nu[p]<<1]=p;
+            us=i++;
+            while(i<nu[up]) {
+                qp=ed[up][i];
+                qs=ed[up][nu[up]+i];
+                vc.n_copy(p,k,up,i);
+                ed[p][k]=qp;
+                ed[p][nu[p]+k]=qs;
+                ed[qp][qs]=p;
+                ed[qp][nu[qp]+qs]=k;
+                ed[up][i]=-1;
+                i++;k++;
+            }
+            i=0;
+            while(i<j) {
+                qp=ed[up][i];
+                qs=ed[up][nu[up]+i];
+                vc.n_copy(p,k,up,i);
+                ed[p][k]=qp;
+                ed[p][nu[p]+k]=qs;
+                ed[qp][qs]=p;
+                ed[qp][nu[qp]+qs]=k;
+                ed[up][i]=-1;
+                i++;k++;
+            }
+            qs=j;
+        }
+        if(!double_edge) {
+            vc.n_copy(p,k,up,qs);
+            vc.n_set(p,0,p_id);
+        } else vc.n_copy(p,0,up,qs);
 
-		// Add this point to the auxiliary delete stack
-		if(stackp2==stacke2) add_memory_ds2();
-		*(stackp2++)=up;
+        // Add this point to the auxiliary delete stack
+        if(stackp2==stacke2) add_memory_ds2();
+        *(stackp2++)=up;
 
-		// Look at the edges on either side of the group that was
-		// detected. We're going to commence facet computation by
-		// moving along one of them. We are going to end up coming back
-		// along the other one.
-		cs=k;
-		qp=up;q=u;
-		i=ed[up][us];
-		us=ed[up][nu[up]+us];
-		up=i;
-		ed[qp][nu[qp]<<1]=-p;
+        // Look at the edges on either side of the group that was
+        // detected. We're going to commence facet computation by
+        // moving along one of them. We are going to end up coming back
+        // along the other one.
+        cs=k;
+        qp=up;q=u;
+        i=ed[up][us];
+        us=ed[up][nu[up]+us];
+        up=i;
+        ed[qp][nu[qp]<<1]=-p;
 
-	} else {
+    } else {
 
-		// The search algorithm found an intersected edge between the
-		// points lp and up. Create a new vertex between them which
-		// lies on the cutting plane. Since u and l differ by at least
-		// the tolerance, this division should never screw up.
-		if(stackp==stacke) add_memory_ds();
-		*(stackp++)=up;
-		r=u/(u-l);l=1-r;
-		pts[p<<2]=pts[lp<<2]*r+pts[up<<2]*l;
-		pts[(p<<2)+1]=pts[(lp<<2)+1]*r+pts[(up<<2)+1]*l;
-		pts[(p<<2)+2]=pts[(lp<<2)+2]*r+pts[(up<<2)+2]*l;
+        // The search algorithm found an intersected edge between the
+        // points lp and up. Create a new vertex between them which
+        // lies on the cutting plane. Since u and l differ by at least
+        // the tolerance, this division should never screw up.
+        if(stackp==stacke) add_memory_ds();
+        *(stackp++)=up;
+        r=u/(u-l);l=1-r;
+        pts[p<<2]=pts[lp<<2]*r+pts[up<<2]*l;
+        pts[(p<<2)+1]=pts[(lp<<2)+1]*r+pts[(up<<2)+1]*l;
+        pts[(p<<2)+2]=pts[(lp<<2)+2]*r+pts[(up<<2)+2]*l;
 
-		// This point will always have three edges. Connect one of them
-		// to lp.
-		nu[p]=3;
-		if(mec[3]==mem[3]) add_memory(vc,3);
-		vc.n_set_pointer(p,3);
-		vc.n_set(p,0,p_id);
-		vc.n_copy(p,1,up,us);
-		vc.n_copy(p,2,lp,ls);
-		ed[p]=mep[3]+7*mec[3]++;
-		ed[p][6]=p;
-		ed[up][us]=-1;
-		ed[lp][ls]=p;
-		ed[lp][nu[lp]+ls]=1;
-		ed[p][1]=lp;
-		ed[p][nu[p]+1]=ls;
-		cs=2;
+        // This point will always have three edges. Connect one of them
+        // to lp.
+        nu[p]=3;
+        if(mec[3]==mem[3]) add_memory(vc,3);
+        vc.n_set_pointer(p,3);
+        vc.n_set(p,0,p_id);
+        vc.n_copy(p,1,up,us);
+        vc.n_copy(p,2,lp,ls);
+        ed[p]=mep[3]+7*mec[3]++;
+        ed[p][6]=p;
+        ed[up][us]=-1;
+        ed[lp][ls]=p;
+        ed[lp][nu[lp]+ls]=1;
+        ed[p][1]=lp;
+        ed[p][nu[p]+1]=ls;
+        cs=2;
 
-		// Set the direction to move in
-		qs=cycle_up(us,up);
-		qp=up;q=u;
-	}
+        // Set the direction to move in
+        qs=cycle_up(us,up);
+        qp=up;q=u;
+    }
 
-	// When the code reaches here, we have initialized the first point, and
-	// we have a direction for moving it to construct the rest of the facet
-	cp=p;rp=p;p++;
-	while(qp!=up||qs!=us) {
+    // When the code reaches here, we have initialized the first point, and
+    // we have a direction for moving it to construct the rest of the facet
+    cp=p;rp=p;p++;
+    while(qp!=up||qs!=us) {
 
-		// We're currently tracing round an intersected facet. Keep
-		// moving around it until we find a point or edge which
-		// intersects the plane.
-		lp=ed[qp][qs];
-		lw=m_testx(lp,l);
+        // We're currently tracing round an intersected facet. Keep
+        // moving around it until we find a point or edge which
+        // intersects the plane.
+        lp=ed[qp][qs];
+        lw=m_testx(lp,l);
 
-		if(lw==2) {
+        if(lw==2) {
 
-			// The point is still in the cutting space. Just add it
-			// to the delete stack and keep moving.
-			qs=cycle_up(ed[qp][nu[qp]+qs],lp);
-			qp=lp;
-			q=l;
-			if(stackp==stacke) add_memory_ds();
-			*(stackp++)=qp;
+            // The point is still in the cutting space. Just add it
+            // to the delete stack and keep moving.
+            qs=cycle_up(ed[qp][nu[qp]+qs],lp);
+            qp=lp;
+            q=l;
+            if(stackp==stacke) add_memory_ds();
+            *(stackp++)=qp;
 
-		} else if(lw==0) {
+        } else if(lw==0) {
 
-			// The point is outside of the cutting space, so we've
-			// found an intersected edge. Introduce a regular point
-			// at the point of intersection. Connect it to the
-			// point we just tested. Also connect it to the previous
-			// new point in the facet we're constructing.
-			if(p==current_vertices) add_memory_vertices(vc);
-			r=q/(q-l);l=1-r;
-			pts[p<<2]=pts[lp<<2]*r+pts[qp<<2]*l;
-			pts[(p<<2)+1]=pts[(lp<<2)+1]*r+pts[(qp<<2)+1]*l;
-			pts[(p<<2)+2]=pts[(lp<<2)+2]*r+pts[(qp<<2)+2]*l;
-			nu[p]=3;
-			if(mec[3]==mem[3]) add_memory(vc,3);
-			ls=ed[qp][qs+nu[qp]];
-			vc.n_set_pointer(p,3);
-			vc.n_set(p,0,p_id);
-			vc.n_copy(p,1,qp,qs);
-			vc.n_copy(p,2,lp,ls);
-			ed[p]=mep[3]+7*mec[3]++;
-			*ed[p]=cp;
-			ed[p][1]=lp;
-			ed[p][3]=cs;
-			ed[p][4]=ls;
-			ed[p][6]=p;
-			ed[lp][ls]=p;
-			ed[lp][nu[lp]+ls]=1;
-			ed[cp][cs]=p;
-			ed[cp][nu[cp]+cs]=0;
-			ed[qp][qs]=-1;
-			qs=cycle_up(qs,qp);
-			cp=p++;
-			cs=2;
-		} else {
+            // The point is outside of the cutting space, so we've
+            // found an intersected edge. Introduce a regular point
+            // at the point of intersection. Connect it to the
+            // point we just tested. Also connect it to the previous
+            // new point in the facet we're constructing.
+            if(p==current_vertices) add_memory_vertices(vc);
+            r=q/(q-l);l=1-r;
+            pts[p<<2]=pts[lp<<2]*r+pts[qp<<2]*l;
+            pts[(p<<2)+1]=pts[(lp<<2)+1]*r+pts[(qp<<2)+1]*l;
+            pts[(p<<2)+2]=pts[(lp<<2)+2]*r+pts[(qp<<2)+2]*l;
+            nu[p]=3;
+            if(mec[3]==mem[3]) add_memory(vc,3);
+            ls=ed[qp][qs+nu[qp]];
+            vc.n_set_pointer(p,3);
+            vc.n_set(p,0,p_id);
+            vc.n_copy(p,1,qp,qs);
+            vc.n_copy(p,2,lp,ls);
+            ed[p]=mep[3]+7*mec[3]++;
+            *ed[p]=cp;
+            ed[p][1]=lp;
+            ed[p][3]=cs;
+            ed[p][4]=ls;
+            ed[p][6]=p;
+            ed[lp][ls]=p;
+            ed[lp][nu[lp]+ls]=1;
+            ed[cp][cs]=p;
+            ed[cp][nu[cp]+cs]=0;
+            ed[qp][qs]=-1;
+            qs=cycle_up(qs,qp);
+            cp=p++;
+            cs=2;
+        } else {
 
-			// We've found a point which is on the cutting plane.
-			// We're going to introduce a new point right here, but
-			// first we need to figure out the number of edges it
-			// has.
-			if(p==current_vertices) add_memory_vertices(vc);
+            // We've found a point which is on the cutting plane.
+            // We're going to introduce a new point right here, but
+            // first we need to figure out the number of edges it
+            // has.
+            if(p==current_vertices) add_memory_vertices(vc);
 
-			// If the previous vertex detected a double edge, our
-			// new vertex will have one less edge.
-			k=double_edge?0:1;
-			qs=ed[qp][nu[qp]+qs];
-			qp=lp;
-			iqs=qs;
+            // If the previous vertex detected a double edge, our
+            // new vertex will have one less edge.
+            k=double_edge?0:1;
+            qs=ed[qp][nu[qp]+qs];
+            qp=lp;
+            iqs=qs;
 
-			// Start testing the edges of the current point until
-			// we find one which isn't outside the cutting space
-			do {
-				k++;
-				qs=cycle_up(qs,qp);
-				lp=ed[qp][qs];
-				lw=m_testx(lp,l);
-			} while (lw==0);
+            // Start testing the edges of the current point until
+            // we find one which isn't outside the cutting space
+            do {
+                k++;
+                qs=cycle_up(qs,qp);
+                lp=ed[qp][qs];
+                lw=m_testx(lp,l);
+            } while (lw==0);
 
-			// Now we need to find out whether this marginal vertex
-			// we are on has been visited before, because if that's
-			// the case, we need to add vertices to the existing
-			// new vertex, rather than creating a fresh one. We also
-			// need to figure out whether we're in a case where we
-			// might be creating a duplicate edge.
-			j=-ed[qp][nu[qp]<<1];
-	 		if(qp==up&&qs==us) {
+            // Now we need to find out whether this marginal vertex
+            // we are on has been visited before, because if that's
+            // the case, we need to add vertices to the existing
+            // new vertex, rather than creating a fresh one. We also
+            // need to figure out whether we're in a case where we
+            // might be creating a duplicate edge.
+            j=-ed[qp][nu[qp]<<1];
+            if(qp==up&&qs==us) {
 
-				// If we're heading into the final part of the
-				// new facet, then we never worry about the
-				// duplicate edge calculation.
-				new_double_edge=false;
-				if(j>0) k+=nu[j];
-			} else {
-				if(j>0) {
+                // If we're heading into the final part of the
+                // new facet, then we never worry about the
+                // duplicate edge calculation.
+                new_double_edge=false;
+                if(j>0) k+=nu[j];
+            } else {
+                if(j>0) {
 
-					// This vertex was visited before, so
-					// count those vertices to the ones we
-					// already have.
-					k+=nu[j];
+                    // This vertex was visited before, so
+                    // count those vertices to the ones we
+                    // already have.
+                    k+=nu[j];
 
-					// The only time when we might make a
-					// duplicate edge is if the point we're
-					// going to move to next is also a
-					// marginal point, so test for that
-					// first.
-					if(lw==1) {
+                    // The only time when we might make a
+                    // duplicate edge is if the point we're
+                    // going to move to next is also a
+                    // marginal point, so test for that
+                    // first.
+                    if(lw==1) {
 
-						// Now see whether this marginal point
-						// has been visited before.
-						i=-ed[lp][nu[lp]<<1];
-						if(i>0) {
+                        // Now see whether this marginal point
+                        // has been visited before.
+                        i=-ed[lp][nu[lp]<<1];
+                        if(i>0) {
 
-							// Now see if the last edge of that other
-							// marginal point actually ends up here.
-							if(ed[i][nu[i]-1]==j) {
-								new_double_edge=true;
-								k-=1;
-							} else new_double_edge=false;
-						} else {
+                            // Now see if the last edge of that other
+                            // marginal point actually ends up here.
+                            if(ed[i][nu[i]-1]==j) {
+                                new_double_edge=true;
+                                k-=1;
+                            } else new_double_edge=false;
+                        } else {
 
-							// That marginal point hasn't been visited
-							// before, so we probably don't have to worry
-							// about duplicate edges, except in the
-							// case when that's the way into the end
-							// of the facet, because that way always creates
-							// an edge.
-							if(j==rp&&lp==up&&ed[qp][nu[qp]+qs]==us) {
-								new_double_edge=true;
-								k-=1;
-							} else new_double_edge=false;
-						}
-					} else new_double_edge=false;
-				} else {
+                            // That marginal point hasn't been visited
+                            // before, so we probably don't have to worry
+                            // about duplicate edges, except in the
+                            // case when that's the way into the end
+                            // of the facet, because that way always creates
+                            // an edge.
+                            if(j==rp&&lp==up&&ed[qp][nu[qp]+qs]==us) {
+                                new_double_edge=true;
+                                k-=1;
+                            } else new_double_edge=false;
+                        }
+                    } else new_double_edge=false;
+                } else {
 
-					// The vertex hasn't been visited
-					// before, but let's see if it's
-					// marginal
-					if(lw==1) {
+                    // The vertex hasn't been visited
+                    // before, but let's see if it's
+                    // marginal
+                    if(lw==1) {
 
-						// If it is, we need to check
-						// for the case that it's a
-						// small branch, and that we're
-						// heading right back to where
-						// we came from
-						i=-ed[lp][nu[lp]<<1];
-						if(i==cp) {
-							new_double_edge=true;
-							k-=1;
-						} else new_double_edge=false;
-					} else new_double_edge=false;
-				}
-			}
+                        // If it is, we need to check
+                        // for the case that it's a
+                        // small branch, and that we're
+                        // heading right back to where
+                        // we came from
+                        i=-ed[lp][nu[lp]<<1];
+                        if(i==cp) {
+                            new_double_edge=true;
+                            k-=1;
+                        } else new_double_edge=false;
+                    } else new_double_edge=false;
+                }
+            }
 
-			// k now holds the number of edges of the new vertex
-			// we are forming. Add memory for it if it doesn't exist
-			// already.
-			while(k>=current_vertex_order) add_memory_vorder(vc);
-			if(mec[k]==mem[k]) add_memory(vc,k);
+            // k now holds the number of edges of the new vertex
+            // we are forming. Add memory for it if it doesn't exist
+            // already.
+            while(k>=current_vertex_order) add_memory_vorder(vc);
+            if(mec[k]==mem[k]) add_memory(vc,k);
 
-			// Now create a new vertex with order k, or augment
-			// the existing one
-			if(j>0) {
+            // Now create a new vertex with order k, or augment
+            // the existing one
+            if(j>0) {
 
-				// If we're augmenting a vertex but we don't
-				// actually need any more edges, just skip this
-				// routine to avoid memory confusion
-				if(nu[j]!=k) {
+                // If we're augmenting a vertex but we don't
+                // actually need any more edges, just skip this
+                // routine to avoid memory confusion
+                if(nu[j]!=k) {
 
-					// Allocate memory and copy the edges
-					// of the previous instance into it
-					vc.n_set_aux1(k);
-					edp=mep[k]+((k<<1)+1)*mec[k]++;
-					i=0;
-					while(i<nu[j]) {
-						vc.n_copy_aux1(j,i);
-						edp[i]=ed[j][i];
-						edp[k+i]=ed[j][nu[j]+i];
-						i++;
-					}
-					edp[k<<1]=j;
+                    // Allocate memory and copy the edges
+                    // of the previous instance into it
+                    vc.n_set_aux1(k);
+                    edp=mep[k]+((k<<1)+1)*mec[k]++;
+                    i=0;
+                    while(i<nu[j]) {
+                        vc.n_copy_aux1(j,i);
+                        edp[i]=ed[j][i];
+                        edp[k+i]=ed[j][nu[j]+i];
+                        i++;
+                    }
+                    edp[k<<1]=j;
 
-					// Remove the previous instance with
-					// fewer vertices from the memory
-					// structure
-					edd=mep[nu[j]]+((nu[j]<<1)+1)*--mec[nu[j]];
-					if(edd!=ed[j]) {
-						for(int lll=0;lll<=(nu[j]<<1);lll++) ed[j][lll]=edd[lll];
-						vc.n_set_aux2_copy(j,nu[j]);
-						vc.n_copy_pointer(edd[nu[j]<<1],j);
-						ed[edd[nu[j]<<1]]=ed[j];
-					}
-					vc.n_set_to_aux1(j);
-					ed[j]=edp;
-				} else i=nu[j];
-			} else {
+                    // Remove the previous instance with
+                    // fewer vertices from the memory
+                    // structure
+                    edd=mep[nu[j]]+((nu[j]<<1)+1)*--mec[nu[j]];
+                    if(edd!=ed[j]) {
+                        for(int lll=0;lll<=(nu[j]<<1);lll++) ed[j][lll]=edd[lll];
+                        vc.n_set_aux2_copy(j,nu[j]);
+                        vc.n_copy_pointer(edd[nu[j]<<1],j);
+                        ed[edd[nu[j]<<1]]=ed[j];
+                    }
+                    vc.n_set_to_aux1(j);
+                    ed[j]=edp;
+                } else i=nu[j];
+            } else {
 
-				// Allocate a new vertex of order k
-				vc.n_set_pointer(p,k);
-				ed[p]=mep[k]+((k<<1)+1)*mec[k]++;
-				ed[p][k<<1]=p;
-				if(stackp2==stacke2) add_memory_ds2();
-				*(stackp2++)=qp;
-				pts[p<<2]=pts[qp<<2];
-				pts[(p<<2)+1]=pts[(qp<<2)+1];
-				pts[(p<<2)+2]=pts[(qp<<2)+2];
-				ed[qp][nu[qp]<<1]=-p;
-				j=p++;
-				i=0;
-			}
-			nu[j]=k;
+                // Allocate a new vertex of order k
+                vc.n_set_pointer(p,k);
+                ed[p]=mep[k]+((k<<1)+1)*mec[k]++;
+                ed[p][k<<1]=p;
+                if(stackp2==stacke2) add_memory_ds2();
+                *(stackp2++)=qp;
+                pts[p<<2]=pts[qp<<2];
+                pts[(p<<2)+1]=pts[(qp<<2)+1];
+                pts[(p<<2)+2]=pts[(qp<<2)+2];
+                ed[qp][nu[qp]<<1]=-p;
+                j=p++;
+                i=0;
+            }
+            nu[j]=k;
 
-			// Unless the previous case was a double edge, connect
-			// the first available edge of the new vertex to the
-			// last one in the facet
-			if(!double_edge) {
-				ed[j][i]=cp;
-				ed[j][nu[j]+i]=cs;
-				vc.n_set(j,i,p_id);
-				ed[cp][cs]=j;
-				ed[cp][nu[cp]+cs]=i;
-				i++;
-			}
+            // Unless the previous case was a double edge, connect
+            // the first available edge of the new vertex to the
+            // last one in the facet
+            if(!double_edge) {
+                ed[j][i]=cp;
+                ed[j][nu[j]+i]=cs;
+                vc.n_set(j,i,p_id);
+                ed[cp][cs]=j;
+                ed[cp][nu[cp]+cs]=i;
+                i++;
+            }
 
-			// Copy in the edges of the underlying vertex,
-			// and do one less if this was a double edge
-			qs=iqs;
-			while(i<(new_double_edge?k:k-1)) {
-				qs=cycle_up(qs,qp);
-				lp=ed[qp][qs];ls=ed[qp][nu[qp]+qs];
-				vc.n_copy(j,i,qp,qs);
-				ed[j][i]=lp;
-				ed[j][nu[j]+i]=ls;
-				ed[lp][ls]=j;
-				ed[lp][nu[lp]+ls]=i;
-				ed[qp][qs]=-1;
-				i++;
-			}
-			qs=cycle_up(qs,qp);
-			cs=i;
-			cp=j;
-			vc.n_copy(j,new_double_edge?0:cs,qp,qs);
+            // Copy in the edges of the underlying vertex,
+            // and do one less if this was a double edge
+            qs=iqs;
+            while(i<(new_double_edge?k:k-1)) {
+                qs=cycle_up(qs,qp);
+                lp=ed[qp][qs];ls=ed[qp][nu[qp]+qs];
+                vc.n_copy(j,i,qp,qs);
+                ed[j][i]=lp;
+                ed[j][nu[j]+i]=ls;
+                ed[lp][ls]=j;
+                ed[lp][nu[lp]+ls]=i;
+                ed[qp][qs]=-1;
+                i++;
+            }
+            qs=cycle_up(qs,qp);
+            cs=i;
+            cp=j;
+            vc.n_copy(j,new_double_edge?0:cs,qp,qs);
 
-			// Update the double_edge flag, to pass it
-			// to the next instance of this routine
-			double_edge=new_double_edge;
-		}
-	}
+            // Update the double_edge flag, to pass it
+            // to the next instance of this routine
+            double_edge=new_double_edge;
+        }
+    }
 
-	// Connect the final created vertex to the initial one
-	ed[cp][cs]=rp;
-	*ed[rp]=cp;
-	ed[cp][nu[cp]+cs]=0;
-	ed[rp][nu[rp]]=cs;
-	return false;
+    // Connect the final created vertex to the initial one
+    ed[cp][cs]=rp;
+    *ed[rp]=cp;
+    ed[cp][nu[cp]+cs]=0;
+    ed[rp][nu[rp]]=cs;
+    return false;
 }
 
 /** During the creation of a new facet in the plane routine, it is possible
@@ -1375,58 +1375,58 @@ bool voronoicell_base::create_facet(vc_class &vc,int lp,int ls,double l,int us,d
  *         was successful. */
 template<class vc_class>
 inline bool voronoicell_base::collapse_order2(vc_class &vc) {
-	if(!collapse_order1(vc)) return false;
-	int a,b,i,j,k,l;
-	while(mec[2]>0) {
+    if(!collapse_order1(vc)) return false;
+    int a,b,i,j,k,l;
+    while(mec[2]>0) {
 
-		// Pick a order 2 vertex and read in its edges
-		i=--mec[2];
-		j=mep[2][5*i];k=mep[2][5*i+1];
-		if(j==k) {
+        // Pick a order 2 vertex and read in its edges
+        i=--mec[2];
+        j=mep[2][5*i];k=mep[2][5*i+1];
+        if(j==k) {
 #if VOROPP_VERBOSE >=1
-			fputs("Order two vertex joins itself",stderr);
+            fputs("Order two vertex joins itself",stderr);
 #endif
-			return false;
-		}
+            return false;
+        }
 
-		// Scan the edges of j to see if joins k
-		for(l=0;l<nu[j];l++) {
-			if(ed[j][l]==k) break;
-		}
+        // Scan the edges of j to see if joins k
+        for(l=0;l<nu[j];l++) {
+            if(ed[j][l]==k) break;
+        }
 
-		// If j doesn't already join k, join them together.
-		// Otherwise delete the connection to the current
-		// vertex from j and k.
-		a=mep[2][5*i+2];b=mep[2][5*i+3];i=mep[2][5*i+4];
-		if(l==nu[j]) {
-			ed[j][a]=k;
-			ed[k][b]=j;
-			ed[j][nu[j]+a]=b;
-			ed[k][nu[k]+b]=a;
-		} else {
-			if(!delete_connection(vc,j,a,false)) return false;
-			if(!delete_connection(vc,k,b,true)) return false;
-		}
+        // If j doesn't already join k, join them together.
+        // Otherwise delete the connection to the current
+        // vertex from j and k.
+        a=mep[2][5*i+2];b=mep[2][5*i+3];i=mep[2][5*i+4];
+        if(l==nu[j]) {
+            ed[j][a]=k;
+            ed[k][b]=j;
+            ed[j][nu[j]+a]=b;
+            ed[k][nu[k]+b]=a;
+        } else {
+            if(!delete_connection(vc,j,a,false)) return false;
+            if(!delete_connection(vc,k,b,true)) return false;
+        }
 
-		// Compact the memory
-		--p;
-		if(up==i) up=0;
-		if(p!=i) {
-			if(up==p) up=i;
-			pts[i<<2]=pts[p<<2];
-			pts[(i<<2)+1]=pts[(p<<2)+1];
-			pts[(i<<2)+2]=pts[(p<<2)+2];
-			for(k=0;k<nu[p];k++) ed[ed[p][k]][ed[p][nu[p]+k]]=i;
-			vc.n_copy_pointer(i,p);
-			ed[i]=ed[p];
-			nu[i]=nu[p];
-			ed[i][nu[i]<<1]=i;
-		}
+        // Compact the memory
+        --p;
+        if(up==i) up=0;
+        if(p!=i) {
+            if(up==p) up=i;
+            pts[i<<2]=pts[p<<2];
+            pts[(i<<2)+1]=pts[(p<<2)+1];
+            pts[(i<<2)+2]=pts[(p<<2)+2];
+            for(k=0;k<nu[p];k++) ed[ed[p][k]][ed[p][nu[p]+k]]=i;
+            vc.n_copy_pointer(i,p);
+            ed[i]=ed[p];
+            nu[i]=nu[p];
+            ed[i][nu[i]<<1]=i;
+        }
 
-		// Collapse any order 1 vertices if they were created
-		if(!collapse_order1(vc)) return false;
-	}
-	return true;
+        // Collapse any order 1 vertices if they were created
+        if(!collapse_order1(vc)) return false;
+    }
+    return true;
 }
 
 /** Order one vertices can potentially be created during the order two collapse
@@ -1436,31 +1436,31 @@ inline bool voronoicell_base::collapse_order2(vc_class &vc) {
  *         successful. */
 template<class vc_class>
 bool voronoicell_base::collapse_order1(vc_class &vc) {
-	int i,j,k;
-	while(mec[1]>0) {
-		up=0;
+    int i,j,k;
+    while(mec[1]>0) {
+        up=0;
 #if VOROPP_VERBOSE >=1
-		fputs("Order one collapse\n",stderr);
+        fputs("Order one collapse\n",stderr);
 #endif
-		i=--mec[1];
-		j=mep[1][3*i];k=mep[1][3*i+1];
-		i=mep[1][3*i+2];
-		if(!delete_connection(vc,j,k,false)) return false;
-		--p;
-		if(up==i) up=0;
-		if(p!=i) {
-			if(up==p) up=i;
-			pts[i<<2]=pts[p<<2];
-			pts[(i<<2)+1]=pts[(p<<2)+1];
-			pts[(i<<2)+2]=pts[(p<<2)+2];
-			for(k=0;k<nu[p];k++) ed[ed[p][k]][ed[p][nu[p]+k]]=i;
-			vc.n_copy_pointer(i,p);
-			ed[i]=ed[p];
-			nu[i]=nu[p];
-			ed[i][nu[i]<<1]=i;
-		}
-	}
-	return true;
+        i=--mec[1];
+        j=mep[1][3*i];k=mep[1][3*i+1];
+        i=mep[1][3*i+2];
+        if(!delete_connection(vc,j,k,false)) return false;
+        --p;
+        if(up==i) up=0;
+        if(p!=i) {
+            if(up==p) up=i;
+            pts[i<<2]=pts[p<<2];
+            pts[(i<<2)+1]=pts[(p<<2)+1];
+            pts[(i<<2)+2]=pts[(p<<2)+2];
+            for(k=0;k<nu[p];k++) ed[ed[p][k]][ed[p][nu[p]+k]]=i;
+            vc.n_copy_pointer(i,p);
+            ed[i]=ed[p];
+            nu[i]=nu[p];
+            ed[i][nu[i]<<1]=i;
+        }
+    }
+    return true;
 }
 
 /** This routine deletes the kth edge of vertex j and reorganizes the memory.
@@ -1471,110 +1471,110 @@ bool voronoicell_base::collapse_order1(vc_class &vc) {
  *         disappearing; true if the vertex removal was successful. */
 template<class vc_class>
 bool voronoicell_base::delete_connection(vc_class &vc,int j,int k,bool hand) {
-	int q=hand?k:cycle_up(k,j);
-	int i=nu[j]-1,l,*edp,*edd,m;
+    int q=hand?k:cycle_up(k,j);
+    int i=nu[j]-1,l,*edp,*edd,m;
 #if VOROPP_VERBOSE >=1
-	if(i<1) {
-		fputs("Zero order vertex formed\n",stderr);
-		return false;
-	}
+    if(i<1) {
+        fputs("Zero order vertex formed\n",stderr);
+        return false;
+    }
 #endif
-	if(mec[i]==mem[i]) add_memory(vc,i);
-	vc.n_set_aux1(i);
-	for(l=0;l<q;l++) vc.n_copy_aux1(j,l);
-	while(l<i) {
-		vc.n_copy_aux1_shift(j,l);
-		l++;
-	}
-	edp=mep[i]+((i<<1)+1)*mec[i]++;
-	edp[i<<1]=j;
-	for(l=0;l<k;l++) {
-		edp[l]=ed[j][l];
-		edp[l+i]=ed[j][l+nu[j]];
-	}
-	while(l<i) {
-		m=ed[j][l+1];
-		edp[l]=m;
-		k=ed[j][l+nu[j]+1];
-		edp[l+i]=k;
-		ed[m][nu[m]+k]--;
-		l++;
-	}
+    if(mec[i]==mem[i]) add_memory(vc,i);
+    vc.n_set_aux1(i);
+    for(l=0;l<q;l++) vc.n_copy_aux1(j,l);
+    while(l<i) {
+        vc.n_copy_aux1_shift(j,l);
+        l++;
+    }
+    edp=mep[i]+((i<<1)+1)*mec[i]++;
+    edp[i<<1]=j;
+    for(l=0;l<k;l++) {
+        edp[l]=ed[j][l];
+        edp[l+i]=ed[j][l+nu[j]];
+    }
+    while(l<i) {
+        m=ed[j][l+1];
+        edp[l]=m;
+        k=ed[j][l+nu[j]+1];
+        edp[l+i]=k;
+        ed[m][nu[m]+k]--;
+        l++;
+    }
 
-	edd=mep[nu[j]]+((nu[j]<<1)+1)*--mec[nu[j]];
-	for(l=0;l<=(nu[j]<<1);l++) ed[j][l]=edd[l];
-	vc.n_set_aux2_copy(j,nu[j]);
-	vc.n_copy_pointer(edd[nu[j]<<1],j);
-	vc.n_set_to_aux1(j);
-	ed[edd[nu[j]<<1]]=ed[j];
-	ed[j]=edp;
-	nu[j]=i;
-	return true;
+    edd=mep[nu[j]]+((nu[j]<<1)+1)*--mec[nu[j]];
+    for(l=0;l<=(nu[j]<<1);l++) ed[j][l]=edd[l];
+    vc.n_set_aux2_copy(j,nu[j]);
+    vc.n_copy_pointer(edd[nu[j]<<1],j);
+    vc.n_set_to_aux1(j);
+    ed[edd[nu[j]<<1]]=ed[j];
+    ed[j]=edp;
+    nu[j]=i;
+    return true;
 }
 
 /** This routine is a fall-back, in case floating point errors caused the usual
  * search routine to fail. In the fall-back routine, we just test every edge to
  * find one straddling the plane. */
 bool voronoicell_base::failsafe_find(int &lp,int &ls,int &us,double &l,double &u) {
-	fputs("Bailed out of convex calculation (not supported yet)\n",stderr);
-	exit(1);
+    fputs("Bailed out of convex calculation (not supported yet)\n",stderr);
+    exit(1);
 /*	qw=1;lw=0;
-	for(qp=0;qp<p;qp++) {
-		qw=m_test(qp,q);
-		if(qw==1) {
+    for(qp=0;qp<p;qp++) {
+        qw=m_test(qp,q);
+        if(qw==1) {
 
-			// The point is inside the cutting space. Now
-			// see if we can find a neighbor which isn't.
-			for(us=0;us<nu[qp];us++) {
-				lp=ed[qp][us];
-				if(lp<qp) {
-					lw=m_test(lp,l);
-					if(lw!=1) break;
-				}
-			}
-			if(us<nu[qp]) {
-				up=qp;
-				if(lw==0) {
-					complicated_setup=true;
-				} else {
-					complicated_setup=false;
-					u=q;
-					ls=ed[up][nu[up]+us];
-				}
-				break;
-			}
-		} else if(qw==-1) {
+            // The point is inside the cutting space. Now
+            // see if we can find a neighbor which isn't.
+            for(us=0;us<nu[qp];us++) {
+                lp=ed[qp][us];
+                if(lp<qp) {
+                    lw=m_test(lp,l);
+                    if(lw!=1) break;
+                }
+            }
+            if(us<nu[qp]) {
+                up=qp;
+                if(lw==0) {
+                    complicated_setup=true;
+                } else {
+                    complicated_setup=false;
+                    u=q;
+                    ls=ed[up][nu[up]+us];
+                }
+                break;
+            }
+        } else if(qw==-1) {
 
-			// The point is outside the cutting space. See
-			// if we can find a neighbor which isn't.
-			for(ls=0;ls<nu[qp];ls++) {
-				up=ed[qp][ls];
-				if(up<qp) {
-					uw=m_test(up,u);
-					if(uw!=-1) break;
-				}
-			}
-			if(ls<nu[qp]) {
-				if(uw==0) {
-					up=qp;
-					complicated_setup=true;
-				} else {
-					complicated_setup=false;
-					lp=qp;l=q;
-					us=ed[lp][nu[lp]+ls];
-				}
-				break;
-			}
-		} else {
+            // The point is outside the cutting space. See
+            // if we can find a neighbor which isn't.
+            for(ls=0;ls<nu[qp];ls++) {
+                up=ed[qp][ls];
+                if(up<qp) {
+                    uw=m_test(up,u);
+                    if(uw!=-1) break;
+                }
+            }
+            if(ls<nu[qp]) {
+                if(uw==0) {
+                    up=qp;
+                    complicated_setup=true;
+                } else {
+                    complicated_setup=false;
+                    lp=qp;l=q;
+                    us=ed[lp][nu[lp]+ls];
+                }
+                break;
+            }
+        } else {
 
-			// The point is in the plane, so we just
-			// proceed with the complicated setup routine
-			up=qp;
-			complicated_setup=true;
-			break;
-		}
-	}
-	if(qp==p) return qw==-1?true:false;*/
+            // The point is in the plane, so we just
+            // proceed with the complicated setup routine
+            up=qp;
+            complicated_setup=true;
+            break;
+        }
+    }
+    if(qp==p) return qw==-1?true:false;*/
 }
 
 /** Calculates the volume of the Voronoi cell, by decomposing the cell into
@@ -1582,37 +1582,37 @@ bool voronoicell_base::failsafe_find(int &lp,int &ls,int &us,double &l,double &u
  * evaluated using a scalar triple product.
  * \return A floating point number holding the calculated volume. */
 double voronoicell_base::volume() {
-	const double fe=1/48.0;
-	double vol=0;
-	int i,j,k,l,m,n;
-	double ux,uy,uz,vx,vy,vz,wx,wy,wz;
-	for(i=1;i<p;i++) {
-		ux=*pts-pts[i<<2];
-		uy=pts[1]-pts[(i<<2)+1];
-		uz=pts[2]-pts[(i<<2)+2];
-		for(j=0;j<nu[i];j++) {
-			k=ed[i][j];
-			if(k>=0) {
-				ed[i][j]=-1-k;
-				l=cycle_up(ed[i][nu[i]+j],k);
-				vx=pts[k<<2]-*pts;
-				vy=pts[(k<<2)+1]-pts[1];
-				vz=pts[(k<<2)+2]-pts[2];
-				m=ed[k][l];ed[k][l]=-1-m;
-				while(m!=i) {
-					n=cycle_up(ed[k][nu[k]+l],m);
-					wx=pts[(m<<2)]-*pts;
-					wy=pts[(m<<2)+1]-pts[1];
-					wz=pts[(m<<2)+2]-pts[2];
-					vol+=ux*vy*wz+uy*vz*wx+uz*vx*wy-uz*vy*wx-uy*vx*wz-ux*vz*wy;
-					k=m;l=n;vx=wx;vy=wy;vz=wz;
-					m=ed[k][l];ed[k][l]=-1-m;
-				}
-			}
-		}
-	}
-	reset_edges();
-	return vol*fe;
+    const double fe=1/48.0;
+    double vol=0;
+    int i,j,k,l,m,n;
+    double ux,uy,uz,vx,vy,vz,wx,wy,wz;
+    for(i=1;i<p;i++) {
+        ux=*pts-pts[i<<2];
+        uy=pts[1]-pts[(i<<2)+1];
+        uz=pts[2]-pts[(i<<2)+2];
+        for(j=0;j<nu[i];j++) {
+            k=ed[i][j];
+            if(k>=0) {
+                ed[i][j]=-1-k;
+                l=cycle_up(ed[i][nu[i]+j],k);
+                vx=pts[k<<2]-*pts;
+                vy=pts[(k<<2)+1]-pts[1];
+                vz=pts[(k<<2)+2]-pts[2];
+                m=ed[k][l];ed[k][l]=-1-m;
+                while(m!=i) {
+                    n=cycle_up(ed[k][nu[k]+l],m);
+                    wx=pts[(m<<2)]-*pts;
+                    wy=pts[(m<<2)+1]-pts[1];
+                    wz=pts[(m<<2)+2]-pts[2];
+                    vol+=ux*vy*wz+uy*vz*wx+uz*vx*wy-uz*vy*wx-uy*vx*wz-ux*vz*wy;
+                    k=m;l=n;vx=wx;vy=wy;vz=wz;
+                    m=ed[k][l];ed[k][l]=-1-m;
+                }
+            }
+        }
+    }
+    reset_edges();
+    return vol*fe;
 }
 
 /** Calculates the contributions to the Minkowski functionals for this Voronoi cell.
@@ -1620,174 +1620,174 @@ double voronoicell_base::volume() {
  * \param[out] ar the area functional.
  * \param[out] vo the volume functional. */
 void voronoicell_base::minkowski(double r,double &ar,double &vo) {
-	int i,j,k,l,m,n;
-	ar=vo=0;r*=2;
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) {
-			ed[i][j]=-1-k;
-			l=cycle_up(ed[i][nu[i]+j],k);
-			m=ed[k][l];ed[k][l]=-1-m;
-			while(m!=i) {
-				n=cycle_up(ed[k][nu[k]+l],m);
-				minkowski_contrib(i,k,m,r,ar,vo);
-				k=m;l=n;
-				m=ed[k][l];ed[k][l]=-1-m;
-			}
-		}
-	}
-	vo*=0.125;
-	ar*=0.25;
-	reset_edges();
+    int i,j,k,l,m,n;
+    ar=vo=0;r*=2;
+    for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        if(k>=0) {
+            ed[i][j]=-1-k;
+            l=cycle_up(ed[i][nu[i]+j],k);
+            m=ed[k][l];ed[k][l]=-1-m;
+            while(m!=i) {
+                n=cycle_up(ed[k][nu[k]+l],m);
+                minkowski_contrib(i,k,m,r,ar,vo);
+                k=m;l=n;
+                m=ed[k][l];ed[k][l]=-1-m;
+            }
+        }
+    }
+    vo*=0.125;
+    ar*=0.25;
+    reset_edges();
 }
 
 inline void voronoicell_base::minkowski_contrib(int i,int k,int m,double r,double &ar,double &vo) {
-	double ix=pts[4*i],iy=pts[4*i+1],iz=pts[4*i+2],
-	       kx=pts[4*k],ky=pts[4*k+1],kz=pts[4*k+2],
-	       mx=pts[4*m],my=pts[4*m+1],mz=pts[4*m+2],
-	       ux=kx-ix,uy=ky-iy,uz=kz-iz,vx=mx-kx,vy=my-ky,vz=mz-kz,
-	       e1x=uz*vy-uy*vz,e1y=ux*vz-uz*vx,e1z=uy*vx-ux*vy,e2x,e2y,e2z,
-	       wmag=e1x*e1x+e1y*e1y+e1z*e1z;
-	if(wmag<tol*tol) return;
-	wmag=1/sqrt(wmag);
-	e1x*=wmag;e1y*=wmag;e1z*=wmag;
+    double ix=pts[4*i],iy=pts[4*i+1],iz=pts[4*i+2],
+           kx=pts[4*k],ky=pts[4*k+1],kz=pts[4*k+2],
+           mx=pts[4*m],my=pts[4*m+1],mz=pts[4*m+2],
+           ux=kx-ix,uy=ky-iy,uz=kz-iz,vx=mx-kx,vy=my-ky,vz=mz-kz,
+           e1x=uz*vy-uy*vz,e1y=ux*vz-uz*vx,e1z=uy*vx-ux*vy,e2x,e2y,e2z,
+           wmag=e1x*e1x+e1y*e1y+e1z*e1z;
+    if(wmag<tol*tol) return;
+    wmag=1/sqrt(wmag);
+    e1x*=wmag;e1y*=wmag;e1z*=wmag;
 
-	// Compute second orthonormal vector
-	if(fabs(e1x)>0.5) {
-		e2x=-e1y;e2y=e1x;e2z=0;
-	} else if(fabs(e1y)>0.5) {
-		e2x=0;e2y=-e1z;e2z=e1y;
-	} else {
-		e2x=e1z;e2y=0;e2z=-e1x;
-	}
-	wmag=1/sqrt(e2x*e2x+e2y*e2y+e2z*e2z);
-	e2x*=wmag;e2y*=wmag;e2z*=wmag;
+    // Compute second orthonormal vector
+    if(fabs(e1x)>0.5) {
+        e2x=-e1y;e2y=e1x;e2z=0;
+    } else if(fabs(e1y)>0.5) {
+        e2x=0;e2y=-e1z;e2z=e1y;
+    } else {
+        e2x=e1z;e2y=0;e2z=-e1x;
+    }
+    wmag=1/sqrt(e2x*e2x+e2y*e2y+e2z*e2z);
+    e2x*=wmag;e2y*=wmag;e2z*=wmag;
 
-	// Compute third orthonormal vector
-	double e3x=e1z*e2y-e1y*e2z,
-	       e3y=e1x*e2z-e1z*e2x,
-	       e3z=e1y*e2x-e1x*e2y,
-	       x0=e1x*ix+e1y*iy+e1z*iz;
-	if(x0<tol) return;
+    // Compute third orthonormal vector
+    double e3x=e1z*e2y-e1y*e2z,
+           e3y=e1x*e2z-e1z*e2x,
+           e3z=e1y*e2x-e1x*e2y,
+           x0=e1x*ix+e1y*iy+e1z*iz;
+    if(x0<tol) return;
 
-	double ir=e2x*ix+e2y*iy+e2z*iz,is=e3x*ix+e3y*iy+e3z*iz,
-	       kr=e2x*kx+e2y*ky+e2z*kz,ks=e3x*kx+e3y*ky+e3z*kz,
-	       mr=e2x*mx+e2y*my+e2z*mz,ms=e3x*mx+e3y*my+e3z*mz;
+    double ir=e2x*ix+e2y*iy+e2z*iz,is=e3x*ix+e3y*iy+e3z*iz,
+           kr=e2x*kx+e2y*ky+e2z*kz,ks=e3x*kx+e3y*ky+e3z*kz,
+           mr=e2x*mx+e2y*my+e2z*mz,ms=e3x*mx+e3y*my+e3z*mz;
 
-	minkowski_edge(x0,ir,is,kr,ks,r,ar,vo);
-	minkowski_edge(x0,kr,ks,mr,ms,r,ar,vo);
-	minkowski_edge(x0,mr,ms,ir,is,r,ar,vo);
+    minkowski_edge(x0,ir,is,kr,ks,r,ar,vo);
+    minkowski_edge(x0,kr,ks,mr,ms,r,ar,vo);
+    minkowski_edge(x0,mr,ms,ir,is,r,ar,vo);
 }
 
 void voronoicell_base::minkowski_edge(double x0,double r1,double s1,double r2,double s2,double r,double &ar,double &vo) {
-	double r12=r2-r1,s12=s2-s1,l12=r12*r12+s12*s12;
-	if(l12<tol*tol) return;
-	l12=1/sqrt(l12);r12*=l12;s12*=l12;
-	double y0=s12*r1-r12*s1;
-	if(fabs(y0)<tol) return;
-	minkowski_formula(x0,y0,-r12*r1-s12*s1,r,ar,vo);
-	minkowski_formula(x0,y0,r12*r2+s12*s2,r,ar,vo);
+    double r12=r2-r1,s12=s2-s1,l12=r12*r12+s12*s12;
+    if(l12<tol*tol) return;
+    l12=1/sqrt(l12);r12*=l12;s12*=l12;
+    double y0=s12*r1-r12*s1;
+    if(fabs(y0)<tol) return;
+    minkowski_formula(x0,y0,-r12*r1-s12*s1,r,ar,vo);
+    minkowski_formula(x0,y0,r12*r2+s12*s2,r,ar,vo);
 }
 
 void voronoicell_base::minkowski_formula(double x0,double y0,double z0,double r,double &ar,double &vo) {
-	const double pi=3.1415926535897932384626433832795;
-	if(fabs(z0)<tol) return;
-	double si;
-	if(z0<0) {z0=-z0;si=-1;} else si=1;
-	if(y0<0) {y0=-y0;si=-si;}
-	double xs=x0*x0,ys=y0*y0,zs=z0*z0,res=xs+ys,rvs=res+zs,theta=atan(z0/y0),rs=r*r,rc=rs*r,temp,voc,arc;
-	if(r<x0) {
-		temp=2*theta-0.5*pi-asin((zs*xs-ys*rvs)/(res*(ys+zs)));
-		voc=rc/6.*temp;
-		arc=rs*0.5*temp;
-	} else if(rs<res*1.0000000001) {
-		temp=0.5*pi+asin((zs*xs-ys*rvs)/(res*(ys+zs)));
-		voc=theta*0.5*(rs*x0-xs*x0/3.)-rc/6.*temp;
-		arc=theta*x0*r-rs*0.5*temp;
-	} else if(rs<rvs) {
-		temp=theta-pi*0.5+asin(y0/sqrt(rs-xs));
-		double temp2=(rs*x0-xs*x0/3.),
-		       x2s=rs*xs/res,y2s=rs*ys/res,
-		       temp3=asin((x2s-y2s-xs)/(rs-xs)),
-		       temp4=asin((zs*xs-ys*rvs)/(res*(ys+zs))),
-		       temp5=sqrt(rs-res);
-		voc=0.5*temp*temp2+x0*y0/6.*temp5+r*rs/6*(temp3-temp4);
-		arc=x0*r*temp-0.5*temp2*y0*r/((rs-xs)*temp5)+x0*y0/6.*r/temp5+rs*0.5*temp3+rs*rs/3.*2*xs*ys/(res*(rs-xs)*sqrt((rs-xs)*(rs-xs)-(x2s-y2s-xs)*(x2s-y2s-xs)))-rs*0.5*temp4;
-	} else {
-		voc=x0*y0*z0/6.;
-		arc=0;
-	}
-	vo+=voc*si;
-	ar+=arc*si;
+    const double pi=3.1415926535897932384626433832795;
+    if(fabs(z0)<tol) return;
+    double si;
+    if(z0<0) {z0=-z0;si=-1;} else si=1;
+    if(y0<0) {y0=-y0;si=-si;}
+    double xs=x0*x0,ys=y0*y0,zs=z0*z0,res=xs+ys,rvs=res+zs,theta=atan(z0/y0),rs=r*r,rc=rs*r,temp,voc,arc;
+    if(r<x0) {
+        temp=2*theta-0.5*pi-asin((zs*xs-ys*rvs)/(res*(ys+zs)));
+        voc=rc/6.*temp;
+        arc=rs*0.5*temp;
+    } else if(rs<res*1.0000000001) {
+        temp=0.5*pi+asin((zs*xs-ys*rvs)/(res*(ys+zs)));
+        voc=theta*0.5*(rs*x0-xs*x0/3.)-rc/6.*temp;
+        arc=theta*x0*r-rs*0.5*temp;
+    } else if(rs<rvs) {
+        temp=theta-pi*0.5+asin(y0/sqrt(rs-xs));
+        double temp2=(rs*x0-xs*x0/3.),
+               x2s=rs*xs/res,y2s=rs*ys/res,
+               temp3=asin((x2s-y2s-xs)/(rs-xs)),
+               temp4=asin((zs*xs-ys*rvs)/(res*(ys+zs))),
+               temp5=sqrt(rs-res);
+        voc=0.5*temp*temp2+x0*y0/6.*temp5+r*rs/6*(temp3-temp4);
+        arc=x0*r*temp-0.5*temp2*y0*r/((rs-xs)*temp5)+x0*y0/6.*r/temp5+rs*0.5*temp3+rs*rs/3.*2*xs*ys/(res*(rs-xs)*sqrt((rs-xs)*(rs-xs)-(x2s-y2s-xs)*(x2s-y2s-xs)))-rs*0.5*temp4;
+    } else {
+        voc=x0*y0*z0/6.;
+        arc=0;
+    }
+    vo+=voc*si;
+    ar+=arc*si;
 }
 
 /** Calculates the areas of each face of the Voronoi cell and prints the
  * results to an output stream.
  * \param[out] v the vector to store the results in. */
 void voronoicell_base::face_areas(std::vector<double> &v) {
-	double area;
-	v.clear();
-	int i,j,k,l,m,n;
-	double ux,uy,uz,vx,vy,vz,wx,wy,wz;
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) {
-			area=0;
-			ed[i][j]=-1-k;
-			l=cycle_up(ed[i][nu[i]+j],k);
-			m=ed[k][l];ed[k][l]=-1-m;
-			while(m!=i) {
-				n=cycle_up(ed[k][nu[k]+l],m);
-				ux=pts[4*k]-pts[4*i];
-				uy=pts[4*k+1]-pts[4*i+1];
-				uz=pts[4*k+2]-pts[4*i+2];
-				vx=pts[4*m]-pts[4*i];
-				vy=pts[4*m+1]-pts[4*i+1];
-				vz=pts[4*m+2]-pts[4*i+2];
-				wx=uy*vz-uz*vy;
-				wy=uz*vx-ux*vz;
-				wz=ux*vy-uy*vx;
-				area+=sqrt(wx*wx+wy*wy+wz*wz);
-				k=m;l=n;
-				m=ed[k][l];ed[k][l]=-1-m;
-			}
-			v.push_back(0.125*area);
-		}
-	}
-	reset_edges();
+    double area;
+    v.clear();
+    int i,j,k,l,m,n;
+    double ux,uy,uz,vx,vy,vz,wx,wy,wz;
+    for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        if(k>=0) {
+            area=0;
+            ed[i][j]=-1-k;
+            l=cycle_up(ed[i][nu[i]+j],k);
+            m=ed[k][l];ed[k][l]=-1-m;
+            while(m!=i) {
+                n=cycle_up(ed[k][nu[k]+l],m);
+                ux=pts[4*k]-pts[4*i];
+                uy=pts[4*k+1]-pts[4*i+1];
+                uz=pts[4*k+2]-pts[4*i+2];
+                vx=pts[4*m]-pts[4*i];
+                vy=pts[4*m+1]-pts[4*i+1];
+                vz=pts[4*m+2]-pts[4*i+2];
+                wx=uy*vz-uz*vy;
+                wy=uz*vx-ux*vz;
+                wz=ux*vy-uy*vx;
+                area+=sqrt(wx*wx+wy*wy+wz*wz);
+                k=m;l=n;
+                m=ed[k][l];ed[k][l]=-1-m;
+            }
+            v.push_back(0.125*area);
+        }
+    }
+    reset_edges();
 }
 
 /** Calculates the total surface area of the Voronoi cell.
  * \return The computed area. */
 double voronoicell_base::surface_area() {
-	double area=0;
-	int i,j,k,l,m,n;
-	double ux,uy,uz,vx,vy,vz,wx,wy,wz;
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) {
-			ed[i][j]=-1-k;
-			l=cycle_up(ed[i][nu[i]+j],k);
-			m=ed[k][l];ed[k][l]=-1-m;
-			while(m!=i) {
-				n=cycle_up(ed[k][nu[k]+l],m);
-				ux=pts[4*k]-pts[4*i];
-				uy=pts[4*k+1]-pts[4*i+1];
-				uz=pts[4*k+2]-pts[4*i+2];
-				vx=pts[4*m]-pts[4*i];
-				vy=pts[4*m+1]-pts[4*i+1];
-				vz=pts[4*m+2]-pts[4*i+2];
-				wx=uy*vz-uz*vy;
-				wy=uz*vx-ux*vz;
-				wz=ux*vy-uy*vx;
-				area+=sqrt(wx*wx+wy*wy+wz*wz);
-				k=m;l=n;
-				m=ed[k][l];ed[k][l]=-1-m;
-			}
-		}
-	}
-	reset_edges();
-	return 0.125*area;
+    double area=0;
+    int i,j,k,l,m,n;
+    double ux,uy,uz,vx,vy,vz,wx,wy,wz;
+    for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        if(k>=0) {
+            ed[i][j]=-1-k;
+            l=cycle_up(ed[i][nu[i]+j],k);
+            m=ed[k][l];ed[k][l]=-1-m;
+            while(m!=i) {
+                n=cycle_up(ed[k][nu[k]+l],m);
+                ux=pts[4*k]-pts[4*i];
+                uy=pts[4*k+1]-pts[4*i+1];
+                uz=pts[4*k+2]-pts[4*i+2];
+                vx=pts[4*m]-pts[4*i];
+                vy=pts[4*m+1]-pts[4*i+1];
+                vz=pts[4*m+2]-pts[4*i+2];
+                wx=uy*vz-uz*vy;
+                wy=uz*vx-ux*vz;
+                wz=ux*vy-uy*vx;
+                area+=sqrt(wx*wx+wy*wy+wz*wz);
+                k=m;l=n;
+                m=ed[k][l];ed[k][l]=-1-m;
+            }
+        }
+    }
+    reset_edges();
+    return 0.125*area;
 }
 
 /** Calculates the centroid of the Voronoi cell, by decomposing the cell into
@@ -1795,45 +1795,45 @@ double voronoicell_base::surface_area() {
  * \param[out] (cx,cy,cz) references to floating point numbers in which to
  *                        pass back the centroid vector. */
 void voronoicell_base::centroid(double &cx,double &cy,double &cz) {
-	double tvol,vol=0;cx=cy=cz=0;
-	int i,j,k,l,m,n;
-	double ux,uy,uz,vx,vy,vz,wx,wy,wz;
-	for(i=1;i<p;i++) {
-		ux=*pts-pts[4*i];
-		uy=pts[1]-pts[4*i+1];
-		uz=pts[2]-pts[4*i+2];
-		for(j=0;j<nu[i];j++) {
-			k=ed[i][j];
-			if(k>=0) {
-				ed[i][j]=-1-k;
-				l=cycle_up(ed[i][nu[i]+j],k);
-				vx=pts[4*k]-*pts;
-				vy=pts[4*k+1]-pts[1];
-				vz=pts[4*k+2]-pts[2];
-				m=ed[k][l];ed[k][l]=-1-m;
-				while(m!=i) {
-					n=cycle_up(ed[k][nu[k]+l],m);
-					wx=pts[4*m]-*pts;
-					wy=pts[4*m+1]-pts[1];
-					wz=pts[4*m+2]-pts[2];
-					tvol=ux*vy*wz+uy*vz*wx+uz*vx*wy-uz*vy*wx-uy*vx*wz-ux*vz*wy;
-					vol+=tvol;
-					cx+=(wx+vx-ux)*tvol;
-					cy+=(wy+vy-uy)*tvol;
-					cz+=(wz+vz-uz)*tvol;
-					k=m;l=n;vx=wx;vy=wy;vz=wz;
-					m=ed[k][l];ed[k][l]=-1-m;
-				}
-			}
-		}
-	}
-	reset_edges();
-	if(vol>tol_cu) {
-		vol=0.125/vol;
-		cx=cx*vol+0.5*(*pts);
-		cy=cy*vol+0.5*pts[1];
-		cz=cz*vol+0.5*pts[2];
-	} else cx=cy=cz=0;
+    double tvol,vol=0;cx=cy=cz=0;
+    int i,j,k,l,m,n;
+    double ux,uy,uz,vx,vy,vz,wx,wy,wz;
+    for(i=1;i<p;i++) {
+        ux=*pts-pts[4*i];
+        uy=pts[1]-pts[4*i+1];
+        uz=pts[2]-pts[4*i+2];
+        for(j=0;j<nu[i];j++) {
+            k=ed[i][j];
+            if(k>=0) {
+                ed[i][j]=-1-k;
+                l=cycle_up(ed[i][nu[i]+j],k);
+                vx=pts[4*k]-*pts;
+                vy=pts[4*k+1]-pts[1];
+                vz=pts[4*k+2]-pts[2];
+                m=ed[k][l];ed[k][l]=-1-m;
+                while(m!=i) {
+                    n=cycle_up(ed[k][nu[k]+l],m);
+                    wx=pts[4*m]-*pts;
+                    wy=pts[4*m+1]-pts[1];
+                    wz=pts[4*m+2]-pts[2];
+                    tvol=ux*vy*wz+uy*vz*wx+uz*vx*wy-uz*vy*wx-uy*vx*wz-ux*vz*wy;
+                    vol+=tvol;
+                    cx+=(wx+vx-ux)*tvol;
+                    cy+=(wy+vy-uy)*tvol;
+                    cz+=(wz+vz-uz)*tvol;
+                    k=m;l=n;vx=wx;vy=wy;vz=wz;
+                    m=ed[k][l];ed[k][l]=-1-m;
+                }
+            }
+        }
+    }
+    reset_edges();
+    if(vol>tol_cu) {
+        vol=0.125/vol;
+        cx=cx*vol+0.5*(*pts);
+        cy=cy*vol+0.5*pts[1];
+        cz=cz*vol+0.5*pts[2];
+    } else cx=cy=cz=0;
 }
 
 /** Computes the maximum radius squared of a vertex from the center of the
@@ -1841,115 +1841,40 @@ void voronoicell_base::centroid(double &cx,double &cy,double &cz) {
  * all planes that could cut the cell have been considered.
  * \return The maximum radius squared of a vertex.*/
 double voronoicell_base::max_radius_squared() {
-	double r,s,*ptsp=pts+4,*ptse=pts+(p<<2);
-	r=*pts*(*pts)+pts[1]*pts[1]+pts[2]*pts[2];
-	while(ptsp<ptse) {
-		s=*ptsp*(*ptsp);ptsp++;
-		s+=*ptsp*(*ptsp);ptsp++;
-		s+=*ptsp*(*ptsp);ptsp+=2;
-		if(s>r) r=s;
-	}
-	return r;
+    double r,s,*ptsp=pts+4,*ptse=pts+(p<<2);
+    r=*pts*(*pts)+pts[1]*pts[1]+pts[2]*pts[2];
+    while(ptsp<ptse) {
+        s=*ptsp*(*ptsp);ptsp++;
+        s+=*ptsp*(*ptsp);ptsp++;
+        s+=*ptsp*(*ptsp);ptsp+=2;
+        if(s>r) r=s;
+    }
+    return r;
 }
 
 /** Calculates the total edge distance of the Voronoi cell.
  * \return A floating point number holding the calculated distance. */
 double voronoicell_base::total_edge_distance() {
-	int i,j,k;
-	double dis=0,dx,dy,dz;
-	for(i=0;i<p-1;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>i) {
-			dx=pts[k<<2]-pts[i<<2];
-			dy=pts[(k<<2)+1]-pts[(i<<2)+1];
-			dz=pts[(k<<2)+2]-pts[(i<<2)+2];
-			dis+=sqrt(dx*dx+dy*dy+dz*dz);
-		}
-	}
-	return 0.5*dis;
-}
-
-/** Outputs the edges of the Voronoi cell in POV-Ray format to an open file
- * stream, displacing the cell by given vector.
- * \param[in] (x,y,z) a displacement vector to be added to the cell's position.
- * \param[in] fp a file handle to write to. */
-void voronoicell_base::draw_pov(double x,double y,double z,FILE* fp) {
-	int i,j,k;double *ptsp=pts,*pt2;
-	char posbuf1[128],posbuf2[128];
-	for(i=0;i<p;i++,ptsp+=4) {
-		sprintf(posbuf1,"%g,%g,%g",x+*ptsp*0.5,y+ptsp[1]*0.5,z+ptsp[2]*0.5);
-		fprintf(fp,"sphere{<%s>,r}\n",posbuf1);
-		for(j=0;j<nu[i];j++) {
-			k=ed[i][j];
-			if(k<i) {
-				pt2=pts+(k<<2);
-				sprintf(posbuf2,"%g,%g,%g",x+*pt2*0.5,y+0.5*pt2[1],z+0.5*pt2[2]);
-				if(strcmp(posbuf1,posbuf2)!=0) fprintf(fp,"cylinder{<%s>,<%s>,r}\n",posbuf1,posbuf2);
-			}
-		}
-	}
-}
-
-/** Outputs the edges of the Voronoi cell in gnuplot format to an output stream.
- * \param[in] (x,y,z) a displacement vector to be added to the cell's position.
- * \param[in] fp a file handle to write to. */
-void voronoicell_base::draw_gnuplot(double x,double y,double z,FILE *fp) {
-	int i,j,k,l,m;
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) {
-			fprintf(fp,"%g %g %g\n",x+0.5*pts[i<<2],y+0.5*pts[(i<<2)+1],z+0.5*pts[(i<<2)+2]);
-			l=i;m=j;
-			do {
-				ed[k][ed[l][nu[l]+m]]=-1-l;
-				ed[l][m]=-1-k;
-				l=k;
-				fprintf(fp,"%g %g %g\n",x+0.5*pts[k<<2],y+0.5*pts[(k<<2)+1],z+0.5*pts[(k<<2)+2]);
-			} while (search_edge(l,m,k));
-			fputs("\n\n",fp);
-		}
-	}
-	reset_edges();
+    int i,j,k;
+    double dis=0,dx,dy,dz;
+    for(i=0;i<p-1;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        if(k>i) {
+            dx=pts[k<<2]-pts[i<<2];
+            dy=pts[(k<<2)+1]-pts[(i<<2)+1];
+            dz=pts[(k<<2)+2]-pts[(i<<2)+2];
+            dis+=sqrt(dx*dx+dy*dy+dz*dz);
+        }
+    }
+    return 0.5*dis;
 }
 
 inline bool voronoicell_base::search_edge(int l,int &m,int &k) {
-	for(m=0;m<nu[l];m++) {
-		k=ed[l][m];
-		if(k>=0) return true;
-	}
-	return false;
-}
-
-/** Outputs the Voronoi cell in the POV mesh2 format, described in section
- * 1.3.2.2 of the POV-Ray documentation. The mesh2 output consists of a list of
- * vertex vectors, followed by a list of triangular faces. The routine also
- * makes use of the optional inside_vector specification, which makes the mesh
- * object solid, so that the POV-Ray Constructive Solid Geometry (CSG) can be
- * applied.
- * \param[in] (x,y,z) a displacement vector to be added to the cell's position.
- * \param[in] fp a file handle to write to. */
-void voronoicell_base::draw_pov_mesh(double x,double y,double z,FILE *fp) {
-	int i,j,k,l,m,n;
-	double *ptsp=pts;
-	fprintf(fp,"mesh2 {\nvertex_vectors {\n%d\n",p);
-	for(i=0;i<p;i++,ptsp+=4) fprintf(fp,",<%g,%g,%g>\n",x+*ptsp*0.5,y+ptsp[1]*0.5,z+ptsp[2]*0.5);
-	fprintf(fp,"}\nface_indices {\n%d\n",(p-2)<<1);
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) {
-			ed[i][j]=-1-k;
-			l=cycle_up(ed[i][nu[i]+j],k);
-			m=ed[k][l];ed[k][l]=-1-m;
-			while(m!=i) {
-				n=cycle_up(ed[k][nu[k]+l],m);
-				fprintf(fp,",<%d,%d,%d>\n",i,k,m);
-				k=m;l=n;
-				m=ed[k][l];ed[k][l]=-1-m;
-			}
-		}
-	}
-	fputs("}\ninside_vector <0,0,1>\n}\n",fp);
-	reset_edges();
+    for(m=0;m<nu[l];m++) {
+        k=ed[l][m];
+        if(k>=0) return true;
+    }
+    return false;
 }
 
 /** Several routines in the class that gather cell-based statistics internally
@@ -1959,11 +1884,11 @@ void voronoicell_base::draw_pov_mesh(double x,double y,double z,FILE *fp) {
  * should have already been flipped to negative, and it bails out with an
  * internal error if it encounters a positive edge. */
 inline void voronoicell_base::reset_edges() {
-	int i,j;
-	for(i=0;i<p;i++) for(j=0;j<nu[i];j++) {
-		if(ed[i][j]>=0) voro_fatal_error("Edge reset routine found a previously untested edge",VOROPP_INTERNAL_ERROR);
-		ed[i][j]=-1-ed[i][j];
-	}
+    int i,j;
+    for(i=0;i<p;i++) for(j=0;j<nu[i];j++) {
+        if(ed[i][j]>=0) voro_fatal_error("Edge reset routine found a previously untested edge",VOROPP_INTERNAL_ERROR);
+        ed[i][j]=-1-ed[i][j];
+    }
 }
 
 /** Checks to see if a given vertex is inside, outside or within the test
@@ -1977,21 +1902,21 @@ inline void voronoicell_base::reset_edges() {
  * \return -1 if the point is inside the plane, 1 if the point is outside the
  *         plane, or 0 if the point is within the plane. */
 inline unsigned int voronoicell_base::m_test(int n,double &ans) {
-	if(mask[n]>=maskc) {
-		ans=pts[4*n+3];
-		return mask[n]&3;
-	} else return m_calc(n,ans);
+    if(mask[n]>=maskc) {
+        ans=pts[4*n+3];
+        return mask[n]&3;
+    } else return m_calc(n,ans);
 }
 
 unsigned int voronoicell_base::m_calc(int n,double &ans) {
-	double *pp=pts+4*n;
-	ans=*(pp++)*px;
-	ans+=*(pp++)*py;
-	ans+=*(pp++)*pz-prsq;
-	*pp=ans;
-	unsigned int maskr=ans<-tol?0:(ans>tol?2:1);
-	mask[n]=maskc|maskr;
-	return maskr;
+    double *pp=pts+4*n;
+    ans=*(pp++)*px;
+    ans+=*(pp++)*py;
+    ans+=*(pp++)*pz-prsq;
+    *pp=ans;
+    unsigned int maskr=ans<-tol?0:(ans>tol?2:1);
+    mask[n]=maskc|maskr;
+    return maskr;
 }
 
 /** Checks to see if a given vertex is inside, outside or within the test
@@ -2005,29 +1930,29 @@ unsigned int voronoicell_base::m_calc(int n,double &ans) {
  * \return -1 if the point is inside the plane, 1 if the point is outside the
  *         plane, or 0 if the point is within the plane. */
 inline unsigned int voronoicell_base::m_testx(int n,double &ans) {
-	unsigned int maskr;
-	if(mask[n]>=maskc) {
-		ans=pts[4*n+3];
-		maskr=mask[n]&3;
-	} else maskr=m_calc(n,ans);
-	if(maskr==0&&ans>-big_tol&&ed[n][nu[n]<<1]!=-1) {
-		ed[n][nu[n]<<1]=-1;
-		if(stackp3==stacke3) add_memory_xse();
-		*(stackp3++)=n;
-	}
-	return maskr;
+    unsigned int maskr;
+    if(mask[n]>=maskc) {
+        ans=pts[4*n+3];
+        maskr=mask[n]&3;
+    } else maskr=m_calc(n,ans);
+    if(maskr==0&&ans>-big_tol&&ed[n][nu[n]<<1]!=-1) {
+        ed[n][nu[n]<<1]=-1;
+        if(stackp3==stacke3) add_memory_xse();
+        *(stackp3++)=n;
+    }
+    return maskr;
 }
 
 /** This routine calculates the unit normal vectors for every face.
  * \param[out] v the vector to store the results in. */
 void voronoicell_base::normals(std::vector<double> &v) {
-	int i,j,k;
-	v.clear();
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) normals_search(v,i,j,k);
-	}
-	reset_edges();
+    int i,j,k;
+    v.clear();
+    for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        if(k>=0) normals_search(v,i,j,k);
+    }
+    reset_edges();
 }
 
 /** This inline routine is called by normals(). It attempts to construct a
@@ -2042,121 +1967,103 @@ void voronoicell_base::normals(std::vector<double> &v) {
  * \param[in] j the index of an edge of the vertex.
  * \param[in] k the neighboring vertex of i, set to ed[i][j]. */
 inline void voronoicell_base::normals_search(std::vector<double> &v,int i,int j,int k) {
-	ed[i][j]=-1-k;
-	int l=cycle_up(ed[i][nu[i]+j],k),m;
-	double ux,uy,uz,vx,vy,vz,wx,wy,wz,wmag;
-	do {
-		m=ed[k][l];ed[k][l]=-1-m;
-		ux=pts[4*m]-pts[4*k];
-		uy=pts[4*m+1]-pts[4*k+1];
-		uz=pts[4*m+2]-pts[4*k+2];
+    ed[i][j]=-1-k;
+    int l=cycle_up(ed[i][nu[i]+j],k),m;
+    double ux,uy,uz,vx,vy,vz,wx,wy,wz,wmag;
+    do {
+        m=ed[k][l];ed[k][l]=-1-m;
+        ux=pts[4*m]-pts[4*k];
+        uy=pts[4*m+1]-pts[4*k+1];
+        uz=pts[4*m+2]-pts[4*k+2];
 
-		// Test to see if the length of this edge is above the tolerance
-		if(ux*ux+uy*uy+uz*uz>tol) {
-			while(m!=i) {
-				l=cycle_up(ed[k][nu[k]+l],m);
-				k=m;m=ed[k][l];ed[k][l]=-1-m;
-				vx=pts[4*m]-pts[4*k];
-				vy=pts[4*m+1]-pts[4*k+1];
-				vz=pts[4*m+2]-pts[4*k+2];
+        // Test to see if the length of this edge is above the tolerance
+        if(ux*ux+uy*uy+uz*uz>tol) {
+            while(m!=i) {
+                l=cycle_up(ed[k][nu[k]+l],m);
+                k=m;m=ed[k][l];ed[k][l]=-1-m;
+                vx=pts[4*m]-pts[4*k];
+                vy=pts[4*m+1]-pts[4*k+1];
+                vz=pts[4*m+2]-pts[4*k+2];
 
-				// Construct the vector product of this edge with
-				// the previous one
-				wx=uz*vy-uy*vz;
-				wy=ux*vz-uz*vx;
-				wz=uy*vx-ux*vy;
-				wmag=wx*wx+wy*wy+wz*wz;
+                // Construct the vector product of this edge with
+                // the previous one
+                wx=uz*vy-uy*vz;
+                wy=ux*vz-uz*vx;
+                wz=uy*vx-ux*vy;
+                wmag=wx*wx+wy*wy+wz*wz;
 
-				// Test to see if this vector product of the
-				// two edges is above the tolerance
-				if(wmag>tol) {
+                // Test to see if this vector product of the
+                // two edges is above the tolerance
+                if(wmag>tol) {
 
-					// Construct the normal vector and print it
-					wmag=1/sqrt(wmag);
-					v.push_back(wx*wmag);
-					v.push_back(wy*wmag);
-					v.push_back(wz*wmag);
+                    // Construct the normal vector and print it
+                    wmag=1/sqrt(wmag);
+                    v.push_back(wx*wmag);
+                    v.push_back(wy*wmag);
+                    v.push_back(wz*wmag);
 
-					// Mark all of the remaining edges of this
-					// face and exit
-					while(m!=i) {
-						l=cycle_up(ed[k][nu[k]+l],m);
-						k=m;m=ed[k][l];ed[k][l]=-1-m;
-					}
-					return;
-				}
-			}
-			v.push_back(0);
-			v.push_back(0);
-			v.push_back(0);
-			return;
-		}
-		l=cycle_up(ed[k][nu[k]+l],m);
-		k=m;
-	} while (k!=i);
-	v.push_back(0);
-	v.push_back(0);
-	v.push_back(0);
+                    // Mark all of the remaining edges of this
+                    // face and exit
+                    while(m!=i) {
+                        l=cycle_up(ed[k][nu[k]+l],m);
+                        k=m;m=ed[k][l];ed[k][l]=-1-m;
+                    }
+                    return;
+                }
+            }
+            v.push_back(0);
+            v.push_back(0);
+            v.push_back(0);
+            return;
+        }
+        l=cycle_up(ed[k][nu[k]+l],m);
+        k=m;
+    } while (k!=i);
+    v.push_back(0);
+    v.push_back(0);
+    v.push_back(0);
 }
 
 /** Returns the number of faces of a computed Voronoi cell.
  * \return The number of faces. */
 int voronoicell_base::number_of_faces() {
-	int i,j,k,l,m,s=0;
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) {
-			s++;
-			ed[i][j]=-1-k;
-			l=cycle_up(ed[i][nu[i]+j],k);
-			do {
-				m=ed[k][l];
-				ed[k][l]=-1-m;
-				l=cycle_up(ed[k][nu[k]+l],m);
-				k=m;
-			} while (k!=i);
+    int i,j,k,l,m,s=0;
+    for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        if(k>=0) {
+            s++;
+            ed[i][j]=-1-k;
+            l=cycle_up(ed[i][nu[i]+j],k);
+            do {
+                m=ed[k][l];
+                ed[k][l]=-1-m;
+                l=cycle_up(ed[k][nu[k]+l],m);
+                k=m;
+            } while (k!=i);
 
-		}
-	}
-	reset_edges();
-	return s;
+        }
+    }
+    reset_edges();
+    return s;
 }
 
 /** Returns a vector of the vertex orders.
  * \param[out] v the vector to store the results in. */
 void voronoicell_base::vertex_orders(std::vector<int> &v) {
-	v.resize(p);
-	for(int i=0;i<p;i++) v[i]=nu[i];
-}
-
-/** Outputs the vertex orders.
- * \param[out] fp the file handle to write to. */
-void voronoicell_base::output_vertex_orders(FILE *fp) {
-	if(p>0) {
-		fprintf(fp,"%d",*nu);
-		for(int *nup=nu+1;nup<nu+p;nup++) fprintf(fp," %d",*nup);
-	}
+    v.resize(p);
+    for(int i=0;i<p;i++) v[i]=nu[i];
 }
 
 /** Returns a vector of the vertex vectors using the local coordinate system.
  * \param[out] v the vector to store the results in. */
 void voronoicell_base::vertices(std::vector<double> &v) {
-	v.resize(3*p);
-	double *ptsp=pts;
-	for(int i=0;i<3*p;i+=3) {
-		v[i]=*(ptsp++)*0.5;
-		v[i+1]=*(ptsp++)*0.5;
-		v[i+2]=*ptsp*0.5;ptsp+=2;
-	}
-}
-
-/** Outputs the vertex vectors using the local coordinate system.
- * \param[out] fp the file handle to write to. */
-void voronoicell_base::output_vertices(FILE *fp) {
-	if(p>0) {
-		fprintf(fp,"(%g,%g,%g)",*pts*0.5,pts[1]*0.5,pts[2]*0.5);
-		for(double *ptsp=pts+4;ptsp<pts+(p<<2);ptsp+=4) fprintf(fp," (%g,%g,%g)",*ptsp*0.5,ptsp[1]*0.5,ptsp[2]*0.5);
-	}
+    v.resize(3*p);
+    double *ptsp=pts;
+    for(int i=0;i<3*p;i+=3) {
+        v[i]=*(ptsp++)*0.5;
+        v[i+1]=*(ptsp++)*0.5;
+        v[i+2]=*ptsp*0.5;ptsp+=2;
+    }
 }
 
 /** Returns a vector of the vertex vectors in the global coordinate system.
@@ -2164,133 +2071,122 @@ void voronoicell_base::output_vertices(FILE *fp) {
  * \param[in] (x,y,z) the position vector of the particle in the global
  *                    coordinate system. */
 void voronoicell_base::vertices(double x,double y,double z,std::vector<double> &v) {
-	v.resize(3*p);
-	double *ptsp=pts;
-	for(int i=0;i<3*p;i+=3) {
-		v[i]=x+*(ptsp++)*0.5;
-		v[i+1]=y+*(ptsp++)*0.5;
-		v[i+2]=z+*ptsp*0.5;ptsp+=2;
-	}
-}
-
-/** Outputs the vertex vectors using the global coordinate system.
- * \param[out] fp the file handle to write to.
- * \param[in] (x,y,z) the position vector of the particle in the global
- *                    coordinate system. */
-void voronoicell_base::output_vertices(double x,double y,double z,FILE *fp) {
-	if(p>0) {
-		fprintf(fp,"(%g,%g,%g)",x+*pts*0.5,y+pts[1]*0.5,z+pts[2]*0.5);
-		for(double *ptsp=pts+4;ptsp<pts+(p<<2);ptsp+=4) fprintf(fp," (%g,%g,%g)",x+*ptsp*0.5,y+ptsp[1]*0.5,z+ptsp[2]*0.5);
-	}
+    v.resize(3*p);
+    double *ptsp=pts;
+    for(int i=0;i<3*p;i+=3) {
+        v[i]=x+*(ptsp++)*0.5;
+        v[i+1]=y+*(ptsp++)*0.5;
+        v[i+2]=z+*ptsp*0.5;ptsp+=2;
+    }
 }
 
 /** This routine returns the perimeters of each face.
  * \param[out] v the vector to store the results in. */
 void voronoicell_base::face_perimeters(std::vector<double> &v) {
-	v.clear();
-	int i,j,k,l,m;
-	double dx,dy,dz,perim;
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) {
-			dx=pts[k<<2]-pts[i<<2];
-			dy=pts[(k<<2)+1]-pts[(i<<2)+1];
-			dz=pts[(k<<2)+2]-pts[(i<<2)+2];
-			perim=sqrt(dx*dx+dy*dy+dz*dz);
-			ed[i][j]=-1-k;
-			l=cycle_up(ed[i][nu[i]+j],k);
-			do {
-				m=ed[k][l];
-				dx=pts[m<<2]-pts[k<<2];
-				dy=pts[(m<<2)+1]-pts[(k<<2)+1];
-				dz=pts[(m<<2)+2]-pts[(k<<2)+2];
-				perim+=sqrt(dx*dx+dy*dy+dz*dz);
-				ed[k][l]=-1-m;
-				l=cycle_up(ed[k][nu[k]+l],m);
-				k=m;
-			} while (k!=i);
-			v.push_back(0.5*perim);
-		}
-	}
-	reset_edges();
+    v.clear();
+    int i,j,k,l,m;
+    double dx,dy,dz,perim;
+    for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        if(k>=0) {
+            dx=pts[k<<2]-pts[i<<2];
+            dy=pts[(k<<2)+1]-pts[(i<<2)+1];
+            dz=pts[(k<<2)+2]-pts[(i<<2)+2];
+            perim=sqrt(dx*dx+dy*dy+dz*dz);
+            ed[i][j]=-1-k;
+            l=cycle_up(ed[i][nu[i]+j],k);
+            do {
+                m=ed[k][l];
+                dx=pts[m<<2]-pts[k<<2];
+                dy=pts[(m<<2)+1]-pts[(k<<2)+1];
+                dz=pts[(m<<2)+2]-pts[(k<<2)+2];
+                perim+=sqrt(dx*dx+dy*dy+dz*dz);
+                ed[k][l]=-1-m;
+                l=cycle_up(ed[k][nu[k]+l],m);
+                k=m;
+            } while (k!=i);
+            v.push_back(0.5*perim);
+        }
+    }
+    reset_edges();
 }
 
 /** For each face, this routine outputs a bracketed sequence of numbers
  * containing a list of all the vertices that make up that face.
  * \param[out] v the vector to store the results in. */
 void voronoicell_base::face_vertices(std::vector<int> &v) {
-	int i,j,k,l,m,vp(0),vn;
-	v.clear();
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) {
-			v.push_back(0);
-			v.push_back(i);
-			ed[i][j]=-1-k;
-			l=cycle_up(ed[i][nu[i]+j],k);
-			do {
-				v.push_back(k);
-				m=ed[k][l];
-				ed[k][l]=-1-m;
-				l=cycle_up(ed[k][nu[k]+l],m);
-				k=m;
-			} while (k!=i);
-			vn=v.size();
-			v[vp]=vn-vp-1;
-			vp=vn;
-		}
-	}
-	reset_edges();
+    int i,j,k,l,m,vp(0),vn;
+    v.clear();
+    for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        if(k>=0) {
+            v.push_back(0);
+            v.push_back(i);
+            ed[i][j]=-1-k;
+            l=cycle_up(ed[i][nu[i]+j],k);
+            do {
+                v.push_back(k);
+                m=ed[k][l];
+                ed[k][l]=-1-m;
+                l=cycle_up(ed[k][nu[k]+l],m);
+                k=m;
+            } while (k!=i);
+            vn=v.size();
+            v[vp]=vn-vp-1;
+            vp=vn;
+        }
+    }
+    reset_edges();
 }
 
 /** Outputs a list of the number of edges in each face.
  * \param[out] v the vector to store the results in. */
 void voronoicell_base::face_orders(std::vector<int> &v) {
-	int i,j,k,l,m,q;
-	v.clear();
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) {
-			q=1;
-			ed[i][j]=-1-k;
-			l=cycle_up(ed[i][nu[i]+j],k);
-			do {
-				q++;
-				m=ed[k][l];
-				ed[k][l]=-1-m;
-				l=cycle_up(ed[k][nu[k]+l],m);
-				k=m;
-			} while (k!=i);
-			v.push_back(q);;
-		}
-	}
-	reset_edges();
+    int i,j,k,l,m,q;
+    v.clear();
+    for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        if(k>=0) {
+            q=1;
+            ed[i][j]=-1-k;
+            l=cycle_up(ed[i][nu[i]+j],k);
+            do {
+                q++;
+                m=ed[k][l];
+                ed[k][l]=-1-m;
+                l=cycle_up(ed[k][nu[k]+l],m);
+                k=m;
+            } while (k!=i);
+            v.push_back(q);;
+        }
+    }
+    reset_edges();
 }
 
 /** Computes the number of edges that each face has and outputs a frequency
  * table of the results.
  * \param[out] v the vector to store the results in. */
 void voronoicell_base::face_freq_table(std::vector<int> &v) {
-	int i,j,k,l,m,q;
-	v.clear();
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) {
-			q=1;
-			ed[i][j]=-1-k;
-			l=cycle_up(ed[i][nu[i]+j],k);
-			do {
-				q++;
-				m=ed[k][l];
-				ed[k][l]=-1-m;
-				l=cycle_up(ed[k][nu[k]+l],m);
-				k=m;
-			} while (k!=i);
-			if((unsigned int) q>=v.size()) v.resize(q+1,0);
-			v[q]++;
-		}
-	}
-	reset_edges();
+    int i,j,k,l,m,q;
+    v.clear();
+    for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        if(k>=0) {
+            q=1;
+            ed[i][j]=-1-k;
+            l=cycle_up(ed[i][nu[i]+j],k);
+            do {
+                q++;
+                m=ed[k][l];
+                ed[k][l]=-1-m;
+                l=cycle_up(ed[k][nu[k]+l],m);
+                k=m;
+            } while (k!=i);
+            if((unsigned int) q>=v.size()) v.resize(q+1,0);
+            v[q]++;
+        }
+    }
+    reset_edges();
 }
 
 /** This routine tests to see whether the cell intersects a plane by starting
@@ -2300,9 +2196,9 @@ void voronoicell_base::face_freq_table(std::vector<int> &v) {
  * \param[in] rsq the distance along this vector of the plane.
  * \return False if the plane does not intersect the plane, true if it does. */
 bool voronoicell_base::plane_intersects(double x,double y,double z,double rsq) {
-	double g=x*pts[up<<2]+y*pts[(up<<2)+1]+z*pts[(up<<2)+2];
-	if(g<rsq) return plane_intersects_track(x,y,z,rsq,g);
-	return true;
+    double g=x*pts[up<<2]+y*pts[(up<<2)+1]+z*pts[(up<<2)+2];
+    if(g<rsq) return plane_intersects_track(x,y,z,rsq,g);
+    return true;
 }
 
 /** This routine tests to see if a cell intersects a plane. It first tests a
@@ -2313,22 +2209,22 @@ bool voronoicell_base::plane_intersects(double x,double y,double z,double rsq) {
  * \param[in] rsq the distance along this vector of the plane.
  * \return False if the plane does not intersect the plane, true if it does. */
 bool voronoicell_base::plane_intersects_guess(double x,double y,double z,double rsq) {
-	up=0;
-	double g=x*pts[up<<2]+y*pts[(up<<2)+1]+z*pts[(up<<2)+2];
-	if(g<rsq) {
-		int ca=1,cc=p>>3,mp=1;
-		double m;
-		while(ca<cc) {
-			m=x*pts[4*mp]+y*pts[4*mp+1]+z*pts[4*mp+2];
-			if(m>g) {
-				if(m>rsq) return true;
-				g=m;up=mp;
-			}
-			ca+=mp++;
-		}
-		return plane_intersects_track(x,y,z,rsq,g);
-	}
-	return true;
+    up=0;
+    double g=x*pts[up<<2]+y*pts[(up<<2)+1]+z*pts[(up<<2)+2];
+    if(g<rsq) {
+        int ca=1,cc=p>>3,mp=1;
+        double m;
+        while(ca<cc) {
+            m=x*pts[4*mp]+y*pts[4*mp+1]+z*pts[4*mp+2];
+            if(m>g) {
+                if(m>rsq) return true;
+                g=m;up=mp;
+            }
+            ca+=mp++;
+        }
+        return plane_intersects_track(x,y,z,rsq,g);
+    }
+    return true;
 }
 
 /* This routine tests to see if a cell intersects a plane, by tracing over the
@@ -2341,156 +2237,71 @@ bool voronoicell_base::plane_intersects_guess(double x,double y,double z,double 
  * \return False if the plane does not intersect the plane, true if it does. */
 inline bool voronoicell_base::plane_intersects_track(double x,double y,double z,double rsq,double g) {
 
-	for(int tp=0;tp<p;tp++) if(x*pts[tp<<2]+y*pts[(tp<<2)+1]+z*pts[(tp<<2)+2]>rsq) return true;
-	return false;
+    for(int tp=0;tp<p;tp++) if(x*pts[tp<<2]+y*pts[(tp<<2)+1]+z*pts[(tp<<2)+2]>rsq) return true;
+    return false;
 /*
-	int ls,us,lp;
-	double l,u;
-	unsigned int uw;
+    int ls,us,lp;
+    double l,u;
+    unsigned int uw;
 
-	// Initialize the safe testing routine
-	px=x;py=y;pz=z;prsq=rsq;
-	maskc+=4;
-	if(maskc<4) reset_mask();
+    // Initialize the safe testing routine
+    px=x;py=y;pz=z;prsq=rsq;
+    maskc+=4;
+    if(maskc<4) reset_mask();
 
-	return search_upward(uw,lp,ls,us,l,u);
+    return search_upward(uw,lp,ls,us,l,u);
 }*/
-	/*
-	int count=0,ls,us,tp;
-	double t;
-	// The test point is outside of the cutting space
-	for(us=0;us<nu[up];us++) {
-		tp=ed[up][us];
-		t=x*pts[tp<<2]+y*pts[(tp<<2)+1]+z*pts[(tp<<2)+2];
-		if(t>g) {
-			ls=ed[up][nu[up]+us];
-			up=tp;
-			while (t<rsq) {
-				if(++count>=p) {
+    /*
+    int count=0,ls,us,tp;
+    double t;
+    // The test point is outside of the cutting space
+    for(us=0;us<nu[up];us++) {
+        tp=ed[up][us];
+        t=x*pts[tp<<2]+y*pts[(tp<<2)+1]+z*pts[(tp<<2)+2];
+        if(t>g) {
+            ls=ed[up][nu[up]+us];
+            up=tp;
+            while (t<rsq) {
+                if(++count>=p) {
 #if VOROPP_VERBOSE >=1
-					fputs("Bailed out of convex calculation",stderr);
+                    fputs("Bailed out of convex calculation",stderr);
 #endif
-					for(tp=0;tp<p;tp++) if(x*pts[tp<<2]+y*pts[(tp<<2)+1]+z*pts[(tp<<2)+2]>rsq) return true;
-					return false;
-				}
+                    for(tp=0;tp<p;tp++) if(x*pts[tp<<2]+y*pts[(tp<<2)+1]+z*pts[(tp<<2)+2]>rsq) return true;
+                    return false;
+                }
 
-				// Test all the neighbors of the current point
-				// and find the one which is closest to the
-				// plane
-				for(us=0;us<ls;us++) {
-					tp=ed[up][us];double *pp=pts+(tp<<2);
-					g=x*(*pp)+y*pp[1]+z*pp[2];
-					if(g>t) break;
-				}
-				if(us==ls) {
-					us++;
-					while(us<nu[up]) {
-						tp=ed[up][us];double *pp=pts+(tp<<2);
-						g=x*(*pp)+y*pp[1]+z*pp[2];
-						if(g>t) break;
-						us++;
-					}
-					if(us==nu[up]) return false;
-				}
-				ls=ed[up][nu[up]+us];up=tp;t=g;
-			}
-			return true;
-		}
-	}
-	return false;*/
+                // Test all the neighbors of the current point
+                // and find the one which is closest to the
+                // plane
+                for(us=0;us<ls;us++) {
+                    tp=ed[up][us];double *pp=pts+(tp<<2);
+                    g=x*(*pp)+y*pp[1]+z*pp[2];
+                    if(g>t) break;
+                }
+                if(us==ls) {
+                    us++;
+                    while(us<nu[up]) {
+                        tp=ed[up][us];double *pp=pts+(tp<<2);
+                        g=x*(*pp)+y*pp[1]+z*pp[2];
+                        if(g>t) break;
+                        us++;
+                    }
+                    if(us==nu[up]) return false;
+                }
+                ls=ed[up][nu[up]+us];up=tp;t=g;
+            }
+            return true;
+        }
+    }
+    return false;*/
 }
 
 /** Counts the number of edges of the Voronoi cell.
  * \return the number of edges. */
 int voronoicell_base::number_of_edges() {
-	int edges=0,*nup=nu;
-	while(nup<nu+p) edges+=*(nup++);
-	return edges>>1;
-}
-
-/** Outputs a custom string of information about the Voronoi cell. The string
- * of information follows a similar style as the C printf command, and detailed
- * information about its format is available at
- * http://math.lbl.gov/voro++/doc/custom.html.
- * \param[in] format the custom string to print.
- * \param[in] i the ID of the particle associated with this Voronoi cell.
- * \param[in] (x,y,z) the position of the particle associated with this Voronoi
- *                    cell.
- * \param[in] r a radius associated with the particle.
- * \param[in] fp the file handle to write to. */
-void voronoicell_base::output_custom(const char *format,int i,double x,double y,double z,double r,FILE *fp) {
-	char *fmp=(const_cast<char*>(format));
-	std::vector<int> vi;
-	std::vector<double> vd;
-	while(*fmp!=0) {
-		if(*fmp=='%') {
-			fmp++;
-			switch(*fmp) {
-
-				// Particle-related output
-				case 'i': fprintf(fp,"%d",i);break;
-				case 'x': fprintf(fp,"%g",x);break;
-				case 'y': fprintf(fp,"%g",y);break;
-				case 'z': fprintf(fp,"%g",z);break;
-				case 'q': fprintf(fp,"%g %g %g",x,y,z);break;
-				case 'r': fprintf(fp,"%g",r);break;
-
-				// Vertex-related output
-				case 'w': fprintf(fp,"%d",p);break;
-				case 'p': output_vertices(fp);break;
-				case 'P': output_vertices(x,y,z,fp);break;
-				case 'o': output_vertex_orders(fp);break;
-				case 'm': fprintf(fp,"%g",0.25*max_radius_squared());break;
-
-				// Edge-related output
-				case 'g': fprintf(fp,"%d",number_of_edges());break;
-				case 'E': fprintf(fp,"%g",total_edge_distance());break;
-				case 'e': face_perimeters(vd);voro_print_vector(vd,fp);break;
-
-				// Face-related output
-				case 's': fprintf(fp,"%d",number_of_faces());break;
-				case 'F': fprintf(fp,"%g",surface_area());break;
-				case 'A': {
-						  face_freq_table(vi);
-						  voro_print_vector(vi,fp);
-					  } break;
-				case 'a': face_orders(vi);voro_print_vector(vi,fp);break;
-				case 'f': face_areas(vd);voro_print_vector(vd,fp);break;
-				case 't': {
-						  face_vertices(vi);
-						  voro_print_face_vertices(vi,fp);
-					  } break;
-				case 'l': normals(vd);
-					  voro_print_positions(vd,fp);
-					  break;
-				case 'n': neighbors(vi);
-					  voro_print_vector(vi,fp);
-					  break;
-
-				// Volume-related output
-				case 'v': fprintf(fp,"%g",volume());break;
-				case 'c': {
-						  double cx,cy,cz;
-						  centroid(cx,cy,cz);
-						  fprintf(fp,"%g %g %g",cx,cy,cz);
-					  } break;
-				case 'C': {
-						  double cx,cy,cz;
-						  centroid(cx,cy,cz);
-						  fprintf(fp,"%g %g %g",x+cx,y+cy,z+cz);
-					  } break;
-
-				// End-of-string reached
-				case 0: fmp--;break;
-
-				// The percent sign is not part of a
-				// control sequence
-				default: putc('%',fp);putc(*fmp,fp);
-			}
-		} else putc(*fmp,fp);
-		fmp++;
-	}
-	fputs("\n",fp);
+    int edges=0,*nup=nu;
+    while(nup<nu+p) edges+=*(nup++);
+    return edges>>1;
 }
 
 /** This initializes the class to be a rectangular box. It calls the base class
@@ -2501,18 +2312,18 @@ void voronoicell_base::output_custom(const char *format,int i,double x,double y,
  * \param[in] (ymin,ymax) the minimum and maximum y coordinates.
  * \param[in] (zmin,zmax) the minimum and maximum z coordinates. */
 void voronoicell_neighbor::init(double xmin,double xmax,double ymin,double ymax,double zmin,double zmax) {
-	init_base(xmin,xmax,ymin,ymax,zmin,zmax);
-	int *q=mne[3];
-	*q=-5;q[1]=-3;q[2]=-1;
-	q[3]=-5;q[4]=-2;q[5]=-3;
-	q[6]=-5;q[7]=-1;q[8]=-4;
-	q[9]=-5;q[10]=-4;q[11]=-2;
-	q[12]=-6;q[13]=-1;q[14]=-3;
-	q[15]=-6;q[16]=-3;q[17]=-2;
-	q[18]=-6;q[19]=-4;q[20]=-1;
-	q[21]=-6;q[22]=-2;q[23]=-4;
-	*ne=q;ne[1]=q+3;ne[2]=q+6;ne[3]=q+9;
-	ne[4]=q+12;ne[5]=q+15;ne[6]=q+18;ne[7]=q+21;
+    init_base(xmin,xmax,ymin,ymax,zmin,zmax);
+    int *q=mne[3];
+    *q=-5;q[1]=-3;q[2]=-1;
+    q[3]=-5;q[4]=-2;q[5]=-3;
+    q[6]=-5;q[7]=-1;q[8]=-4;
+    q[9]=-5;q[10]=-4;q[11]=-2;
+    q[12]=-6;q[13]=-1;q[14]=-3;
+    q[15]=-6;q[16]=-3;q[17]=-2;
+    q[18]=-6;q[19]=-4;q[20]=-1;
+    q[21]=-6;q[22]=-2;q[23]=-4;
+    *ne=q;ne[1]=q+3;ne[2]=q+6;ne[3]=q+9;
+    ne[4]=q+12;ne[5]=q+15;ne[6]=q+18;ne[7]=q+21;
 }
 
 /** This initializes the class to be an octahedron. It calls the base class
@@ -2523,15 +2334,15 @@ void voronoicell_neighbor::init(double xmin,double xmax,double ymin,double ymax,
  *              vertices are initialized at (-l,0,0), (l,0,0), (0,-l,0),
  *              (0,l,0), (0,0,-l), and (0,0,l). */
 void voronoicell_neighbor::init_octahedron(double l) {
-	init_octahedron_base(l);
-	int *q=mne[4];
-	*q=-5;q[1]=-6;q[2]=-7;q[3]=-8;
-	q[4]=-1;q[5]=-2;q[6]=-3;q[7]=-4;
-	q[8]=-6;q[9]=-5;q[10]=-2;q[11]=-1;
-	q[12]=-8;q[13]=-7;q[14]=-4;q[15]=-3;
-	q[16]=-5;q[17]=-8;q[18]=-3;q[19]=-2;
-	q[20]=-7;q[21]=-6;q[22]=-1;q[23]=-4;
-	*ne=q;ne[1]=q+4;ne[2]=q+8;ne[3]=q+12;ne[4]=q+16;ne[5]=q+20;
+    init_octahedron_base(l);
+    int *q=mne[4];
+    *q=-5;q[1]=-6;q[2]=-7;q[3]=-8;
+    q[4]=-1;q[5]=-2;q[6]=-3;q[7]=-4;
+    q[8]=-6;q[9]=-5;q[10]=-2;q[11]=-1;
+    q[12]=-8;q[13]=-7;q[14]=-4;q[15]=-3;
+    q[16]=-5;q[17]=-8;q[18]=-3;q[19]=-2;
+    q[20]=-7;q[21]=-6;q[22]=-1;q[23]=-4;
+    *ne=q;ne[1]=q+4;ne[2]=q+8;ne[3]=q+12;ne[4]=q+16;ne[5]=q+20;
 }
 
 /** This initializes the class to be a tetrahedron. It calls the base class
@@ -2543,102 +2354,74 @@ void voronoicell_neighbor::init_octahedron(double l) {
  * \param (x2,y2,z2) a position vector for the third vertex.
  * \param (x3,y3,z3) a position vector for the fourth vertex. */
 void voronoicell_neighbor::init_tetrahedron(double x0,double y0,double z0,double x1,double y1,double z1,double x2,double y2,double z2,double x3,double y3,double z3) {
-	init_tetrahedron_base(x0,y0,z0,x1,y1,z1,x2,y2,z2,x3,y3,z3);
-	int *q=mne[3];
-	*q=-4;q[1]=-3;q[2]=-2;
-	q[3]=-3;q[4]=-4;q[5]=-1;
-	q[6]=-4;q[7]=-2;q[8]=-1;
-	q[9]=-2;q[10]=-3;q[11]=-1;
-	*ne=q;ne[1]=q+3;ne[2]=q+6;ne[3]=q+9;
+    init_tetrahedron_base(x0,y0,z0,x1,y1,z1,x2,y2,z2,x3,y3,z3);
+    int *q=mne[3];
+    *q=-4;q[1]=-3;q[2]=-2;
+    q[3]=-3;q[4]=-4;q[5]=-1;
+    q[6]=-4;q[7]=-2;q[8]=-1;
+    q[9]=-2;q[10]=-3;q[11]=-1;
+    *ne=q;ne[1]=q+3;ne[2]=q+6;ne[3]=q+9;
 }
 
 /** This routine checks to make sure the neighbor information of each face is
  * consistent. */
 void voronoicell_neighbor::check_facets() {
-	int i,j,k,l,m,q;
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) {
-			ed[i][j]=-1-k;
-			q=ne[i][j];
-			l=cycle_up(ed[i][nu[i]+j],k);
-			do {
-				m=ed[k][l];
-				ed[k][l]=-1-m;
-				if(ne[k][l]!=q) fprintf(stderr,"Facet error at (%d,%d)=%d, started from (%d,%d)=%d\n",k,l,ne[k][l],i,j,q);
-				l=cycle_up(ed[k][nu[k]+l],m);
-				k=m;
-			} while (k!=i);
-		}
-	}
-	reset_edges();
+    int i,j,k,l,m,q;
+    for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        if(k>=0) {
+            ed[i][j]=-1-k;
+            q=ne[i][j];
+            l=cycle_up(ed[i][nu[i]+j],k);
+            do {
+                m=ed[k][l];
+                ed[k][l]=-1-m;
+                if(ne[k][l]!=q) fprintf(stderr,"Facet error at (%d,%d)=%d, started from (%d,%d)=%d\n",k,l,ne[k][l],i,j,q);
+                l=cycle_up(ed[k][nu[k]+l],m);
+                k=m;
+            } while (k!=i);
+        }
+    }
+    reset_edges();
 }
 
 /** The class constructor allocates memory for storing neighbor information. */
 void voronoicell_neighbor::memory_setup() {
-	int i;
-	mne=new int*[current_vertex_order];
-	ne=new int*[current_vertices];
-	for(i=0;i<3;i++) mne[i]=new int[init_n_vertices*i];
-	mne[3]=new int[init_3_vertices*3];
-	for(i=4;i<current_vertex_order;i++) mne[i]=new int[init_n_vertices*i];
+    int i;
+    mne=new int*[current_vertex_order];
+    ne=new int*[current_vertices];
+    for(i=0;i<3;i++) mne[i]=new int[init_n_vertices*i];
+    mne[3]=new int[init_3_vertices*3];
+    for(i=4;i<current_vertex_order;i++) mne[i]=new int[init_n_vertices*i];
 }
 
 /** The class destructor frees the dynamically allocated memory for storing
  * neighbor information. */
 voronoicell_neighbor::~voronoicell_neighbor() {
-	for(int i=current_vertex_order-1;i>=0;i--) if(mem[i]>0) delete [] mne[i];
-	delete [] mne;
-	delete [] ne;
+    for(int i=current_vertex_order-1;i>=0;i--) if(mem[i]>0) delete [] mne[i];
+    delete [] mne;
+    delete [] ne;
 }
 
 /** Computes a vector list of neighbors. */
 void voronoicell_neighbor::neighbors(std::vector<int> &v) {
-	v.clear();
-	int i,j,k,l,m;
-	for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
-		k=ed[i][j];
-		if(k>=0) {
-			v.push_back(ne[i][j]);
-			ed[i][j]=-1-k;
-			l=cycle_up(ed[i][nu[i]+j],k);
-			do {
-				m=ed[k][l];
-				ed[k][l]=-1-m;
-				l=cycle_up(ed[k][nu[k]+l],m);
-				k=m;
-			} while (k!=i);
-		}
-	}
-	reset_edges();
-}
-
-/** Prints the vertices, their edges, the relation table, and also notifies if
- * any memory errors are visible. */
-void voronoicell_base::print_edges() {
-	int j;
-	double *ptsp=pts;
-	for(int i=0;i<p;i++,ptsp+=4) {
-		printf("%d %d  ",i,nu[i]);
-		for(j=0;j<nu[i];j++) printf(" %d",ed[i][j]);
-		printf("  ");
-		while(j<(nu[i]<<1)) printf(" %d",ed[i][j]);
-		printf("   %d",ed[i][j]);
-		print_edges_neighbors(i);
-		printf("  %g %g %g %p",*ptsp,ptsp[1],ptsp[2],(void*) ed[i]);
-		if(ed[i]>=mep[nu[i]]+mec[nu[i]]*((nu[i]<<1)+1)) puts(" Memory error");
-		else puts("");
-	}
-}
-
-/** This prints out the neighbor information for vertex i. */
-void voronoicell_neighbor::print_edges_neighbors(int i) {
-	if(nu[i]>0) {
-		int j=0;
-		printf("     (");
-		while(j<nu[i]-1) printf("%d,",ne[i][j++]);
-		printf("%d)",ne[i][j]);
-	} else printf("     ()");
+    v.clear();
+    int i,j,k,l,m;
+    for(i=1;i<p;i++) for(j=0;j<nu[i];j++) {
+        k=ed[i][j];
+        if(k>=0) {
+            v.push_back(ne[i][j]);
+            ed[i][j]=-1-k;
+            l=cycle_up(ed[i][nu[i]+j],k);
+            do {
+                m=ed[k][l];
+                ed[k][l]=-1-m;
+                l=cycle_up(ed[k][nu[k]+l],m);
+                k=m;
+            } while (k!=i);
+        }
+    }
+    reset_edges();
 }
 
 // Explicit instantiation

--- a/SKIRT/voro/cell.hh
+++ b/SKIRT/voro/cell.hh
@@ -95,38 +95,6 @@ class voronoicell_base {
         void init_octahedron_base(double l);
         void init_tetrahedron_base(double x0,double y0,double z0,double x1,double y1,double z1,double x2,double y2,double z2,double x3,double y3,double z3);
         void translate(double x,double y,double z);
-        void draw_pov(double x,double y,double z,FILE *fp=stdout);
-        /** Outputs the cell in POV-Ray format, using cylinders for edges
-         * and spheres for vertices, to a given file.
-         * \param[in] (x,y,z) a displacement to add to the cell's
-         *                    position.
-         * \param[in] filename the name of the file to write to. */
-        inline void draw_pov(double x,double y,double z,const char *filename) {
-            FILE *fp=safe_fopen(filename,"w");
-            draw_pov(x,y,z,fp);
-            fclose(fp);
-        }
-        void draw_pov_mesh(double x,double y,double z,FILE *fp=stdout);
-        /** Outputs the cell in POV-Ray format as a mesh2 object to a
-         * given file.
-         * \param[in] (x,y,z) a displacement to add to the cell's
-         *                    position.
-         * \param[in] filename the name of the file to write to. */
-        inline void draw_pov_mesh(double x,double y,double z,const char *filename) {
-            FILE *fp=safe_fopen(filename,"w");
-            draw_pov_mesh(x,y,z,fp);
-            fclose(fp);
-        }
-        void draw_gnuplot(double x,double y,double z,FILE *fp=stdout);
-        /** Outputs the cell in Gnuplot format a given file.
-         * \param[in] (x,y,z) a displacement to add to the cell's
-         *                    position.
-         * \param[in] filename the name of the file to write to. */
-        inline void draw_gnuplot(double x,double y,double z,const char *filename) {
-            FILE *fp=safe_fopen(filename,"w");
-            draw_gnuplot(x,y,z,fp);
-            fclose(fp);
-        }
         double volume();
         double max_radius_squared();
         double total_edge_distance();
@@ -135,59 +103,15 @@ class voronoicell_base {
         int number_of_faces();
         int number_of_edges();
         void vertex_orders(std::vector<int> &v);
-        void output_vertex_orders(FILE *fp=stdout);
         void vertices(std::vector<double> &v);
-        void output_vertices(FILE *fp=stdout);
         void vertices(double x,double y,double z,std::vector<double> &v);
-        void output_vertices(double x,double y,double z,FILE *fp=stdout);
         void face_areas(std::vector<double> &v);
         void minkowski(double r,double &ar,double &vo);
-        /** Outputs the areas of the faces.
-         * \param[in] fp the file handle to write to. */
-        inline void output_face_areas(FILE *fp=stdout) {
-            std::vector<double> v;face_areas(v);
-            voro_print_vector(v,fp);
-        }
         void face_orders(std::vector<int> &v);
-        /** Outputs a list of the number of sides of each face.
-         * \param[in] fp the file handle to write to. */
-        inline void output_face_orders(FILE *fp=stdout) {
-            std::vector<int> v;face_orders(v);
-            voro_print_vector(v,fp);
-        }
         void face_freq_table(std::vector<int> &v);
-        /** Outputs a */
-        inline void output_face_freq_table(FILE *fp=stdout) {
-            std::vector<int> v;face_freq_table(v);
-            voro_print_vector(v,fp);
-        }
         void face_vertices(std::vector<int> &v);
-        /** Outputs the */
-        inline void output_face_vertices(FILE *fp=stdout) {
-            std::vector<int> v;face_vertices(v);
-            voro_print_face_vertices(v,fp);
-        }
         void face_perimeters(std::vector<double> &v);
-        /** Outputs a list of the perimeters of each face.
-         * \param[in] fp the file handle to write to. */
-        inline void output_face_perimeters(FILE *fp=stdout) {
-            std::vector<double> v;face_perimeters(v);
-            voro_print_vector(v,fp);
-        }
         void normals(std::vector<double> &v);
-        /** Outputs a list of the perimeters of each face.
-         * \param[in] fp the file handle to write to. */
-        inline void output_normals(FILE *fp=stdout) {
-            std::vector<double> v;normals(v);
-            voro_print_positions(v,fp);
-        }
-        /** Outputs a custom string of information about the Voronoi
-         * cell to a file. It assumes the cell is at (0,0,0) and has a
-         * the default_radius associated with it.
-         * \param[in] format the custom format string to use.
-         * \param[in] fp the file handle to write to. */
-        inline void output_custom(const char *format,FILE *fp=stdout) {output_custom(format,0,0,0,0,default_radius,fp);}
-        void output_custom(const char *format,int i,double x,double y,double z,double r,FILE *fp=stdout);
         template<class vc_class>
         bool nplane(vc_class &vc,double x,double y,double z,double rsq,int p_id);
         bool plane_intersects(double x,double y,double z,double rsq);
@@ -195,25 +119,12 @@ class voronoicell_base {
         void construct_relations();
         void check_relations();
         void check_duplicates();
-        void print_edges();
         /** Returns a list of IDs of neighboring particles
          * corresponding to each face.
          * \param[out] v a reference to a vector in which to return the
          *               results. If no neighbor information is
          *               available, a blank vector is returned. */
         virtual void neighbors(std::vector<int> &v) {v.clear();}
-        /** This is a virtual function that is overridden by a routine
-         * to print a list of IDs of neighboring particles
-         * corresponding to each face. By default, when no neighbor
-         * information is available, the routine does nothing.
-         * \param[in] fp the file handle to write to. */
-        virtual void output_neighbors(FILE * /*fp=stdout*/) {}
-        /** This a virtual function that is overridden by a routine to
-         * print the neighboring particle IDs for a given vertex. By
-         * default, when no neighbor information is available, the
-         * routine does nothing.
-         * \param[in] i the vertex to consider. */
-        virtual void print_edges_neighbors(int /*i*/) {}
         /** This is a simple inline function for picking out the index
          * of the next edge counterclockwise at the current vertex.
          * \param[in] a the index of an edge of the current vertex.
@@ -499,11 +410,6 @@ class voronoicell_neighbor : public voronoicell_base {
         void init_tetrahedron(double x0,double y0,double z0,double x1,double y1,double z1,double x2,double y2,double z2,double x3,double y3,double z3);
         void check_facets();
         virtual void neighbors(std::vector<int> &v);
-        virtual void print_edges_neighbors(int i);
-        virtual void output_neighbors(FILE *fp=stdout) {
-            std::vector<int> v;neighbors(v);
-            voro_print_vector(v,fp);
-        }
     private:
         int *paux1;
         int *paux2;

--- a/SKIRT/voro/common.cc
+++ b/SKIRT/voro/common.cc
@@ -29,20 +29,4 @@ void voro_fatal_error(const char *p,int status) {
     exit(status);
 }
 
-/** \brief Opens a file and checks the operation was successful.
- *
- * Opens a file, and checks the return value to ensure that the operation
- * was successful.
- * \param[in] filename the file to open.
- * \param[in] mode the cstdio fopen mode to use.
- * \return The file handle. */
-FILE* safe_fopen(const char *filename,const char *mode) {
-    FILE *fp=fopen(filename,mode);
-    if(fp==NULL) {
-        fprintf(stderr,"voro++: Unable to open file '%s'\n",filename);
-        exit(VOROPP_FILE_ERROR);
-    }
-    return fp;
-}
-
 }

--- a/SKIRT/voro/common.cc
+++ b/SKIRT/voro/common.cc
@@ -12,11 +12,11 @@
 namespace voro {
 
 void check_duplicate(int n,double x,double y,double z,int id,double *qp) {
-	double dx=*qp-x,dy=qp[1]-y,dz=qp[2]-z;
-	if(dx*dx+dy*dy+dz*dz<1e-10) {
-		printf("Duplicate: %d (%g,%g,%g) matches %d (%g,%g,%g)\n",n,x,y,z,id,*qp,qp[1],qp[2]);
-		exit(1);
-	}
+    double dx=*qp-x,dy=qp[1]-y,dz=qp[2]-z;
+    if(dx*dx+dy*dy+dz*dz<1e-10) {
+        printf("Duplicate: %d (%g,%g,%g) matches %d (%g,%g,%g)\n",n,x,y,z,id,*qp,qp[1],qp[2]);
+        exit(1);
+    }
 }
 
 /** \brief Function for printing fatal error messages and exiting.
@@ -25,22 +25,8 @@ void check_duplicate(int n,double x,double y,double z,int id,double *qp) {
  * \param[in] p a pointer to the message to print.
  * \param[in] status the status code to return with. */
 void voro_fatal_error(const char *p,int status) {
-	fprintf(stderr,"voro++: %s\n",p);
-	exit(status);
-}
-
-/** \brief Prints a vector of positions.
- *
- * Prints a vector of positions as bracketed triplets.
- * \param[in] v the vector to print.
- * \param[in] fp the file stream to print to. */
-void voro_print_positions(std::vector<double> &v,FILE *fp) {
-	if(v.size()>0) {
-		fprintf(fp,"(%g,%g,%g)",v[0],v[1],v[2]);
-		for(int k=3;(unsigned int) k<v.size();k+=3) {
-			fprintf(fp," (%g,%g,%g)",v[k],v[k+1],v[k+2]);
-		}
-	}
+    fprintf(stderr,"voro++: %s\n",p);
+    exit(status);
 }
 
 /** \brief Opens a file and checks the operation was successful.
@@ -51,88 +37,12 @@ void voro_print_positions(std::vector<double> &v,FILE *fp) {
  * \param[in] mode the cstdio fopen mode to use.
  * \return The file handle. */
 FILE* safe_fopen(const char *filename,const char *mode) {
-	FILE *fp=fopen(filename,mode);
-	if(fp==NULL) {
-		fprintf(stderr,"voro++: Unable to open file '%s'\n",filename);
-		exit(VOROPP_FILE_ERROR);
-	}
-	return fp;
-}
-
-/** \brief Prints a vector of integers.
- *
- * Prints a vector of integers.
- * \param[in] v the vector to print.
- * \param[in] fp the file stream to print to. */
-void voro_print_vector(std::vector<int> &v,FILE *fp) {
-	int k=0,s=v.size();
-	while(k+4<s) {
-		fprintf(fp,"%d %d %d %d ",v[k],v[k+1],v[k+2],v[k+3]);
-		k+=4;
-	}
-	if(k+3<=s) {
-		if(k+4==s) fprintf(fp,"%d %d %d %d",v[k],v[k+1],v[k+2],v[k+3]);
-		else fprintf(fp,"%d %d %d",v[k],v[k+1],v[k+2]);
-	} else {
-		if(k+2==s) fprintf(fp,"%d %d",v[k],v[k+1]);
-		else fprintf(fp,"%d",v[k]);
-	}
-}
-
-/** \brief Prints a vector of doubles.
- *
- * Prints a vector of doubles.
- * \param[in] v the vector to print.
- * \param[in] fp the file stream to print to. */
-void voro_print_vector(std::vector<double> &v,FILE *fp) {
-	int k=0,s=v.size();
-	while(k+4<s) {
-		fprintf(fp,"%g %g %g %g ",v[k],v[k+1],v[k+2],v[k+3]);
-		k+=4;
-	}
-	if(k+3<=s) {
-		if(k+4==s) fprintf(fp,"%g %g %g %g",v[k],v[k+1],v[k+2],v[k+3]);
-		else fprintf(fp,"%g %g %g",v[k],v[k+1],v[k+2]);
-	} else {
-		if(k+2==s) fprintf(fp,"%g %g",v[k],v[k+1]);
-		else fprintf(fp,"%g",v[k]);
-	}
-}
-
-/** \brief Prints a vector a face vertex information.
- *
- * Prints a vector of face vertex information. A value is read, which
- * corresponds to the number of vertices in the next face. The routine reads
- * this number of values and prints them as a bracked list. This is repeated
- * until the end of the vector is reached.
- * \param[in] v the vector to interpret and print.
- * \param[in] fp the file stream to print to. */
-void voro_print_face_vertices(std::vector<int> &v,FILE *fp) {
-	int j,k=0,l;
-	if(v.size()>0) {
-		l=v[k++];
-		if(l<=1) {
-			if(l==1) fprintf(fp,"(%d)",v[k++]);
-			else fputs("()",fp);
-		} else {
-			j=k+l;
-			fprintf(fp,"(%d",v[k++]);
-			while(k<j) fprintf(fp,",%d",v[k++]);
-			fputs(")",fp);
-		}
-		while((unsigned int) k<v.size()) {
-			l=v[k++];
-			if(l<=1) {
-				if(l==1) fprintf(fp," (%d)",v[k++]);
-				else fputs(" ()",fp);
-			} else {
-				j=k+l;
-				fprintf(fp," (%d",v[k++]);
-				while(k<j) fprintf(fp,",%d",v[k++]);
-				fputs(")",fp);
-			}
-		}
-	}
+    FILE *fp=fopen(filename,mode);
+    if(fp==NULL) {
+        fprintf(stderr,"voro++: Unable to open file '%s'\n",filename);
+        exit(VOROPP_FILE_ERROR);
+    }
+    return fp;
 }
 
 }

--- a/SKIRT/voro/common.hh
+++ b/SKIRT/voro/common.hh
@@ -21,11 +21,7 @@ namespace voro {
 void check_duplicate(int n,double x,double y,double z,int id,double *qp);
 
 void voro_fatal_error(const char *p,int status);
-void voro_print_positions(std::vector<double> &v,FILE *fp=stdout);
 FILE* safe_fopen(const char *filename,const char *mode);
-void voro_print_vector(std::vector<int> &v,FILE *fp=stdout);
-void voro_print_vector(std::vector<double> &v,FILE *fp=stdout);
-void voro_print_face_vertices(std::vector<int> &v,FILE *fp=stdout);
 
 }
 

--- a/SKIRT/voro/common.hh
+++ b/SKIRT/voro/common.hh
@@ -21,7 +21,6 @@ namespace voro {
 void check_duplicate(int n,double x,double y,double z,int id,double *qp);
 
 void voro_fatal_error(const char *p,int status);
-FILE* safe_fopen(const char *filename,const char *mode);
 
 }
 

--- a/SKIRT/voro/container.cc
+++ b/SKIRT/voro/container.cc
@@ -28,30 +28,30 @@ namespace voro {
  * \param[in] ps_ the number of floating point entries to store for each
  *                particle. */
 container_base::container_base(double ax_,double bx_,double ay_,double by_,double az_,double bz_,
-		int nx_,int ny_,int nz_,bool xperiodic_,bool yperiodic_,bool zperiodic_,int init_mem,int ps_)
-	: voro_base(nx_,ny_,nz_,(bx_-ax_)/nx_,(by_-ay_)/ny_,(bz_-az_)/nz_),
-	ax(ax_), bx(bx_), ay(ay_), by(by_), az(az_), bz(bz_),
-	max_len_sq((bx-ax)*(bx-ax)*(xperiodic_?0.25:1)+(by-ay)*(by-ay)*(yperiodic_?0.25:1)
-		  +(bz-az)*(bz-az)*(zperiodic_?0.25:1)),
-	xperiodic(xperiodic_), yperiodic(yperiodic_), zperiodic(zperiodic_),
-	id(new int*[nxyz]), p(new double*[nxyz]), co(new int[nxyz]), mem(new int[nxyz]), ps(ps_) {
+        int nx_,int ny_,int nz_,bool xperiodic_,bool yperiodic_,bool zperiodic_,int init_mem,int ps_)
+    : voro_base(nx_,ny_,nz_,(bx_-ax_)/nx_,(by_-ay_)/ny_,(bz_-az_)/nz_),
+    ax(ax_), bx(bx_), ay(ay_), by(by_), az(az_), bz(bz_),
+    max_len_sq((bx-ax)*(bx-ax)*(xperiodic_?0.25:1)+(by-ay)*(by-ay)*(yperiodic_?0.25:1)
+          +(bz-az)*(bz-az)*(zperiodic_?0.25:1)),
+    xperiodic(xperiodic_), yperiodic(yperiodic_), zperiodic(zperiodic_),
+    id(new int*[nxyz]), p(new double*[nxyz]), co(new int[nxyz]), mem(new int[nxyz]), ps(ps_) {
 
-	int l;
-	for(l=0;l<nxyz;l++) co[l]=0;
-	for(l=0;l<nxyz;l++) mem[l]=init_mem;
-	for(l=0;l<nxyz;l++) id[l]=new int[init_mem];
-	for(l=0;l<nxyz;l++) p[l]=new double[ps*init_mem];
+    int l;
+    for(l=0;l<nxyz;l++) co[l]=0;
+    for(l=0;l<nxyz;l++) mem[l]=init_mem;
+    for(l=0;l<nxyz;l++) id[l]=new int[init_mem];
+    for(l=0;l<nxyz;l++) p[l]=new double[ps*init_mem];
 }
 
 /** The container destructor frees the dynamically allocated memory. */
 container_base::~container_base() {
-	int l;
-	for(l=0;l<nxyz;l++) delete [] p[l];
-	for(l=0;l<nxyz;l++) delete [] id[l];
-	delete [] id;
-	delete [] p;
-	delete [] co;
-	delete [] mem;
+    int l;
+    for(l=0;l<nxyz;l++) delete [] p[l];
+    for(l=0;l<nxyz;l++) delete [] id[l];
+    delete [] id;
+    delete [] p;
+    delete [] co;
+    delete [] mem;
 }
 
 /** The class constructor sets up the geometry of container.
@@ -65,9 +65,9 @@ container_base::~container_base() {
  *                                               coordinate direction.
  * \param[in] init_mem the initial memory allocation for each block. */
 container::container(double ax_,double bx_,double ay_,double by_,double az_,double bz_,
-	int nx_,int ny_,int nz_,bool xperiodic_,bool yperiodic_,bool zperiodic_,int init_mem)
-	: container_base(ax_,bx_,ay_,by_,az_,bz_,nx_,ny_,nz_,xperiodic_,yperiodic_,zperiodic_,init_mem,3),
-	vc(*this,xperiodic_?2*nx_+1:nx_,yperiodic_?2*ny_+1:ny_,zperiodic_?2*nz_+1:nz_) {}
+    int nx_,int ny_,int nz_,bool xperiodic_,bool yperiodic_,bool zperiodic_,int init_mem)
+    : container_base(ax_,bx_,ay_,by_,az_,bz_,nx_,ny_,nz_,xperiodic_,yperiodic_,zperiodic_,init_mem,3),
+    vc(*this,xperiodic_?2*nx_+1:nx_,yperiodic_?2*ny_+1:ny_,zperiodic_?2*nz_+1:nz_) {}
 
 /** The class constructor sets up the geometry of container.
  * \param[in] (ax_,bx_) the minimum and maximum x coordinates.
@@ -80,20 +80,20 @@ container::container(double ax_,double bx_,double ay_,double by_,double az_,doub
  *                                               coordinate direction.
  * \param[in] init_mem the initial memory allocation for each block. */
 container_poly::container_poly(double ax_,double bx_,double ay_,double by_,double az_,double bz_,
-	int nx_,int ny_,int nz_,bool xperiodic_,bool yperiodic_,bool zperiodic_,int init_mem)
-	: container_base(ax_,bx_,ay_,by_,az_,bz_,nx_,ny_,nz_,xperiodic_,yperiodic_,zperiodic_,init_mem,4),
-	vc(*this,xperiodic_?2*nx_+1:nx_,yperiodic_?2*ny_+1:ny_,zperiodic_?2*nz_+1:nz_) {ppr=p;}
+    int nx_,int ny_,int nz_,bool xperiodic_,bool yperiodic_,bool zperiodic_,int init_mem)
+    : container_base(ax_,bx_,ay_,by_,az_,bz_,nx_,ny_,nz_,xperiodic_,yperiodic_,zperiodic_,init_mem,4),
+    vc(*this,xperiodic_?2*nx_+1:nx_,yperiodic_?2*ny_+1:ny_,zperiodic_?2*nz_+1:nz_) {ppr=p;}
 
 /** Put a particle into the correct region of the container.
  * \param[in] n the numerical ID of the inserted particle.
  * \param[in] (x,y,z) the position vector of the inserted particle. */
 void container::put(int n,double x,double y,double z) {
-	int ijk;
-	if(put_locate_block(ijk,x,y,z)) {
-		id[ijk][co[ijk]]=n;
-		double *pp=p[ijk]+3*co[ijk]++;
-		*(pp++)=x;*(pp++)=y;*pp=z;
-	}
+    int ijk;
+    if(put_locate_block(ijk,x,y,z)) {
+        id[ijk][co[ijk]]=n;
+        double *pp=p[ijk]+3*co[ijk]++;
+        *(pp++)=x;*(pp++)=y;*pp=z;
+    }
 }
 
 /** Put a particle into the correct region of the container.
@@ -101,13 +101,13 @@ void container::put(int n,double x,double y,double z) {
  * \param[in] (x,y,z) the position vector of the inserted particle.
  * \param[in] r the radius of the particle. */
 void container_poly::put(int n,double x,double y,double z,double r) {
-	int ijk;
-	if(put_locate_block(ijk,x,y,z)) {
-		id[ijk][co[ijk]]=n;
-		double *pp=p[ijk]+4*co[ijk]++;
-		*(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-		if(max_radius<r) max_radius=r;
-	}
+    int ijk;
+    if(put_locate_block(ijk,x,y,z)) {
+        id[ijk][co[ijk]]=n;
+        double *pp=p[ijk]+4*co[ijk]++;
+        *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
+        if(max_radius<r) max_radius=r;
+    }
 }
 
 /** Put a particle into the correct region of the container, also recording
@@ -116,13 +116,13 @@ void container_poly::put(int n,double x,double y,double z,double r) {
  * \param[in] n the numerical ID of the inserted particle.
  * \param[in] (x,y,z) the position vector of the inserted particle. */
 void container::put(particle_order &vo,int n,double x,double y,double z) {
-	int ijk;
-	if(put_locate_block(ijk,x,y,z)) {
-		id[ijk][co[ijk]]=n;
-		vo.add(ijk,co[ijk]);
-		double *pp=p[ijk]+3*co[ijk]++;
-		*(pp++)=x;*(pp++)=y;*pp=z;
-	}
+    int ijk;
+    if(put_locate_block(ijk,x,y,z)) {
+        id[ijk][co[ijk]]=n;
+        vo.add(ijk,co[ijk]);
+        double *pp=p[ijk]+3*co[ijk]++;
+        *(pp++)=x;*(pp++)=y;*pp=z;
+    }
 }
 
 /** Put a particle into the correct region of the container, also recording
@@ -132,14 +132,14 @@ void container::put(particle_order &vo,int n,double x,double y,double z) {
  * \param[in] (x,y,z) the position vector of the inserted particle.
  * \param[in] r the radius of the particle. */
 void container_poly::put(particle_order &vo,int n,double x,double y,double z,double r) {
-	int ijk;
-	if(put_locate_block(ijk,x,y,z)) {
-		id[ijk][co[ijk]]=n;
-		vo.add(ijk,co[ijk]);
-		double *pp=p[ijk]+4*co[ijk]++;
-		*(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-		if(max_radius<r) max_radius=r;
-	}
+    int ijk;
+    if(put_locate_block(ijk,x,y,z)) {
+        id[ijk][co[ijk]]=n;
+        vo.add(ijk,co[ijk]);
+        double *pp=p[ijk]+4*co[ijk]++;
+        *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
+        if(max_radius<r) max_radius=r;
+    }
 }
 
 /** This routine takes a particle position vector, tries to remap it into the
@@ -152,14 +152,14 @@ void container_poly::put(particle_order &vo,int n,double x,double y,double z,dou
  * \return True if the particle can be successfully placed into the container,
  * false otherwise. */
 bool container_base::put_locate_block(int &ijk,double &x,double &y,double &z) {
-	if(put_remap(ijk,x,y,z)) {
-		if(co[ijk]==mem[ijk]) add_particle_memory(ijk);
-		return true;
-	}
+    if(put_remap(ijk,x,y,z)) {
+        if(co[ijk]==mem[ijk]) add_particle_memory(ijk);
+        return true;
+    }
 #if VOROPP_REPORT_OUT_OF_BOUNDS ==1
-	fprintf(stderr,"Out of bounds: (x,y,z)=(%g,%g,%g)\n",x,y,z);
+    fprintf(stderr,"Out of bounds: (x,y,z)=(%g,%g,%g)\n",x,y,z);
 #endif
-	return false;
+    return false;
 }
 
 /** Takes a particle position vector and computes the region index into which
@@ -172,22 +172,22 @@ bool container_base::put_locate_block(int &ijk,double &x,double &y,double &z) {
  * \return True if the particle can be successfully placed into the container,
  * false otherwise. */
 inline bool container_base::put_remap(int &ijk,double &x,double &y,double &z) {
-	int l;
+    int l;
 
-	ijk=step_int((x-ax)*xsp);
-	if(xperiodic) {l=step_mod(ijk,nx);x+=boxx*(l-ijk);ijk=l;}
-	else if(ijk<0||ijk>=nx) return false;
+    ijk=step_int((x-ax)*xsp);
+    if(xperiodic) {l=step_mod(ijk,nx);x+=boxx*(l-ijk);ijk=l;}
+    else if(ijk<0||ijk>=nx) return false;
 
-	int j=step_int((y-ay)*ysp);
-	if(yperiodic) {l=step_mod(j,ny);y+=boxy*(l-j);j=l;}
-	else if(j<0||j>=ny) return false;
+    int j=step_int((y-ay)*ysp);
+    if(yperiodic) {l=step_mod(j,ny);y+=boxy*(l-j);j=l;}
+    else if(j<0||j>=ny) return false;
 
-	int k=step_int((z-az)*zsp);
-	if(zperiodic) {l=step_mod(k,nz);z+=boxz*(l-k);k=l;}
-	else if(k<0||k>=nz) return false;
+    int k=step_int((z-az)*zsp);
+    if(zperiodic) {l=step_mod(k,nz);z+=boxz*(l-k);k=l;}
+    else if(k<0||k>=nz) return false;
 
-	ijk+=nx*j+nxy*k;
-	return true;
+    ijk+=nx*j+nxy*k;
+    return true;
 }
 
 /** Takes a position vector and attempts to remap it into the primary domain.
@@ -201,26 +201,26 @@ inline bool container_base::put_remap(int &ijk,double &x,double &y,double &z) {
  * \return True if the particle is within the container or can be remapped into
  * it, false if it lies outside of the container bounds. */
 inline bool container_base::remap(int &ai,int &aj,int &ak,int &ci,int &cj,int &ck,double &x,double &y,double &z,int &ijk) {
-	ci=step_int((x-ax)*xsp);
-	if(ci<0||ci>=nx) {
-		if(xperiodic) {ai=step_div(ci,nx);x-=ai*(bx-ax);ci-=ai*nx;}
-		else return false;
-	} else ai=0;
+    ci=step_int((x-ax)*xsp);
+    if(ci<0||ci>=nx) {
+        if(xperiodic) {ai=step_div(ci,nx);x-=ai*(bx-ax);ci-=ai*nx;}
+        else return false;
+    } else ai=0;
 
-	cj=step_int((y-ay)*ysp);
-	if(cj<0||cj>=ny) {
-		if(yperiodic) {aj=step_div(cj,ny);y-=aj*(by-ay);cj-=aj*ny;}
-		else return false;
-	} else aj=0;
+    cj=step_int((y-ay)*ysp);
+    if(cj<0||cj>=ny) {
+        if(yperiodic) {aj=step_div(cj,ny);y-=aj*(by-ay);cj-=aj*ny;}
+        else return false;
+    } else aj=0;
 
-	ck=step_int((z-az)*zsp);
-	if(ck<0||ck>=nz) {
-		if(zperiodic) {ak=step_div(ck,nz);z-=ak*(bz-az);ck-=ak*nz;}
-		else return false;
-	} else ak=0;
+    ck=step_int((z-az)*zsp);
+    if(ck<0||ck>=nz) {
+        if(zperiodic) {ak=step_div(ck,nz);z-=ak*(bz-az);ck-=ak*nz;}
+        else return false;
+    } else ak=0;
 
-	ijk=ci+nx*cj+nxy*ck;
-	return true;
+    ijk=ci+nx*cj+nxy*ck;
+    return true;
 }
 
 /** Takes a vector and finds the particle whose Voronoi cell contains that
@@ -235,31 +235,31 @@ inline bool container_base::remap(int &ai,int &aj,int &ak,int &ci,int &cj,int &c
  * \return True if a particle was found. If the container has no particles,
  * then the search will not find a Voronoi cell and false is returned. */
 bool container::find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid) {
-	int ai,aj,ak,ci,cj,ck,ijk;
-	particle_record w;
-	double mrs;
+    int ai,aj,ak,ci,cj,ck,ijk;
+    particle_record w;
+    double mrs;
 
-	// If the given vector lies outside the domain, but the container
-	// is periodic, then remap it back into the domain
-	if(!remap(ai,aj,ak,ci,cj,ck,x,y,z,ijk)) return false;
-	vc.find_voronoi_cell(x,y,z,ci,cj,ck,ijk,w,mrs);
+    // If the given vector lies outside the domain, but the container
+    // is periodic, then remap it back into the domain
+    if(!remap(ai,aj,ak,ci,cj,ck,x,y,z,ijk)) return false;
+    vc.find_voronoi_cell(x,y,z,ci,cj,ck,ijk,w,mrs);
 
-	if(w.ijk!=-1) {
+    if(w.ijk!=-1) {
 
-		// Assemble the position vector of the particle to be returned,
-		// applying a periodic remapping if necessary
-		if(xperiodic) {ci+=w.di;if(ci<0||ci>=nx) ai+=step_div(ci,nx);}
-		if(yperiodic) {cj+=w.dj;if(cj<0||cj>=ny) aj+=step_div(cj,ny);}
-		if(zperiodic) {ck+=w.dk;if(ck<0||ck>=nz) ak+=step_div(ck,nz);}
-		rx=p[w.ijk][3*w.l]+ai*(bx-ax);
-		ry=p[w.ijk][3*w.l+1]+aj*(by-ay);
-		rz=p[w.ijk][3*w.l+2]+ak*(bz-az);
-		pid=id[w.ijk][w.l];
-		return true;
-	}
+        // Assemble the position vector of the particle to be returned,
+        // applying a periodic remapping if necessary
+        if(xperiodic) {ci+=w.di;if(ci<0||ci>=nx) ai+=step_div(ci,nx);}
+        if(yperiodic) {cj+=w.dj;if(cj<0||cj>=ny) aj+=step_div(cj,ny);}
+        if(zperiodic) {ck+=w.dk;if(ck<0||ck>=nz) ak+=step_div(ck,nz);}
+        rx=p[w.ijk][3*w.l]+ai*(bx-ax);
+        ry=p[w.ijk][3*w.l+1]+aj*(by-ay);
+        rz=p[w.ijk][3*w.l+2]+ak*(bz-az);
+        pid=id[w.ijk][w.l];
+        return true;
+    }
 
-	// If no particle if found then just return false
-	return false;
+    // If no particle if found then just return false
+    return false;
 }
 
 /** Takes a vector and finds the particle whose Voronoi cell contains that
@@ -273,56 +273,56 @@ bool container::find_voronoi_cell(double x,double y,double z,double &rx,double &
  * \return True if a particle was found. If the container has no particles,
  * then the search will not find a Voronoi cell and false is returned. */
 bool container_poly::find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid) {
-	int ai,aj,ak,ci,cj,ck,ijk;
-	particle_record w;
-	double mrs;
+    int ai,aj,ak,ci,cj,ck,ijk;
+    particle_record w;
+    double mrs;
 
-	// If the given vector lies outside the domain, but the container
-	// is periodic, then remap it back into the domain
-	if(!remap(ai,aj,ak,ci,cj,ck,x,y,z,ijk)) return false;
-	vc.find_voronoi_cell(x,y,z,ci,cj,ck,ijk,w,mrs);
+    // If the given vector lies outside the domain, but the container
+    // is periodic, then remap it back into the domain
+    if(!remap(ai,aj,ak,ci,cj,ck,x,y,z,ijk)) return false;
+    vc.find_voronoi_cell(x,y,z,ci,cj,ck,ijk,w,mrs);
 
-	if(w.ijk!=-1) {
+    if(w.ijk!=-1) {
 
-		// Assemble the position vector of the particle to be returned,
-		// applying a periodic remapping if necessary
-		if(xperiodic) {ci+=w.di;if(ci<0||ci>=nx) ai+=step_div(ci,nx);}
-		if(yperiodic) {cj+=w.dj;if(cj<0||cj>=ny) aj+=step_div(cj,ny);}
-		if(zperiodic) {ck+=w.dk;if(ck<0||ck>=nz) ak+=step_div(ck,nz);}
-		rx=p[w.ijk][4*w.l]+ai*(bx-ax);
-		ry=p[w.ijk][4*w.l+1]+aj*(by-ay);
-		rz=p[w.ijk][4*w.l+2]+ak*(bz-az);
-		pid=id[w.ijk][w.l];
-		return true;
-	}
+        // Assemble the position vector of the particle to be returned,
+        // applying a periodic remapping if necessary
+        if(xperiodic) {ci+=w.di;if(ci<0||ci>=nx) ai+=step_div(ci,nx);}
+        if(yperiodic) {cj+=w.dj;if(cj<0||cj>=ny) aj+=step_div(cj,ny);}
+        if(zperiodic) {ck+=w.dk;if(ck<0||ck>=nz) ak+=step_div(ck,nz);}
+        rx=p[w.ijk][4*w.l]+ai*(bx-ax);
+        ry=p[w.ijk][4*w.l+1]+aj*(by-ay);
+        rz=p[w.ijk][4*w.l+2]+ak*(bz-az);
+        pid=id[w.ijk][w.l];
+        return true;
+    }
 
-	// If no particle if found then just return false
-	return false;
+    // If no particle if found then just return false
+    return false;
 }
 
 /** Increase memory for a particular region.
  * \param[in] i the index of the region to reallocate. */
 void container_base::add_particle_memory(int i) {
-	int l,nmem=mem[i]<<1;
+    int l,nmem=mem[i]<<1;
 
-	// Carry out a check on the memory allocation size, and
-	// print a status message if requested
-	if(nmem>max_particle_memory)
-		voro_fatal_error("Absolute maximum memory allocation exceeded",VOROPP_MEMORY_ERROR);
+    // Carry out a check on the memory allocation size, and
+    // print a status message if requested
+    if(nmem>max_particle_memory)
+        voro_fatal_error("Absolute maximum memory allocation exceeded",VOROPP_MEMORY_ERROR);
 #if VOROPP_VERBOSE >=3
-	fprintf(stderr,"Particle memory in region %d scaled up to %d\n",i,nmem);
+    fprintf(stderr,"Particle memory in region %d scaled up to %d\n",i,nmem);
 #endif
 
-	// Allocate new memory and copy in the contents of the old arrays
-	int *idp=new int[nmem];
-	for(l=0;l<co[i];l++) idp[l]=id[i][l];
-	double *pp=new double[ps*nmem];
-	for(l=0;l<ps*co[i];l++) pp[l]=p[i][l];
+    // Allocate new memory and copy in the contents of the old arrays
+    int *idp=new int[nmem];
+    for(l=0;l<co[i];l++) idp[l]=id[i][l];
+    double *pp=new double[ps*nmem];
+    for(l=0;l<ps*co[i];l++) pp[l]=p[i][l];
 
-	// Update pointers and delete old arrays
-	mem[i]=nmem;
-	delete [] id[i];id[i]=idp;
-	delete [] p[i];p[i]=pp;
+    // Update pointers and delete old arrays
+    mem[i]=nmem;
+    delete [] id[i];id[i]=idp;
+    delete [] p[i];p[i]=pp;
 }
 
 /** Import a list of particles from an open file stream into the container.
@@ -331,10 +331,10 @@ void container_base::add_particle_memory(int i) {
  * causes a fatal error.
  * \param[in] fp the file handle to read from. */
 void container::import(FILE *fp) {
-	int i,j;
-	double x,y,z;
-	while((j=fscanf(fp,"%d %lg %lg %lg",&i,&x,&y,&z))==4) put(i,x,y,z);
-	if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
+    int i,j;
+    double x,y,z;
+    while((j=fscanf(fp,"%d %lg %lg %lg",&i,&x,&y,&z))==4) put(i,x,y,z);
+    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
 }
 
 /** Import a list of particles from an open file stream, also storing the order
@@ -344,10 +344,10 @@ void container::import(FILE *fp) {
  * \param[in,out] vo a reference to an ordering class to use.
  * \param[in] fp the file handle to read from. */
 void container::import(particle_order &vo,FILE *fp) {
-	int i,j;
-	double x,y,z;
-	while((j=fscanf(fp,"%d %lg %lg %lg",&i,&x,&y,&z))==4) put(vo,i,x,y,z);
-	if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
+    int i,j;
+    double x,y,z;
+    while((j=fscanf(fp,"%d %lg %lg %lg",&i,&x,&y,&z))==4) put(vo,i,x,y,z);
+    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
 }
 
 /** Import a list of particles from an open file stream into the container.
@@ -356,10 +356,10 @@ void container::import(particle_order &vo,FILE *fp) {
  * routine causes a fatal error.
  * \param[in] fp the file handle to read from. */
 void container_poly::import(FILE *fp) {
-	int i,j;
-	double x,y,z,r;
-	while((j=fscanf(fp,"%d %lg %lg %lg %lg",&i,&x,&y,&z,&r))==5) put(i,x,y,z,r);
-	if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
+    int i,j;
+    double x,y,z,r;
+    while((j=fscanf(fp,"%d %lg %lg %lg %lg",&i,&x,&y,&z,&r))==5) put(i,x,y,z,r);
+    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
 }
 
 /** Import a list of particles from an open file stream, also storing the order
@@ -369,66 +369,30 @@ void container_poly::import(FILE *fp) {
  * \param[in,out] vo a reference to an ordering class to use.
  * \param[in] fp the file handle to read from. */
 void container_poly::import(particle_order &vo,FILE *fp) {
-	int i,j;
-	double x,y,z,r;
-	while((j=fscanf(fp,"%d %lg %lg %lg %lg",&i,&x,&y,&z,&r))==5) put(vo,i,x,y,z,r);
-	if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
+    int i,j;
+    double x,y,z,r;
+    while((j=fscanf(fp,"%d %lg %lg %lg %lg",&i,&x,&y,&z,&r))==5) put(vo,i,x,y,z,r);
+    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
 }
 
 /** Outputs the a list of all the container regions along with the number of
  * particles stored within each. */
 void container_base::region_count() {
-	int i,j,k,*cop=co;
-	for(k=0;k<nz;k++) for(j=0;j<ny;j++) for(i=0;i<nx;i++)
-		printf("Region (%d,%d,%d): %d particles\n",i,j,k,*(cop++));
+    int i,j,k,*cop=co;
+    for(k=0;k<nz;k++) for(j=0;j<ny;j++) for(i=0;i<nx;i++)
+        printf("Region (%d,%d,%d): %d particles\n",i,j,k,*(cop++));
 }
 
 /** Clears a container of particles. */
 void container::clear() {
-	for(int *cop=co;cop<co+nxyz;cop++) *cop=0;
+    for(int *cop=co;cop<co+nxyz;cop++) *cop=0;
 }
 
 /** Clears a container of particles, also clearing resetting the maximum radius
  * to zero. */
 void container_poly::clear() {
-	for(int *cop=co;cop<co+nxyz;cop++) *cop=0;
-	max_radius=0;
-}
-
-/** Computes all the Voronoi cells and saves customized information about them.
- * \param[in] format the custom output string to use.
- * \param[in] fp a file handle to write to. */
-void container::print_custom(const char *format,FILE *fp) {
-	c_loop_all vl(*this);
-	print_custom(vl,format,fp);
-}
-
-/** Computes all the Voronoi cells and saves customized
- * information about them.
- * \param[in] format the custom output string to use.
- * \param[in] fp a file handle to write to. */
-void container_poly::print_custom(const char *format,FILE *fp) {
-	c_loop_all vl(*this);
-	print_custom(vl,format,fp);
-}
-
-/** Computes all the Voronoi cells and saves customized information about them.
- * \param[in] format the custom output string to use.
- * \param[in] filename the name of the file to write to. */
-void container::print_custom(const char *format,const char *filename) {
-	FILE *fp=safe_fopen(filename,"w");
-	print_custom(format,fp);
-	fclose(fp);
-}
-
-/** Computes all the Voronoi cells and saves customized
- * information about them
- * \param[in] format the custom output string to use.
- * \param[in] filename the name of the file to write to. */
-void container_poly::print_custom(const char *format,const char *filename) {
-	FILE *fp=safe_fopen(filename,"w");
-	print_custom(format,fp);
-	fclose(fp);
+    for(int *cop=co;cop<co+nxyz;cop++) *cop=0;
+    max_radius=0;
 }
 
 /** Computes all of the Voronoi cells in the container, but does nothing
@@ -436,10 +400,10 @@ void container_poly::print_custom(const char *format,const char *filename) {
  * of the Voronoi algorithm, without any additional calculations such as
  * volume evaluation or cell output. */
 void container::compute_all_cells() {
-	voronoicell c(*this);
-	c_loop_all vl(*this);
-	if(vl.start()) do compute_cell(c,vl);
-	while(vl.inc());
+    voronoicell c(*this);
+    c_loop_all vl(*this);
+    if(vl.start()) do compute_cell(c,vl);
+    while(vl.inc());
 }
 
 /** Computes all of the Voronoi cells in the container, but does nothing
@@ -447,9 +411,9 @@ void container::compute_all_cells() {
  * of the Voronoi algorithm, without any additional calculations such as
  * volume evaluation or cell output. */
 void container_poly::compute_all_cells() {
-	voronoicell c(*this);
-	c_loop_all vl(*this);
-	if(vl.start()) do compute_cell(c,vl);while(vl.inc());
+    voronoicell c(*this);
+    c_loop_all vl(*this);
+    if(vl.start()) do compute_cell(c,vl);while(vl.inc());
 }
 
 /** Calculates all of the Voronoi cells and sums their volumes. In most cases
@@ -457,11 +421,11 @@ void container_poly::compute_all_cells() {
  * of the container to numerical precision.
  * \return The sum of all of the computed Voronoi volumes. */
 double container::sum_cell_volumes() {
-	voronoicell c(*this);
-	double vol=0;
-	c_loop_all vl(*this);
-	if(vl.start()) do if(compute_cell(c,vl)) vol+=c.volume();while(vl.inc());
-	return vol;
+    voronoicell c(*this);
+    double vol=0;
+    c_loop_all vl(*this);
+    if(vl.start()) do if(compute_cell(c,vl)) vol+=c.volume();while(vl.inc());
+    return vol;
 }
 
 /** Calculates all of the Voronoi cells and sums their volumes. In most cases
@@ -469,11 +433,11 @@ double container::sum_cell_volumes() {
  * of the container to numerical precision.
  * \return The sum of all of the computed Voronoi volumes. */
 double container_poly::sum_cell_volumes() {
-	voronoicell c(*this);
-	double vol=0;
-	c_loop_all vl(*this);
-	if(vl.start()) do if(compute_cell(c,vl)) vol+=c.volume();while(vl.inc());
-	return vol;
+    voronoicell c(*this);
+    double vol=0;
+    c_loop_all vl(*this);
+    if(vl.start()) do if(compute_cell(c,vl)) vol+=c.volume();while(vl.inc());
+    return vol;
 }
 
 /** This function tests to see if a given vector lies within the container
@@ -482,70 +446,40 @@ double container_poly::sum_cell_volumes() {
  * \return True if the point is inside the container, false if the point is
  *         outside. */
 bool container_base::point_inside(double x,double y,double z) {
-	if(x<ax||x>bx||y<ay||y>by||z<az||z>bz) return false;
-	return point_inside_walls(x,y,z);
-}
-
-/** Draws an outline of the domain in gnuplot format.
- * \param[in] fp the file handle to write to. */
-void container_base::draw_domain_gnuplot(FILE *fp) {
-	fprintf(fp,"%g %g %g\n%g %g %g\n%g %g %g\n%g %g %g\n",ax,ay,az,bx,ay,az,bx,by,az,ax,by,az);
-	fprintf(fp,"%g %g %g\n%g %g %g\n%g %g %g\n%g %g %g\n",ax,by,bz,bx,by,bz,bx,ay,bz,ax,ay,bz);
-	fprintf(fp,"%g %g %g\n\n%g %g %g\n%g %g %g\n\n",ax,by,bz,ax,ay,az,ax,ay,bz);
-	fprintf(fp,"%g %g %g\n%g %g %g\n\n%g %g %g\n%g %g %g\n\n",bx,ay,az,bx,ay,bz,bx,by,az,bx,by,bz);
-}
-
-/** Draws an outline of the domain in POV-Ray format.
- * \param[in] fp the file handle to write to. */
-void container_base::draw_domain_pov(FILE *fp) {
-	fprintf(fp,"cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n"
-		   "cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n",ax,ay,az,bx,ay,az,ax,by,az,bx,by,az);
-	fprintf(fp,"cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n"
-		   "cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n",ax,by,bz,bx,by,bz,ax,ay,bz,bx,ay,bz);
-	fprintf(fp,"cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n"
-		   "cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n",ax,ay,az,ax,by,az,bx,ay,az,bx,by,az);
-	fprintf(fp,"cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n"
-		   "cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n",bx,ay,bz,bx,by,bz,ax,ay,bz,ax,by,bz);
-	fprintf(fp,"cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n"
-		   "cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n",ax,ay,az,ax,ay,bz,bx,ay,az,bx,ay,bz);
-	fprintf(fp,"cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n"
-		   "cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n",bx,by,az,bx,by,bz,ax,by,az,ax,by,bz);
-	fprintf(fp,"sphere{<%g,%g,%g>,rr}\nsphere{<%g,%g,%g>,rr}\n"
-		   "sphere{<%g,%g,%g>,rr}\nsphere{<%g,%g,%g>,rr}\n",ax,ay,az,bx,ay,az,ax,by,az,bx,by,az);
-	fprintf(fp,"sphere{<%g,%g,%g>,rr}\nsphere{<%g,%g,%g>,rr}\n"
-		   "sphere{<%g,%g,%g>,rr}\nsphere{<%g,%g,%g>,rr}\n",ax,ay,bz,bx,ay,bz,ax,by,bz,bx,by,bz);
+    if(x<ax||x>bx||y<ay||y>by||z<az||z>bz) return false;
+    return point_inside_walls(x,y,z);
 }
 
 /** The wall_list constructor sets up an array of pointers to wall classes. */
 wall_list::wall_list() : walls(new wall*[init_wall_size]), wep(walls), wel(walls+init_wall_size),
-	current_wall_size(init_wall_size) {}
+    current_wall_size(init_wall_size) {}
 
 /** The wall_list destructor frees the array of pointers to the wall classes.
  */
 wall_list::~wall_list() {
-	delete [] walls;
+    delete [] walls;
 }
 
 /** Adds all of the walls on another wall_list to this class.
  * \param[in] wl a reference to the wall class. */
 void wall_list::add_wall(wall_list &wl) {
-	for(wall **wp=wl.walls;wp<wl.wep;wp++) add_wall(*wp);
+    for(wall **wp=wl.walls;wp<wl.wep;wp++) add_wall(*wp);
 }
 
 /** Deallocates all of the wall classes pointed to by the wall_list. */
 void wall_list::deallocate() {
-	for(wall **wp=walls;wp<wep;wp++) delete *wp;
+    for(wall **wp=walls;wp<wep;wp++) delete *wp;
 }
 
 /** Increases the memory allocation for the walls array. */
 void wall_list::increase_wall_memory() {
-	current_wall_size<<=1;
-	if(current_wall_size>max_wall_size)
-		voro_fatal_error("Wall memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
-	wall **nwalls=new wall*[current_wall_size],**nwp=nwalls,**wp=walls;
-	while(wp<wep) *(nwp++)=*(wp++);
-	delete [] walls;
-	walls=nwalls;wel=walls+current_wall_size;wep=nwp;
+    current_wall_size<<=1;
+    if(current_wall_size>max_wall_size)
+        voro_fatal_error("Wall memory allocation exceeded absolute maximum",VOROPP_MEMORY_ERROR);
+    wall **nwalls=new wall*[current_wall_size],**nwp=nwalls,**wp=walls;
+    while(wp<wep) *(nwp++)=*(wp++);
+    delete [] walls;
+    walls=nwalls;wel=walls+current_wall_size;wep=nwp;
 }
 
 }

--- a/SKIRT/voro/container.cc
+++ b/SKIRT/voro/container.cc
@@ -325,64 +325,6 @@ void container_base::add_particle_memory(int i) {
     delete [] p[i];p[i]=pp;
 }
 
-/** Import a list of particles from an open file stream into the container.
- * Entries of four numbers (Particle ID, x position, y position, z position)
- * are searched for. If the file cannot be successfully read, then the routine
- * causes a fatal error.
- * \param[in] fp the file handle to read from. */
-void container::import(FILE *fp) {
-    int i,j;
-    double x,y,z;
-    while((j=fscanf(fp,"%d %lg %lg %lg",&i,&x,&y,&z))==4) put(i,x,y,z);
-    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
-}
-
-/** Import a list of particles from an open file stream, also storing the order
- * of that the particles are read. Entries of four numbers (Particle ID, x
- * position, y position, z position) are searched for. If the file cannot be
- * successfully read, then the routine causes a fatal error.
- * \param[in,out] vo a reference to an ordering class to use.
- * \param[in] fp the file handle to read from. */
-void container::import(particle_order &vo,FILE *fp) {
-    int i,j;
-    double x,y,z;
-    while((j=fscanf(fp,"%d %lg %lg %lg",&i,&x,&y,&z))==4) put(vo,i,x,y,z);
-    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
-}
-
-/** Import a list of particles from an open file stream into the container.
- * Entries of five numbers (Particle ID, x position, y position, z position,
- * radius) are searched for. If the file cannot be successfully read, then the
- * routine causes a fatal error.
- * \param[in] fp the file handle to read from. */
-void container_poly::import(FILE *fp) {
-    int i,j;
-    double x,y,z,r;
-    while((j=fscanf(fp,"%d %lg %lg %lg %lg",&i,&x,&y,&z,&r))==5) put(i,x,y,z,r);
-    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
-}
-
-/** Import a list of particles from an open file stream, also storing the order
- * of that the particles are read. Entries of four numbers (Particle ID, x
- * position, y position, z position, radius) are searched for. If the file
- * cannot be successfully read, then the routine causes a fatal error.
- * \param[in,out] vo a reference to an ordering class to use.
- * \param[in] fp the file handle to read from. */
-void container_poly::import(particle_order &vo,FILE *fp) {
-    int i,j;
-    double x,y,z,r;
-    while((j=fscanf(fp,"%d %lg %lg %lg %lg",&i,&x,&y,&z,&r))==5) put(vo,i,x,y,z,r);
-    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
-}
-
-/** Outputs the a list of all the container regions along with the number of
- * particles stored within each. */
-void container_base::region_count() {
-    int i,j,k,*cop=co;
-    for(k=0;k<nz;k++) for(j=0;j<ny;j++) for(i=0;i<nx;i++)
-        printf("Region (%d,%d,%d): %d particles\n",i,j,k,*(cop++));
-}
-
 /** Clears a container of particles. */
 void container::clear() {
     for(int *cop=co;cop<co+nxyz;cop++) *cop=0;

--- a/SKIRT/voro/container.hh
+++ b/SKIRT/voro/container.hh
@@ -29,17 +29,17 @@ namespace voro {
  * can be specified by deriving a new class from this and specifying the
  * functions.*/
 class wall {
-	public:
-		virtual ~wall() {}
-		/** A pure virtual function for testing whether a point is
-		 * inside the wall object. */
-		virtual bool point_inside(double x,double y,double z) = 0;
-		/** A pure virtual function for cutting a cell without
-		 * neighbor-tracking with a wall. */
-		virtual bool cut_cell(voronoicell &c,double x,double y,double z) = 0;
-		/** A pure virtual function for cutting a cell with
-		 * neighbor-tracking enabled with a wall. */
-		virtual bool cut_cell(voronoicell_neighbor &c,double x,double y,double z) = 0;
+    public:
+        virtual ~wall() {}
+        /** A pure virtual function for testing whether a point is
+         * inside the wall object. */
+        virtual bool point_inside(double x,double y,double z) = 0;
+        /** A pure virtual function for cutting a cell without
+         * neighbor-tracking with a wall. */
+        virtual bool cut_cell(voronoicell &c,double x,double y,double z) = 0;
+        /** A pure virtual function for cutting a cell with
+         * neighbor-tracking enabled with a wall. */
+        virtual bool cut_cell(voronoicell_neighbor &c,double x,double y,double z) = 0;
 };
 
 /** \brief A class for storing a list of pointers to walls.
@@ -50,51 +50,51 @@ class wall {
  * but also forms part of container_base, for associating walls with this
  * class. */
 class wall_list {
-	public:
-		/** An array holding pointers to wall objects. */
-		wall **walls;
-		/** A pointer to the next free position to add a wall pointer.
-		 */
-		wall **wep;
-		wall_list();
-		~wall_list();
-		/** Adds a wall to the list.
-		 * \param[in] w the wall to add. */
-		inline void add_wall(wall *w) {
-			if(wep==wel) increase_wall_memory();
-			*(wep++)=w;
-		}
-		/** Adds a wall to the list.
-		 * \param[in] w a reference to the wall to add. */
-		inline void add_wall(wall &w) {add_wall(&w);}
-		void add_wall(wall_list &wl);
-		/** Determines whether a given position is inside all of the
-		 * walls on the list.
-		 * \param[in] (x,y,z) the position to test.
-		 * \return True if it is inside, false if it is outside. */
-		inline bool point_inside_walls(double x,double y,double z) {
-			for(wall **wp=walls;wp<wep;wp++) if(!((*wp)->point_inside(x,y,z))) return false;
-			return true;
-		}
-		/** Cuts a Voronoi cell by all of the walls currently on
-		 * the list.
-		 * \param[in] c a reference to the Voronoi cell class.
-		 * \param[in] (x,y,z) the position of the cell.
-		 * \return True if the cell still exists, false if the cell is
-		 * deleted. */
-		template<class c_class>
-		bool apply_walls(c_class &c,double x,double y,double z) {
-			for(wall **wp=walls;wp<wep;wp++) if(!((*wp)->cut_cell(c,x,y,z))) return false;
-			return true;
-		}
-		void deallocate();
-	protected:
-		void increase_wall_memory();
-		/** A pointer to the limit of the walls array, used to
-		 * determine when array is full. */
-		wall **wel;
-		/** The current amount of memory allocated for walls. */
-		int current_wall_size;
+    public:
+        /** An array holding pointers to wall objects. */
+        wall **walls;
+        /** A pointer to the next free position to add a wall pointer.
+         */
+        wall **wep;
+        wall_list();
+        ~wall_list();
+        /** Adds a wall to the list.
+         * \param[in] w the wall to add. */
+        inline void add_wall(wall *w) {
+            if(wep==wel) increase_wall_memory();
+            *(wep++)=w;
+        }
+        /** Adds a wall to the list.
+         * \param[in] w a reference to the wall to add. */
+        inline void add_wall(wall &w) {add_wall(&w);}
+        void add_wall(wall_list &wl);
+        /** Determines whether a given position is inside all of the
+         * walls on the list.
+         * \param[in] (x,y,z) the position to test.
+         * \return True if it is inside, false if it is outside. */
+        inline bool point_inside_walls(double x,double y,double z) {
+            for(wall **wp=walls;wp<wep;wp++) if(!((*wp)->point_inside(x,y,z))) return false;
+            return true;
+        }
+        /** Cuts a Voronoi cell by all of the walls currently on
+         * the list.
+         * \param[in] c a reference to the Voronoi cell class.
+         * \param[in] (x,y,z) the position of the cell.
+         * \return True if the cell still exists, false if the cell is
+         * deleted. */
+        template<class c_class>
+        bool apply_walls(c_class &c,double x,double y,double z) {
+            for(wall **wp=walls;wp<wep;wp++) if(!((*wp)->cut_cell(c,x,y,z))) return false;
+            return true;
+        }
+        void deallocate();
+    protected:
+        void increase_wall_memory();
+        /** A pointer to the limit of the walls array, used to
+         * determine when array is full. */
+        wall **wel;
+        /** The current amount of memory allocated for walls. */
+        int current_wall_size;
 };
 
 /** \brief Class for representing a particle system in a three-dimensional
@@ -113,170 +113,154 @@ class wall_list {
  * for associating walls with the container, and the voro_base class, which
  * encapsulates routines about the underlying computational grid. */
 class container_base : public voro_base, public wall_list {
-	public:
-		/** The minimum x coordinate of the container. */
-		const double ax;
-		/** The maximum x coordinate of the container. */
-		const double bx;
-		/** The minimum y coordinate of the container. */
-		const double ay;
-		/** The maximum y coordinate of the container. */
-		const double by;
-		/** The minimum z coordinate of the container. */
-		const double az;
-		/** The maximum z coordinate of the container. */
-		const double bz;
-		/** The maximum length squared that could be encountered in the
-		 * Voronoi cell calculation. */
-		const double max_len_sq;
-		/** A boolean value that determines if the x coordinate in
-		 * periodic or not. */
-		const bool xperiodic;
-		/** A boolean value that determines if the y coordinate in
-		 * periodic or not. */
-		const bool yperiodic;
-		/** A boolean value that determines if the z coordinate in
-		 * periodic or not. */
-		const bool zperiodic;
-		/** This array holds the numerical IDs of each particle in each
-		 * computational box. */
-		int **id;
-		/** A two dimensional array holding particle positions. For the
-		 * derived container_poly class, this also holds particle
-		 * radii. */
-		double **p;
-		/** This array holds the number of particles within each
-		 * computational box of the container. */
-		int *co;
-		/** This array holds the maximum amount of particle memory for
-		 * each computational box of the container. If the number of
-		 * particles in a particular box ever approaches this limit,
-		 * more is allocated using the add_particle_memory() function.
-		 */
-		int *mem;
-		/** The amount of memory in the array structure for each
-		 * particle. This is set to 3 when the basic class is
-		 * initialized, so that the array holds (x,y,z) positions. If
-		 * the container class is initialized as part of the derived
-		 * class container_poly, then this is set to 4, to also hold
-		 * the particle radii. */
-		const int ps;
-		container_base(double ax_,double bx_,double ay_,double by_,double az_,double bz_,
-				int nx_,int ny_,int nz_,bool xperiodic_,bool yperiodic_,bool zperiodic_,
-				int init_mem,int ps_);
-		~container_base();
-		bool point_inside(double x,double y,double z);
-		void region_count();
-		/** Initializes the Voronoi cell prior to a compute_cell
-		 * operation for a specific particle being carried out by a
-		 * voro_compute class. The cell is initialized to fill the
-		 * entire container. For non-periodic coordinates, this is set
-		 * by the position of the walls. For periodic coordinates, the
-		 * space is equally divided in either direction from the
-		 * particle's initial position. Plane cuts made by any walls
-		 * that have been added are then applied to the cell.
-		 * \param[in,out] c a reference to a voronoicell object.
-		 * \param[in] ijk the block that the particle is within.
-		 * \param[in] q the index of the particle within its block.
-		 * \param[in] (ci,cj,ck) the coordinates of the block in the
-		 * 			 container coordinate system.
-		 * \param[out] (i,j,k) the coordinates of the test block
-		 * 		       relative to the voro_compute
-		 * 		       coordinate system.
-		 * \param[out] (x,y,z) the position of the particle.
-		 * \param[out] disp a block displacement used internally by the
-		 *		    compute_cell routine.
-		 * \return False if the plane cuts applied by walls completely
-		 * removed the cell, true otherwise. */
-		template<class v_cell>
-		inline bool initialize_voronoicell(v_cell &c,int ijk,int q,int ci,int cj,int ck,
-				int &i,int &j,int &k,double &x,double &y,double &z,int &disp) {
-			double x1,x2,y1,y2,z1,z2,*pp=p[ijk]+ps*q;
-			x=*(pp++);y=*(pp++);z=*pp;
-			if(xperiodic) {x1=-(x2=0.5*(bx-ax));i=nx;} else {x1=ax-x;x2=bx-x;i=ci;}
-			if(yperiodic) {y1=-(y2=0.5*(by-ay));j=ny;} else {y1=ay-y;y2=by-y;j=cj;}
-			if(zperiodic) {z1=-(z2=0.5*(bz-az));k=nz;} else {z1=az-z;z2=bz-z;k=ck;}
-			c.init(x1,x2,y1,y2,z1,z2);
-			if(!apply_walls(c,x,y,z)) return false;
-			disp=ijk-i-nx*(j+ny*k);
-			return true;
-		}
-		/** Initializes parameters for a find_voronoi_cell call within
-		 * the voro_compute template.
-		 * \param[in] (ci,cj,ck) the coordinates of the test block in
-		 * 			 the container coordinate system.
-		 * \param[in] ijk the index of the test block
-		 * \param[out] (i,j,k) the coordinates of the test block
-		 * 		       relative to the voro_compute
-		 * 		       coordinate system.
-		 * \param[out] disp a block displacement used internally by the
-		 *		    find_voronoi_cell routine. */
-		inline void initialize_search(int ci,int cj,int ck,int ijk,int &i,int &j,int &k,int &disp) {
-			i=xperiodic?nx:ci;
-			j=yperiodic?ny:cj;
-			k=zperiodic?nz:ck;
-			disp=ijk-i-nx*(j+ny*k);
-		}
-		/** Returns the position of a particle currently being computed
-		 * relative to the computational block that it is within. It is
-		 * used to select the optimal worklist entry to use.
-		 * \param[in] (x,y,z) the position of the particle.
-		 * \param[in] (ci,cj,ck) the block that the particle is within.
-		 * \param[out] (fx,fy,fz) the position relative to the block.
-		 */
-		inline void frac_pos(double x,double y,double z,double ci,double cj,double ck,
-				double &fx,double &fy,double &fz) {
-			fx=x-ax-boxx*ci;
-			fy=y-ay-boxy*cj;
-			fz=z-az-boxz*ck;
-		}
-		/** Calculates the index of block in the container structure
-		 * corresponding to given coordinates.
-		 * \param[in] (ci,cj,ck) the coordinates of the original block
-		 * 			 in the current computation, relative
-		 * 			 to the container coordinate system.
-		 * \param[in] (ei,ej,ek) the displacement of the current block
-		 * 			 from the original block.
-		 * \param[in,out] (qx,qy,qz) the periodic displacement that
-		 * 			     must be added to the particles
-		 * 			     within the computed block.
-		 * \param[in] disp a block displacement used internally by the
-		 * 		    find_voronoi_cell and compute_cell routines.
-		 * \return The block index. */
-		inline int region_index(int ci,int cj,int ck,int ei,int ej,int ek,double &qx,double &qy,double &qz,int &disp) {
-			if(xperiodic) {if(ci+ei<nx) {ei+=nx;qx=-(bx-ax);} else if(ci+ei>=(nx<<1)) {ei-=nx;qx=bx-ax;} else qx=0;}
-			if(yperiodic) {if(cj+ej<ny) {ej+=ny;qy=-(by-ay);} else if(cj+ej>=(ny<<1)) {ej-=ny;qy=by-ay;} else qy=0;}
-			if(zperiodic) {if(ck+ek<nz) {ek+=nz;qz=-(bz-az);} else if(ck+ek>=(nz<<1)) {ek-=nz;qz=bz-az;} else qz=0;}
-			return disp+ei+nx*(ej+ny*ek);
-		}
-		void draw_domain_gnuplot(FILE *fp=stdout);
-		/** Draws an outline of the domain in Gnuplot format.
-		 * \param[in] filename the filename to write to. */
-		inline void draw_domain_gnuplot(const char* filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_domain_gnuplot(fp);
-			fclose(fp);
-		}
-		void draw_domain_pov(FILE *fp=stdout);
-		/** Draws an outline of the domain in Gnuplot format.
-		 * \param[in] filename the filename to write to. */
-		inline void draw_domain_pov(const char* filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_domain_pov(fp);
-			fclose(fp);
-		}
-		/** Sums up the total number of stored particles.
-		 * \return The number of particles. */
-		inline int total_particles() {
-			int tp=*co;
-			for(int *cop=co+1;cop<co+nxyz;cop++) tp+=*cop;
-			return tp;
-		}
-	protected:
-		void add_particle_memory(int i);
-		bool put_locate_block(int &ijk,double &x,double &y,double &z);
-		inline bool put_remap(int &ijk,double &x,double &y,double &z);
-		inline bool remap(int &ai,int &aj,int &ak,int &ci,int &cj,int &ck,double &x,double &y,double &z,int &ijk);
+    public:
+        /** The minimum x coordinate of the container. */
+        const double ax;
+        /** The maximum x coordinate of the container. */
+        const double bx;
+        /** The minimum y coordinate of the container. */
+        const double ay;
+        /** The maximum y coordinate of the container. */
+        const double by;
+        /** The minimum z coordinate of the container. */
+        const double az;
+        /** The maximum z coordinate of the container. */
+        const double bz;
+        /** The maximum length squared that could be encountered in the
+         * Voronoi cell calculation. */
+        const double max_len_sq;
+        /** A boolean value that determines if the x coordinate in
+         * periodic or not. */
+        const bool xperiodic;
+        /** A boolean value that determines if the y coordinate in
+         * periodic or not. */
+        const bool yperiodic;
+        /** A boolean value that determines if the z coordinate in
+         * periodic or not. */
+        const bool zperiodic;
+        /** This array holds the numerical IDs of each particle in each
+         * computational box. */
+        int **id;
+        /** A two dimensional array holding particle positions. For the
+         * derived container_poly class, this also holds particle
+         * radii. */
+        double **p;
+        /** This array holds the number of particles within each
+         * computational box of the container. */
+        int *co;
+        /** This array holds the maximum amount of particle memory for
+         * each computational box of the container. If the number of
+         * particles in a particular box ever approaches this limit,
+         * more is allocated using the add_particle_memory() function.
+         */
+        int *mem;
+        /** The amount of memory in the array structure for each
+         * particle. This is set to 3 when the basic class is
+         * initialized, so that the array holds (x,y,z) positions. If
+         * the container class is initialized as part of the derived
+         * class container_poly, then this is set to 4, to also hold
+         * the particle radii. */
+        const int ps;
+        container_base(double ax_,double bx_,double ay_,double by_,double az_,double bz_,
+                int nx_,int ny_,int nz_,bool xperiodic_,bool yperiodic_,bool zperiodic_,
+                int init_mem,int ps_);
+        ~container_base();
+        bool point_inside(double x,double y,double z);
+        void region_count();
+        /** Initializes the Voronoi cell prior to a compute_cell
+         * operation for a specific particle being carried out by a
+         * voro_compute class. The cell is initialized to fill the
+         * entire container. For non-periodic coordinates, this is set
+         * by the position of the walls. For periodic coordinates, the
+         * space is equally divided in either direction from the
+         * particle's initial position. Plane cuts made by any walls
+         * that have been added are then applied to the cell.
+         * \param[in,out] c a reference to a voronoicell object.
+         * \param[in] ijk the block that the particle is within.
+         * \param[in] q the index of the particle within its block.
+         * \param[in] (ci,cj,ck) the coordinates of the block in the
+         * 			 container coordinate system.
+         * \param[out] (i,j,k) the coordinates of the test block
+         * 		       relative to the voro_compute
+         * 		       coordinate system.
+         * \param[out] (x,y,z) the position of the particle.
+         * \param[out] disp a block displacement used internally by the
+         *		    compute_cell routine.
+         * \return False if the plane cuts applied by walls completely
+         * removed the cell, true otherwise. */
+        template<class v_cell>
+        inline bool initialize_voronoicell(v_cell &c,int ijk,int q,int ci,int cj,int ck,
+                int &i,int &j,int &k,double &x,double &y,double &z,int &disp) {
+            double x1,x2,y1,y2,z1,z2,*pp=p[ijk]+ps*q;
+            x=*(pp++);y=*(pp++);z=*pp;
+            if(xperiodic) {x1=-(x2=0.5*(bx-ax));i=nx;} else {x1=ax-x;x2=bx-x;i=ci;}
+            if(yperiodic) {y1=-(y2=0.5*(by-ay));j=ny;} else {y1=ay-y;y2=by-y;j=cj;}
+            if(zperiodic) {z1=-(z2=0.5*(bz-az));k=nz;} else {z1=az-z;z2=bz-z;k=ck;}
+            c.init(x1,x2,y1,y2,z1,z2);
+            if(!apply_walls(c,x,y,z)) return false;
+            disp=ijk-i-nx*(j+ny*k);
+            return true;
+        }
+        /** Initializes parameters for a find_voronoi_cell call within
+         * the voro_compute template.
+         * \param[in] (ci,cj,ck) the coordinates of the test block in
+         * 			 the container coordinate system.
+         * \param[in] ijk the index of the test block
+         * \param[out] (i,j,k) the coordinates of the test block
+         * 		       relative to the voro_compute
+         * 		       coordinate system.
+         * \param[out] disp a block displacement used internally by the
+         *		    find_voronoi_cell routine. */
+        inline void initialize_search(int ci,int cj,int ck,int ijk,int &i,int &j,int &k,int &disp) {
+            i=xperiodic?nx:ci;
+            j=yperiodic?ny:cj;
+            k=zperiodic?nz:ck;
+            disp=ijk-i-nx*(j+ny*k);
+        }
+        /** Returns the position of a particle currently being computed
+         * relative to the computational block that it is within. It is
+         * used to select the optimal worklist entry to use.
+         * \param[in] (x,y,z) the position of the particle.
+         * \param[in] (ci,cj,ck) the block that the particle is within.
+         * \param[out] (fx,fy,fz) the position relative to the block.
+         */
+        inline void frac_pos(double x,double y,double z,double ci,double cj,double ck,
+                double &fx,double &fy,double &fz) {
+            fx=x-ax-boxx*ci;
+            fy=y-ay-boxy*cj;
+            fz=z-az-boxz*ck;
+        }
+        /** Calculates the index of block in the container structure
+         * corresponding to given coordinates.
+         * \param[in] (ci,cj,ck) the coordinates of the original block
+         * 			 in the current computation, relative
+         * 			 to the container coordinate system.
+         * \param[in] (ei,ej,ek) the displacement of the current block
+         * 			 from the original block.
+         * \param[in,out] (qx,qy,qz) the periodic displacement that
+         * 			     must be added to the particles
+         * 			     within the computed block.
+         * \param[in] disp a block displacement used internally by the
+         * 		    find_voronoi_cell and compute_cell routines.
+         * \return The block index. */
+        inline int region_index(int ci,int cj,int ck,int ei,int ej,int ek,double &qx,double &qy,double &qz,int &disp) {
+            if(xperiodic) {if(ci+ei<nx) {ei+=nx;qx=-(bx-ax);} else if(ci+ei>=(nx<<1)) {ei-=nx;qx=bx-ax;} else qx=0;}
+            if(yperiodic) {if(cj+ej<ny) {ej+=ny;qy=-(by-ay);} else if(cj+ej>=(ny<<1)) {ej-=ny;qy=by-ay;} else qy=0;}
+            if(zperiodic) {if(ck+ek<nz) {ek+=nz;qz=-(bz-az);} else if(ck+ek>=(nz<<1)) {ek-=nz;qz=bz-az;} else qz=0;}
+            return disp+ei+nx*(ej+ny*ek);
+        }
+        /** Sums up the total number of stored particles.
+         * \return The number of particles. */
+        inline int total_particles() {
+            int tp=*co;
+            for(int *cop=co+1;cop<co+nxyz;cop++) tp+=*cop;
+            return tp;
+        }
+    protected:
+        void add_particle_memory(int i);
+        bool put_locate_block(int &ijk,double &x,double &y,double &z);
+        inline bool put_remap(int &ijk,double &x,double &y,double &z);
+        inline bool remap(int &ai,int &aj,int &ak,int &ci,int &cj,int &ck,double &x,double &y,double &z,int &ijk);
 };
 
 /** \brief Extension of the container_base class for computing regular Voronoi
@@ -286,219 +270,91 @@ class container_base : public voro_base, public wall_list {
  * specifically for computing the regular Voronoi tessellation with no
  * dependence on particle radii. */
 class container : public container_base, public radius_mono {
-	public:
-		container(double ax_,double bx_,double ay_,double by_,double az_,double bz_,
-				int nx_,int ny_,int nz_,bool xperiodic_,bool yperiodic_,bool zperiodic_,int init_mem);
-		void clear();
-		void put(int n,double x,double y,double z);
-		void put(particle_order &vo,int n,double x,double y,double z);
-		void import(FILE *fp=stdin);
-		void import(particle_order &vo,FILE *fp=stdin);
-		/** Imports a list of particles from an open file stream into
-		 * the container. Entries of four numbers (Particle ID, x
-		 * position, y position, z position) are searched for. If the
-		 * file cannot be successfully read, then the routine causes a
-		 * fatal error.
-		 * \param[in] filename the name of the file to open and read
-		 *                     from. */
-		inline void import(const char* filename) {
-			FILE *fp=safe_fopen(filename,"r");
-			import(fp);
-			fclose(fp);
-		}
-		/** Imports a list of particles from an open file stream into
-		 * the container. Entries of four numbers (Particle ID, x
-		 * position, y position, z position) are searched for. In
-		 * addition, the order in which particles are read is saved
-		 * into an ordering class. If the file cannot be successfully
-		 * read, then the routine causes a fatal error.
-		 * \param[in,out] vo the ordering class to use.
-		 * \param[in] filename the name of the file to open and read
-		 *                     from. */
-		inline void import(particle_order &vo,const char* filename) {
-			FILE *fp=safe_fopen(filename,"r");
-			import(vo,fp);
-			fclose(fp);
-		}
-		void compute_all_cells();
-		double sum_cell_volumes();
-		/** Dumps particle IDs and positions to a file.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_particles(c_loop &vl,FILE *fp) {
-			double *pp;
-			if(vl.start()) do {
-				pp=p[vl.ijk]+3*vl.q;
-				fprintf(fp,"%d %g %g %g\n",id[vl.ijk][vl.q],*pp,pp[1],pp[2]);
-			} while(vl.inc());
-		}
-		/** Dumps all of the particle IDs and positions to a file.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_particles(FILE *fp=stdout) {
-			c_loop_all vl(*this);
-			draw_particles(vl,fp);
-		}
-		/** Dumps all of the particle IDs and positions to a file.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_particles(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_particles(fp);
-			fclose(fp);
-		}
-		/** Dumps particle positions in POV-Ray format.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_particles_pov(c_loop &vl,FILE *fp) {
-			double *pp;
-			if(vl.start()) do {
-				pp=p[vl.ijk]+3*vl.q;
-				fprintf(fp,"// id %d\nsphere{<%g,%g,%g>,s}\n",
-						id[vl.ijk][vl.q],*pp,pp[1],pp[2]);
-			} while(vl.inc());
-		}
-		/** Dumps all particle positions in POV-Ray format.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_particles_pov(FILE *fp=stdout) {
-			c_loop_all vl(*this);
-			draw_particles_pov(vl,fp);
-		}
-		/** Dumps all particle positions in POV-Ray format.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_particles_pov(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_particles_pov(fp);
-			fclose(fp);
-		}
-		/** Computes Voronoi cells and saves the output in gnuplot
-		 * format.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_cells_gnuplot(c_loop &vl,FILE *fp) {
-			voronoicell c(*this);double *pp;
-			if(vl.start()) do if(compute_cell(c,vl)) {
-				pp=p[vl.ijk]+ps*vl.q;
-				c.draw_gnuplot(*pp,pp[1],pp[2],fp);
-			} while(vl.inc());
-		}
-		/** Computes all Voronoi cells and saves the output in gnuplot
-		 * format.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_cells_gnuplot(FILE *fp=stdout) {
-			c_loop_all vl(*this);
-			draw_cells_gnuplot(vl,fp);
-		}
-		/** Computes all Voronoi cells and saves the output in gnuplot
-		 * format.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_cells_gnuplot(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_cells_gnuplot(fp);
-			fclose(fp);
-		}
-		/** Computes Voronoi cells and saves the output in POV-Ray
-		 * format.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_cells_pov(c_loop &vl,FILE *fp) {
-			voronoicell c(*this);double *pp;
-			if(vl.start()) do if(compute_cell(c,vl)) {
-				fprintf(fp,"// cell %d\n",id[vl.ijk][vl.q]);
-				pp=p[vl.ijk]+ps*vl.q;
-				c.draw_pov(*pp,pp[1],pp[2],fp);
-			} while(vl.inc());
-		}
-		/** Computes all Voronoi cells and saves the output in POV-Ray
-		 * format.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_cells_pov(FILE *fp=stdout) {
-			c_loop_all vl(*this);
-			draw_cells_pov(vl,fp);
-		}
-		/** Computes all Voronoi cells and saves the output in POV-Ray
-		 * format.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_cells_pov(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_cells_pov(fp);
-			fclose(fp);
-		}
-		/** Computes the Voronoi cells and saves customized information
-		 * about them.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] format the custom output string to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void print_custom(c_loop &vl,const char *format,FILE *fp) {
-			int ijk,q;double *pp;
-			if(contains_neighbor(format)) {
-				voronoicell_neighbor c(*this);
-				if(vl.start()) do if(compute_cell(c,vl)) {
-					ijk=vl.ijk;q=vl.q;pp=p[ijk]+ps*q;
-					c.output_custom(format,id[ijk][q],*pp,pp[1],pp[2],default_radius,fp);
-				} while(vl.inc());
-			} else {
-				voronoicell c(*this);
-				if(vl.start()) do if(compute_cell(c,vl)) {
-					ijk=vl.ijk;q=vl.q;pp=p[ijk]+ps*q;
-					c.output_custom(format,id[ijk][q],*pp,pp[1],pp[2],default_radius,fp);
-				} while(vl.inc());
-			}
-		}
-		void print_custom(const char *format,FILE *fp=stdout);
-		void print_custom(const char *format,const char *filename);
-		bool find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid);
-		/** Computes the Voronoi cell for a particle currently being
-		 * referenced by a loop class.
-		 * \param[out] c a Voronoi cell class in which to store the
-		 * 		 computed cell.
-		 * \param[in] vl the loop class to use.
-		 * \return True if the cell was computed. If the cell cannot be
-		 * computed, if it is removed entirely by a wall or boundary
-		 * condition, then the routine returns false. */
-		template<class v_cell,class c_loop>
-		inline bool compute_cell(v_cell &c,c_loop &vl) {
-			return vc.compute_cell(c,vl.ijk,vl.q,vl.i,vl.j,vl.k);
-		}
-		/** Computes the Voronoi cell for given particle.
-		 * \param[out] c a Voronoi cell class in which to store the
-		 * 		 computed cell.
-		 * \param[in] ijk the block that the particle is within.
-		 * \param[in] q the index of the particle within the block.
-		 * \return True if the cell was computed. If the cell cannot be
-		 * computed, if it is removed entirely by a wall or boundary
-		 * condition, then the routine returns false. */
-		template<class v_cell>
-		inline bool compute_cell(v_cell &c,int ijk,int q) {
-			int k=ijk/nxy,ijkt=ijk-nxy*k,j=ijkt/nx,i=ijkt-j*nx;
-			return vc.compute_cell(c,ijk,q,i,j,k);
-		}
-		/** Computes the Voronoi cell for a ghost particle at a given
-		 * location.
-		 * \param[out] c a Voronoi cell class in which to store the
-		 * 		 computed cell.
-		 * \param[in] (x,y,z) the location of the ghost particle.
-		 * \return True if the cell was computed. If the cell cannot be
-		 * computed, if it is removed entirely by a wall or boundary
-		 * condition, then the routine returns false. */
-		template<class v_cell>
-		inline bool compute_ghost_cell(v_cell &c,double x,double y,double z) {
-			int ijk;
-			if(put_locate_block(ijk,x,y,z)) {
-				double *pp=p[ijk]+3*co[ijk]++;
-				*(pp++)=x;*(pp++)=y;*pp=z;
-				bool q=compute_cell(c,ijk,co[ijk]-1);
-				co[ijk]--;
-				return q;
-			}
-			return false;
-		}
-	private:
-		voro_compute<container> vc;
-		friend class voro_compute<container>;
+    public:
+        container(double ax_,double bx_,double ay_,double by_,double az_,double bz_,
+                int nx_,int ny_,int nz_,bool xperiodic_,bool yperiodic_,bool zperiodic_,int init_mem);
+        void clear();
+        void put(int n,double x,double y,double z);
+        void put(particle_order &vo,int n,double x,double y,double z);
+        void import(FILE *fp=stdin);
+        void import(particle_order &vo,FILE *fp=stdin);
+        /** Imports a list of particles from an open file stream into
+         * the container. Entries of four numbers (Particle ID, x
+         * position, y position, z position) are searched for. If the
+         * file cannot be successfully read, then the routine causes a
+         * fatal error.
+         * \param[in] filename the name of the file to open and read
+         *                     from. */
+        inline void import(const char* filename) {
+            FILE *fp=safe_fopen(filename,"r");
+            import(fp);
+            fclose(fp);
+        }
+        /** Imports a list of particles from an open file stream into
+         * the container. Entries of four numbers (Particle ID, x
+         * position, y position, z position) are searched for. In
+         * addition, the order in which particles are read is saved
+         * into an ordering class. If the file cannot be successfully
+         * read, then the routine causes a fatal error.
+         * \param[in,out] vo the ordering class to use.
+         * \param[in] filename the name of the file to open and read
+         *                     from. */
+        inline void import(particle_order &vo,const char* filename) {
+            FILE *fp=safe_fopen(filename,"r");
+            import(vo,fp);
+            fclose(fp);
+        }
+        void compute_all_cells();
+        double sum_cell_volumes();
+        bool find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid);
+        /** Computes the Voronoi cell for a particle currently being
+         * referenced by a loop class.
+         * \param[out] c a Voronoi cell class in which to store the
+         * 		 computed cell.
+         * \param[in] vl the loop class to use.
+         * \return True if the cell was computed. If the cell cannot be
+         * computed, if it is removed entirely by a wall or boundary
+         * condition, then the routine returns false. */
+        template<class v_cell,class c_loop>
+        inline bool compute_cell(v_cell &c,c_loop &vl) {
+            return vc.compute_cell(c,vl.ijk,vl.q,vl.i,vl.j,vl.k);
+        }
+        /** Computes the Voronoi cell for given particle.
+         * \param[out] c a Voronoi cell class in which to store the
+         * 		 computed cell.
+         * \param[in] ijk the block that the particle is within.
+         * \param[in] q the index of the particle within the block.
+         * \return True if the cell was computed. If the cell cannot be
+         * computed, if it is removed entirely by a wall or boundary
+         * condition, then the routine returns false. */
+        template<class v_cell>
+        inline bool compute_cell(v_cell &c,int ijk,int q) {
+            int k=ijk/nxy,ijkt=ijk-nxy*k,j=ijkt/nx,i=ijkt-j*nx;
+            return vc.compute_cell(c,ijk,q,i,j,k);
+        }
+        /** Computes the Voronoi cell for a ghost particle at a given
+         * location.
+         * \param[out] c a Voronoi cell class in which to store the
+         * 		 computed cell.
+         * \param[in] (x,y,z) the location of the ghost particle.
+         * \return True if the cell was computed. If the cell cannot be
+         * computed, if it is removed entirely by a wall or boundary
+         * condition, then the routine returns false. */
+        template<class v_cell>
+        inline bool compute_ghost_cell(v_cell &c,double x,double y,double z) {
+            int ijk;
+            if(put_locate_block(ijk,x,y,z)) {
+                double *pp=p[ijk]+3*co[ijk]++;
+                *(pp++)=x;*(pp++)=y;*pp=z;
+                bool q=compute_cell(c,ijk,co[ijk]-1);
+                co[ijk]--;
+                return q;
+            }
+            return false;
+        }
+    private:
+        voro_compute<container> vc;
+        friend class voro_compute<container>;
 };
 
 /** \brief Extension of the container_base class for computing radical Voronoi
@@ -508,223 +364,93 @@ class container : public container_base, public radius_mono {
  * specifically for computing the radical Voronoi tessellation that depends on
  * the particle radii. */
 class container_poly : public container_base, public radius_poly {
-	public:
-		container_poly(double ax_,double bx_,double ay_,double by_,double az_,double bz_,
-				int nx_,int ny_,int nz_,bool xperiodic_,bool yperiodic_,bool zperiodic_,int init_mem);
-		void clear();
-		void put(int n,double x,double y,double z,double r);
-		void put(particle_order &vo,int n,double x,double y,double z,double r);
-		void import(FILE *fp=stdin);
-		void import(particle_order &vo,FILE *fp=stdin);
-		/** Imports a list of particles from an open file stream into
-		 * the container_poly class. Entries of five numbers (Particle
-		 * ID, x position, y position, z position, radius) are searched
-		 * for. If the file cannot be successfully read, then the
-		 * routine causes a fatal error.
-		 * \param[in] filename the name of the file to open and read
-		 *                     from. */
-		inline void import(const char* filename) {
-			FILE *fp=safe_fopen(filename,"r");
-			import(fp);
-			fclose(fp);
-		}
-		/** Imports a list of particles from an open file stream into
-		 * the container_poly class. Entries of five numbers (Particle
-		 * ID, x position, y position, z position, radius) are searched
-		 * for. In addition, the order in which particles are read is
-		 * saved into an ordering class. If the file cannot be
-		 * successfully read, then the routine causes a fatal error.
-		 * \param[in,out] vo the ordering class to use.
-		 * \param[in] filename the name of the file to open and read
-		 *                     from. */
-		inline void import(particle_order &vo,const char* filename) {
-			FILE *fp=safe_fopen(filename,"r");
-			import(vo,fp);
-			fclose(fp);
-		}
-		void compute_all_cells();
-		double sum_cell_volumes();
-		/** Dumps particle IDs, positions and radii to a file.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_particles(c_loop &vl,FILE *fp) {
-			double *pp;
-			if(vl.start()) do {
-				pp=p[vl.ijk]+4*vl.q;
-				fprintf(fp,"%d %g %g %g %g\n",id[vl.ijk][vl.q],*pp,pp[1],pp[2],pp[3]);
-			} while(vl.inc());
-		}
-		/** Dumps all of the particle IDs, positions and radii to a
-		 * file.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_particles(FILE *fp=stdout) {
-			c_loop_all vl(*this);
-			draw_particles(vl,fp);
-		}
-		/** Dumps all of the particle IDs, positions and radii to a
-		 * file.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_particles(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_particles(fp);
-			fclose(fp);
-		}
-		/** Dumps particle positions in POV-Ray format.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_particles_pov(c_loop &vl,FILE *fp) {
-			double *pp;
-			if(vl.start()) do {
-				pp=p[vl.ijk]+4*vl.q;
-				fprintf(fp,"// id %d\nsphere{<%g,%g,%g>,%g}\n",
-						id[vl.ijk][vl.q],*pp,pp[1],pp[2],pp[3]);
-			} while(vl.inc());
-		}
-		/** Dumps all the particle positions in POV-Ray format.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_particles_pov(FILE *fp=stdout) {
-			c_loop_all vl(*this);
-			draw_particles_pov(vl,fp);
-		}
-		/** Dumps all the particle positions in POV-Ray format.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_particles_pov(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_particles_pov(fp);
-			fclose(fp);
-		}
-		/** Computes Voronoi cells and saves the output in gnuplot
-		 * format.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_cells_gnuplot(c_loop &vl,FILE *fp) {
-			voronoicell c;double *pp;
-			if(vl.start()) do if(compute_cell(c,vl)) {
-				pp=p[vl.ijk]+ps*vl.q;
-				c.draw_gnuplot(*pp,pp[1],pp[2],fp);
-			} while(vl.inc());
-		}
-		/** Compute all Voronoi cells and saves the output in gnuplot
-		 * format.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_cells_gnuplot(FILE *fp=stdout) {
-			c_loop_all vl(*this);
-			draw_cells_gnuplot(vl,fp);
-		}
-		/** Compute all Voronoi cells and saves the output in gnuplot
-		 * format.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_cells_gnuplot(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_cells_gnuplot(fp);
-			fclose(fp);
-		}
-		/** Computes Voronoi cells and saves the output in POV-Ray
-		 * format.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_cells_pov(c_loop &vl,FILE *fp) {
-			voronoicell c(*this);double *pp;
-			if(vl.start()) do if(compute_cell(c,vl)) {
-				fprintf(fp,"// cell %d\n",id[vl.ijk][vl.q]);
-				pp=p[vl.ijk]+ps*vl.q;
-				c.draw_pov(*pp,pp[1],pp[2],fp);
-			} while(vl.inc());
-		}
-		/** Computes all Voronoi cells and saves the output in POV-Ray
-		 * format.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_cells_pov(FILE *fp=stdout) {
-			c_loop_all vl(*this);
-			draw_cells_pov(vl,fp);
-		}
-		/** Computes all Voronoi cells and saves the output in POV-Ray
-		 * format.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_cells_pov(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_cells_pov(fp);
-			fclose(fp);
-		}
-		/** Computes the Voronoi cells and saves customized information
-		 * about them.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] format the custom output string to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void print_custom(c_loop &vl,const char *format,FILE *fp) {
-			int ijk,q;double *pp;
-			if(contains_neighbor(format)) {
-				voronoicell_neighbor c(*this);
-				if(vl.start()) do if(compute_cell(c,vl)) {
-					ijk=vl.ijk;q=vl.q;pp=p[ijk]+ps*q;
-					c.output_custom(format,id[ijk][q],*pp,pp[1],pp[2],pp[3],fp);
-				} while(vl.inc());
-			} else {
-				voronoicell c(*this);
-				if(vl.start()) do if(compute_cell(c,vl)) {
-					ijk=vl.ijk;q=vl.q;pp=p[ijk]+ps*q;
-					c.output_custom(format,id[ijk][q],*pp,pp[1],pp[2],pp[3],fp);
-				} while(vl.inc());
-			}
-		}
-		/** Computes the Voronoi cell for a particle currently being
-		 * referenced by a loop class.
-		 * \param[out] c a Voronoi cell class in which to store the
-		 * 		 computed cell.
-		 * \param[in] vl the loop class to use.
-		 * \return True if the cell was computed. If the cell cannot be
-		 * computed, if it is removed entirely by a wall or boundary
-		 * condition, then the routine returns false. */
-		template<class v_cell,class c_loop>
-		inline bool compute_cell(v_cell &c,c_loop &vl) {
-			return vc.compute_cell(c,vl.ijk,vl.q,vl.i,vl.j,vl.k);
-		}
-		/** Computes the Voronoi cell for given particle.
-		 * \param[out] c a Voronoi cell class in which to store the
-		 * 		 computed cell.
-		 * \param[in] ijk the block that the particle is within.
-		 * \param[in] q the index of the particle within the block.
-		 * \return True if the cell was computed. If the cell cannot be
-		 * computed, if it is removed entirely by a wall or boundary
-		 * condition, then the routine returns false. */
-		template<class v_cell>
-		inline bool compute_cell(v_cell &c,int ijk,int q) {
-			int k=ijk/nxy,ijkt=ijk-nxy*k,j=ijkt/nx,i=ijkt-j*nx;
-			return vc.compute_cell(c,ijk,q,i,j,k);
-		}
-		/** Computes the Voronoi cell for a ghost particle at a given
-		 * location.
-		 * \param[out] c a Voronoi cell class in which to store the
-		 * 		 computed cell.
-		 * \param[in] (x,y,z) the location of the ghost particle.
-		 * \param[in] r the radius of the ghost particle.
-		 * \return True if the cell was computed. If the cell cannot be
-		 * computed, if it is removed entirely by a wall or boundary
-		 * condition, then the routine returns false. */
-		template<class v_cell>
-		inline bool compute_ghost_cell(v_cell &c,double x,double y,double z,double r) {
-			int ijk;
-			if(put_locate_block(ijk,x,y,z)) {
-				double *pp=p[ijk]+4*co[ijk]++,tm=max_radius;
-				*(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-				if(r>max_radius) max_radius=r;
-				bool q=compute_cell(c,ijk,co[ijk]-1);
-				co[ijk]--;max_radius=tm;
-				return q;
-			}
-			return false;
-		}
-		void print_custom(const char *format,FILE *fp=stdout);
-		void print_custom(const char *format,const char *filename);
-		bool find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid);
-	private:
-		voro_compute<container_poly> vc;
-		friend class voro_compute<container_poly>;
+    public:
+        container_poly(double ax_,double bx_,double ay_,double by_,double az_,double bz_,
+                int nx_,int ny_,int nz_,bool xperiodic_,bool yperiodic_,bool zperiodic_,int init_mem);
+        void clear();
+        void put(int n,double x,double y,double z,double r);
+        void put(particle_order &vo,int n,double x,double y,double z,double r);
+        void import(FILE *fp=stdin);
+        void import(particle_order &vo,FILE *fp=stdin);
+        /** Imports a list of particles from an open file stream into
+         * the container_poly class. Entries of five numbers (Particle
+         * ID, x position, y position, z position, radius) are searched
+         * for. If the file cannot be successfully read, then the
+         * routine causes a fatal error.
+         * \param[in] filename the name of the file to open and read
+         *                     from. */
+        inline void import(const char* filename) {
+            FILE *fp=safe_fopen(filename,"r");
+            import(fp);
+            fclose(fp);
+        }
+        /** Imports a list of particles from an open file stream into
+         * the container_poly class. Entries of five numbers (Particle
+         * ID, x position, y position, z position, radius) are searched
+         * for. In addition, the order in which particles are read is
+         * saved into an ordering class. If the file cannot be
+         * successfully read, then the routine causes a fatal error.
+         * \param[in,out] vo the ordering class to use.
+         * \param[in] filename the name of the file to open and read
+         *                     from. */
+        inline void import(particle_order &vo,const char* filename) {
+            FILE *fp=safe_fopen(filename,"r");
+            import(vo,fp);
+            fclose(fp);
+        }
+        void compute_all_cells();
+        double sum_cell_volumes();
+        /** Computes the Voronoi cell for a particle currently being
+         * referenced by a loop class.
+         * \param[out] c a Voronoi cell class in which to store the
+         * 		 computed cell.
+         * \param[in] vl the loop class to use.
+         * \return True if the cell was computed. If the cell cannot be
+         * computed, if it is removed entirely by a wall or boundary
+         * condition, then the routine returns false. */
+        template<class v_cell,class c_loop>
+        inline bool compute_cell(v_cell &c,c_loop &vl) {
+            return vc.compute_cell(c,vl.ijk,vl.q,vl.i,vl.j,vl.k);
+        }
+        /** Computes the Voronoi cell for given particle.
+         * \param[out] c a Voronoi cell class in which to store the
+         * 		 computed cell.
+         * \param[in] ijk the block that the particle is within.
+         * \param[in] q the index of the particle within the block.
+         * \return True if the cell was computed. If the cell cannot be
+         * computed, if it is removed entirely by a wall or boundary
+         * condition, then the routine returns false. */
+        template<class v_cell>
+        inline bool compute_cell(v_cell &c,int ijk,int q) {
+            int k=ijk/nxy,ijkt=ijk-nxy*k,j=ijkt/nx,i=ijkt-j*nx;
+            return vc.compute_cell(c,ijk,q,i,j,k);
+        }
+        /** Computes the Voronoi cell for a ghost particle at a given
+         * location.
+         * \param[out] c a Voronoi cell class in which to store the
+         * 		 computed cell.
+         * \param[in] (x,y,z) the location of the ghost particle.
+         * \param[in] r the radius of the ghost particle.
+         * \return True if the cell was computed. If the cell cannot be
+         * computed, if it is removed entirely by a wall or boundary
+         * condition, then the routine returns false. */
+        template<class v_cell>
+        inline bool compute_ghost_cell(v_cell &c,double x,double y,double z,double r) {
+            int ijk;
+            if(put_locate_block(ijk,x,y,z)) {
+                double *pp=p[ijk]+4*co[ijk]++,tm=max_radius;
+                *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
+                if(r>max_radius) max_radius=r;
+                bool q=compute_cell(c,ijk,co[ijk]-1);
+                co[ijk]--;max_radius=tm;
+                return q;
+            }
+            return false;
+        }
+        bool find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid);
+    private:
+        voro_compute<container_poly> vc;
+        friend class voro_compute<container_poly>;
 };
 
 }

--- a/SKIRT/voro/container.hh
+++ b/SKIRT/voro/container.hh
@@ -166,7 +166,6 @@ class container_base : public voro_base, public wall_list {
                 int init_mem,int ps_);
         ~container_base();
         bool point_inside(double x,double y,double z);
-        void region_count();
         /** Initializes the Voronoi cell prior to a compute_cell
          * operation for a specific particle being carried out by a
          * voro_compute class. The cell is initialized to fill the
@@ -276,34 +275,6 @@ class container : public container_base, public radius_mono {
         void clear();
         void put(int n,double x,double y,double z);
         void put(particle_order &vo,int n,double x,double y,double z);
-        void import(FILE *fp=stdin);
-        void import(particle_order &vo,FILE *fp=stdin);
-        /** Imports a list of particles from an open file stream into
-         * the container. Entries of four numbers (Particle ID, x
-         * position, y position, z position) are searched for. If the
-         * file cannot be successfully read, then the routine causes a
-         * fatal error.
-         * \param[in] filename the name of the file to open and read
-         *                     from. */
-        inline void import(const char* filename) {
-            FILE *fp=safe_fopen(filename,"r");
-            import(fp);
-            fclose(fp);
-        }
-        /** Imports a list of particles from an open file stream into
-         * the container. Entries of four numbers (Particle ID, x
-         * position, y position, z position) are searched for. In
-         * addition, the order in which particles are read is saved
-         * into an ordering class. If the file cannot be successfully
-         * read, then the routine causes a fatal error.
-         * \param[in,out] vo the ordering class to use.
-         * \param[in] filename the name of the file to open and read
-         *                     from. */
-        inline void import(particle_order &vo,const char* filename) {
-            FILE *fp=safe_fopen(filename,"r");
-            import(vo,fp);
-            fclose(fp);
-        }
         void compute_all_cells();
         double sum_cell_volumes();
         bool find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid);
@@ -370,34 +341,6 @@ class container_poly : public container_base, public radius_poly {
         void clear();
         void put(int n,double x,double y,double z,double r);
         void put(particle_order &vo,int n,double x,double y,double z,double r);
-        void import(FILE *fp=stdin);
-        void import(particle_order &vo,FILE *fp=stdin);
-        /** Imports a list of particles from an open file stream into
-         * the container_poly class. Entries of five numbers (Particle
-         * ID, x position, y position, z position, radius) are searched
-         * for. If the file cannot be successfully read, then the
-         * routine causes a fatal error.
-         * \param[in] filename the name of the file to open and read
-         *                     from. */
-        inline void import(const char* filename) {
-            FILE *fp=safe_fopen(filename,"r");
-            import(fp);
-            fclose(fp);
-        }
-        /** Imports a list of particles from an open file stream into
-         * the container_poly class. Entries of five numbers (Particle
-         * ID, x position, y position, z position, radius) are searched
-         * for. In addition, the order in which particles are read is
-         * saved into an ordering class. If the file cannot be
-         * successfully read, then the routine causes a fatal error.
-         * \param[in,out] vo the ordering class to use.
-         * \param[in] filename the name of the file to open and read
-         *                     from. */
-        inline void import(particle_order &vo,const char* filename) {
-            FILE *fp=safe_fopen(filename,"r");
-            import(vo,fp);
-            fclose(fp);
-        }
         void compute_all_cells();
         double sum_cell_volumes();
         /** Computes the Voronoi cell for a particle currently being

--- a/SKIRT/voro/container_prd.cc
+++ b/SKIRT/voro/container_prd.cc
@@ -27,39 +27,39 @@ namespace voro {
  * \param[in] ps_ the number of floating point entries to store for each
  *                particle. */
 container_periodic_base::container_periodic_base(double bx_,double bxy_,double by_,
-		double bxz_,double byz_,double bz_,int nx_,int ny_,int nz_,int init_mem_,int ps_)
-	: unitcell(bx_,bxy_,by_,bxz_,byz_,bz_),
-	voro_base(nx_,ny_,nz_,bx_/nx_,by_/ny_,bz_/nz_), max_len_sq(unit_voro.max_radius_squared()),
-	ey(int(max_uv_y*ysp+1)), ez(int(max_uv_z*zsp+1)), wy(ny+ey), wz(nz+ez),
-	oy(ny+2*ey), oz(nz+2*ez), oxyz(nx*oy*oz), id(new int*[oxyz]), p(new double*[oxyz]),
-	co(new int[oxyz]), mem(new int[oxyz]), img(new char[oxyz]), init_mem(init_mem_), ps(ps_) {
-	int i,j,k,l;
+        double bxz_,double byz_,double bz_,int nx_,int ny_,int nz_,int init_mem_,int ps_)
+    : unitcell(bx_,bxy_,by_,bxz_,byz_,bz_),
+    voro_base(nx_,ny_,nz_,bx_/nx_,by_/ny_,bz_/nz_), max_len_sq(unit_voro.max_radius_squared()),
+    ey(int(max_uv_y*ysp+1)), ez(int(max_uv_z*zsp+1)), wy(ny+ey), wz(nz+ez),
+    oy(ny+2*ey), oz(nz+2*ez), oxyz(nx*oy*oz), id(new int*[oxyz]), p(new double*[oxyz]),
+    co(new int[oxyz]), mem(new int[oxyz]), img(new char[oxyz]), init_mem(init_mem_), ps(ps_) {
+    int i,j,k,l;
 
-	// Clear the global arrays
-	int *pp=co;while(pp<co+oxyz) *(pp++)=0;
-	pp=mem;while(pp<mem+oxyz) *(pp++)=0;
-	char *cp=img;while(cp<img+oxyz) *(cp++)=0;
+    // Clear the global arrays
+    int *pp=co;while(pp<co+oxyz) *(pp++)=0;
+    pp=mem;while(pp<mem+oxyz) *(pp++)=0;
+    char *cp=img;while(cp<img+oxyz) *(cp++)=0;
 
-	// Set up memory for the blocks in the primary domain
-	for(k=ez;k<wz;k++) for(j=ey;j<wy;j++) for(i=0;i<nx;i++) {
-		l=i+nx*(j+oy*k);
-		mem[l]=init_mem;
-		id[l]=new int[init_mem];
-		p[l]=new double[ps*init_mem];
-	}
+    // Set up memory for the blocks in the primary domain
+    for(k=ez;k<wz;k++) for(j=ey;j<wy;j++) for(i=0;i<nx;i++) {
+        l=i+nx*(j+oy*k);
+        mem[l]=init_mem;
+        id[l]=new int[init_mem];
+        p[l]=new double[ps*init_mem];
+    }
 }
 
 /** The container destructor frees the dynamically allocated memory. */
 container_periodic_base::~container_periodic_base() {
-	for(int l=oxyz-1;l>=0;l--) if(mem[l]>0) {
-		delete [] p[l];
-		delete [] id[l];
-	}
-	delete [] img;
-	delete [] mem;
-	delete [] co;
-	delete [] id;
-	delete [] p;
+    for(int l=oxyz-1;l>=0;l--) if(mem[l]>0) {
+        delete [] p[l];
+        delete [] id[l];
+    }
+    delete [] img;
+    delete [] mem;
+    delete [] co;
+    delete [] id;
+    delete [] p;
 }
 
 /** The class constructor sets up the geometry of container.
@@ -71,9 +71,9 @@ container_periodic_base::~container_periodic_base() {
  *			    coordinate directions.
  * \param[in] init_mem_ the initial memory allocation for each block. */
 container_periodic::container_periodic(double bx_,double bxy_,double by_,double bxz_,double byz_,double bz_,
-	int nx_,int ny_,int nz_,int init_mem_)
-	: container_periodic_base(bx_,bxy_,by_,bxz_,byz_,bz_,nx_,ny_,nz_,init_mem_,3),
-	vc(*this,2*nx_+1,2*ey+1,2*ez+1) {}
+    int nx_,int ny_,int nz_,int init_mem_)
+    : container_periodic_base(bx_,bxy_,by_,bxz_,byz_,bz_,nx_,ny_,nz_,init_mem_,3),
+    vc(*this,2*nx_+1,2*ey+1,2*ez+1) {}
 
 /** The class constructor sets up the geometry of container.
  * \param[in] (bx_) The x coordinate of the first unit vector.
@@ -84,20 +84,20 @@ container_periodic::container_periodic(double bx_,double bxy_,double by_,double 
  *			    coordinate directions.
  * \param[in] init_mem_ the initial memory allocation for each block. */
 container_periodic_poly::container_periodic_poly(double bx_,double bxy_,double by_,double bxz_,double byz_,double bz_,
-	int nx_,int ny_,int nz_,int init_mem_)
-	: container_periodic_base(bx_,bxy_,by_,bxz_,byz_,bz_,nx_,ny_,nz_,init_mem_,4),
-	vc(*this,2*nx_+1,2*ey+1,2*ez+1) {ppr=p;}
+    int nx_,int ny_,int nz_,int init_mem_)
+    : container_periodic_base(bx_,bxy_,by_,bxz_,byz_,bz_,nx_,ny_,nz_,init_mem_,4),
+    vc(*this,2*nx_+1,2*ey+1,2*ez+1) {ppr=p;}
 
 /** Put a particle into the correct region of the container.
  * \param[in] n the numerical ID of the inserted particle.
  * \param[in] (x,y,z) the position vector of the inserted particle. */
 void container_periodic::put(int n,double x,double y,double z) {
-	int ijk;
-	put_locate_block(ijk,x,y,z);
-	for(int l=0;l<co[ijk];l++) check_duplicate(n,x,y,z,id[ijk][l],p[ijk]+3*l);
-	id[ijk][co[ijk]]=n;
-	double *pp=p[ijk]+3*co[ijk]++;
-	*(pp++)=x;*(pp++)=y;*pp=z;
+    int ijk;
+    put_locate_block(ijk,x,y,z);
+    for(int l=0;l<co[ijk];l++) check_duplicate(n,x,y,z,id[ijk][l],p[ijk]+3*l);
+    id[ijk][co[ijk]]=n;
+    double *pp=p[ijk]+3*co[ijk]++;
+    *(pp++)=x;*(pp++)=y;*pp=z;
 }
 
 /** Put a particle into the correct region of the container.
@@ -105,13 +105,13 @@ void container_periodic::put(int n,double x,double y,double z) {
  * \param[in] (x,y,z) the position vector of the inserted particle.
  * \param[in] r the radius of the particle. */
 void container_periodic_poly::put(int n,double x,double y,double z,double r) {
-	int ijk;
-	put_locate_block(ijk,x,y,z);
-	for(int l=0;l<co[ijk];l++) check_duplicate(n,x,y,z,id[ijk][l],p[ijk]+4*l);
-	id[ijk][co[ijk]]=n;
-	double *pp=p[ijk]+4*co[ijk]++;
-	*(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-	if(max_radius<r) max_radius=r;
+    int ijk;
+    put_locate_block(ijk,x,y,z);
+    for(int l=0;l<co[ijk];l++) check_duplicate(n,x,y,z,id[ijk][l],p[ijk]+4*l);
+    id[ijk][co[ijk]]=n;
+    double *pp=p[ijk]+4*co[ijk]++;
+    *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
+    if(max_radius<r) max_radius=r;
 }
 
 /** Put a particle into the correct region of the container.
@@ -121,12 +121,12 @@ void container_periodic_poly::put(int n,double x,double y,double z,double r) {
  * 			  in, with (0,0,0) corresponding to the primary domain.
  */
 void container_periodic::put(int n,double x,double y,double z,int &ai,int &aj,int &ak) {
-	int ijk;
-	put_locate_block(ijk,x,y,z,ai,aj,ak);
-	for(int l=0;l<co[ijk];l++) check_duplicate(n,x,y,z,id[ijk][l],p[ijk]+3*l);
-	id[ijk][co[ijk]]=n;
-	double *pp=p[ijk]+3*co[ijk]++;
-	*(pp++)=x;*(pp++)=y;*pp=z;
+    int ijk;
+    put_locate_block(ijk,x,y,z,ai,aj,ak);
+    for(int l=0;l<co[ijk];l++) check_duplicate(n,x,y,z,id[ijk][l],p[ijk]+3*l);
+    id[ijk][co[ijk]]=n;
+    double *pp=p[ijk]+3*co[ijk]++;
+    *(pp++)=x;*(pp++)=y;*pp=z;
 }
 
 /** Put a particle into the correct region of the container.
@@ -137,14 +137,14 @@ void container_periodic::put(int n,double x,double y,double z,int &ai,int &aj,in
  * 			  in, with (0,0,0) corresponding to the primary domain.
  */
 void container_periodic_poly::put(int n,double x,double y,double z,double r,int &ai,int &aj,int &ak) {
-	int ijk;
-	put_locate_block(ijk,x,y,z,ai,aj,ak);
-	for(int l=0;l<co[ijk];l++) check_duplicate(n,x,y,z,id[ijk][l],p[ijk]+4*l);
+    int ijk;
+    put_locate_block(ijk,x,y,z,ai,aj,ak);
+    for(int l=0;l<co[ijk];l++) check_duplicate(n,x,y,z,id[ijk][l],p[ijk]+4*l);
 
-	id[ijk][co[ijk]]=n;
-	double *pp=p[ijk]+4*co[ijk]++;
-	*(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-	if(max_radius<r) max_radius=r;
+    id[ijk][co[ijk]]=n;
+    double *pp=p[ijk]+4*co[ijk]++;
+    *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
+    if(max_radius<r) max_radius=r;
 }
 
 /** Put a particle into the correct region of the container, also recording
@@ -153,12 +153,12 @@ void container_periodic_poly::put(int n,double x,double y,double z,double r,int 
  * \param[in] n the numerical ID of the inserted particle.
  * \param[in] (x,y,z) the position vector of the inserted particle. */
 void container_periodic::put(particle_order &vo,int n,double x,double y,double z) {
-	int ijk;
-	put_locate_block(ijk,x,y,z);
-	id[ijk][co[ijk]]=n;
-	vo.add(ijk,co[ijk]);
-	double *pp=p[ijk]+3*co[ijk]++;
-	*(pp++)=x;*(pp++)=y;*pp=z;
+    int ijk;
+    put_locate_block(ijk,x,y,z);
+    id[ijk][co[ijk]]=n;
+    vo.add(ijk,co[ijk]);
+    double *pp=p[ijk]+3*co[ijk]++;
+    *(pp++)=x;*(pp++)=y;*pp=z;
 }
 
 /** Put a particle into the correct region of the container, also recording
@@ -168,13 +168,13 @@ void container_periodic::put(particle_order &vo,int n,double x,double y,double z
  * \param[in] (x,y,z) the position vector of the inserted particle.
  * \param[in] r the radius of the particle. */
 void container_periodic_poly::put(particle_order &vo,int n,double x,double y,double z,double r) {
-	int ijk;
-	put_locate_block(ijk,x,y,z);
-	id[ijk][co[ijk]]=n;
-	vo.add(ijk,co[ijk]);
-	double *pp=p[ijk]+4*co[ijk]++;
-	*(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-	if(max_radius<r) max_radius=r;
+    int ijk;
+    put_locate_block(ijk,x,y,z);
+    id[ijk][co[ijk]]=n;
+    vo.add(ijk,co[ijk]);
+    double *pp=p[ijk]+4*co[ijk]++;
+    *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
+    if(max_radius<r) max_radius=r;
 }
 
 /** Takes a particle position vector and computes the region index into which
@@ -188,31 +188,31 @@ void container_periodic_poly::put(particle_order &vo,int n,double x,double y,dou
  * false otherwise. */
 void container_periodic_base::put_locate_block(int &ijk,double &x,double &y,double &z) {
 
-	// Remap particle in the z direction if necessary
-	int k=step_int(z*zsp);
-	if(k<0||k>=nz) {
-		int ak=step_div(k,nz);
-		z-=ak*bz;y-=ak*byz;x-=ak*bxz;k-=ak*nz;
-	}
+    // Remap particle in the z direction if necessary
+    int k=step_int(z*zsp);
+    if(k<0||k>=nz) {
+        int ak=step_div(k,nz);
+        z-=ak*bz;y-=ak*byz;x-=ak*bxz;k-=ak*nz;
+    }
 
-	// Remap particle in the y direction if necessary
-	int j=step_int(y*ysp);
-	if(j<0||j>=ny) {
-		int aj=step_div(j,ny);
-		y-=aj*by;x-=aj*bxy;j-=aj*ny;
-	}
+    // Remap particle in the y direction if necessary
+    int j=step_int(y*ysp);
+    if(j<0||j>=ny) {
+        int aj=step_div(j,ny);
+        y-=aj*by;x-=aj*bxy;j-=aj*ny;
+    }
 
-	// Remap particle in the x direction if necessary
-	ijk=step_int(x*xsp);
-	if(ijk<0||ijk>=nx) {
-		int ai=step_div(ijk,nx);
-		x-=ai*bx;ijk-=ai*nx;
-	}
+    // Remap particle in the x direction if necessary
+    ijk=step_int(x*xsp);
+    if(ijk<0||ijk>=nx) {
+        int ai=step_div(ijk,nx);
+        x-=ai*bx;ijk-=ai*nx;
+    }
 
-	// Compute the block index and check memory allocation
-	j+=ey;k+=ez;
-	ijk+=nx*(j+oy*k);
-	if(co[ijk]==mem[ijk]) add_particle_memory(ijk);
+    // Compute the block index and check memory allocation
+    j+=ey;k+=ez;
+    ijk+=nx*(j+oy*k);
+    if(co[ijk]==mem[ijk]) add_particle_memory(ijk);
 }
 
 /** Takes a particle position vector and computes the region index into which
@@ -228,31 +228,31 @@ void container_periodic_base::put_locate_block(int &ijk,double &x,double &y,doub
  * false otherwise. */
 void container_periodic_base::put_locate_block(int &ijk,double &x,double &y,double &z,int &ai,int &aj,int &ak) {
 
-	// Remap particle in the z direction if necessary
-	int k=step_int(z*zsp);
-	if(k<0||k>=nz) {
-		ak=step_div(k,nz);
-		z-=ak*bz;y-=ak*byz;x-=ak*bxz;k-=ak*nz;
-	} else ak=0;
+    // Remap particle in the z direction if necessary
+    int k=step_int(z*zsp);
+    if(k<0||k>=nz) {
+        ak=step_div(k,nz);
+        z-=ak*bz;y-=ak*byz;x-=ak*bxz;k-=ak*nz;
+    } else ak=0;
 
-	// Remap particle in the y direction if necessary
-	int j=step_int(y*ysp);
-	if(j<0||j>=ny) {
-		aj=step_div(j,ny);
-		y-=aj*by;x-=aj*bxy;j-=aj*ny;
-	} else aj=0;
+    // Remap particle in the y direction if necessary
+    int j=step_int(y*ysp);
+    if(j<0||j>=ny) {
+        aj=step_div(j,ny);
+        y-=aj*by;x-=aj*bxy;j-=aj*ny;
+    } else aj=0;
 
-	// Remap particle in the x direction if necessary
-	ijk=step_int(x*xsp);
-	if(ijk<0||ijk>=nx) {
-		ai=step_div(ijk,nx);
-		x-=ai*bx;ijk-=ai*nx;
-	} else ai=0;
+    // Remap particle in the x direction if necessary
+    ijk=step_int(x*xsp);
+    if(ijk<0||ijk>=nx) {
+        ai=step_div(ijk,nx);
+        x-=ai*bx;ijk-=ai*nx;
+    } else ai=0;
 
-	// Compute the block index and check memory allocation
-	j+=ey;k+=ez;
-	ijk+=nx*(j+oy*k);
-	if(co[ijk]==mem[ijk]) add_particle_memory(ijk);
+    // Compute the block index and check memory allocation
+    j+=ey;k+=ez;
+    ijk+=nx*(j+oy*k);
+    if(co[ijk]==mem[ijk]) add_particle_memory(ijk);
 }
 
 /** Takes a position vector and remaps it into the primary domain.
@@ -265,29 +265,29 @@ void container_periodic_base::put_locate_block(int &ijk,double &x,double &y,doub
  * \param[out] ijk the block index that the vector is within. */
 inline void container_periodic_base::remap(int &ai,int &aj,int &ak,int &ci,int &cj,int &ck,double &x,double &y,double &z,int &ijk) {
 
-	// Remap particle in the z direction if necessary
-	ck=step_int(z*zsp);
-	if(ck<0||ck>=nz) {
-		ak=step_div(ck,nz);
-		z-=ak*bz;y-=ak*byz;x-=ak*bxz;ck-=ak*nz;
-	} else ak=0;
+    // Remap particle in the z direction if necessary
+    ck=step_int(z*zsp);
+    if(ck<0||ck>=nz) {
+        ak=step_div(ck,nz);
+        z-=ak*bz;y-=ak*byz;x-=ak*bxz;ck-=ak*nz;
+    } else ak=0;
 
-	// Remap particle in the y direction if necessary
-	cj=step_int(y*ysp);
-	if(cj<0||cj>=ny) {
-		aj=step_div(cj,ny);
-		y-=aj*by;x-=aj*bxy;cj-=aj*ny;
-	} else aj=0;
+    // Remap particle in the y direction if necessary
+    cj=step_int(y*ysp);
+    if(cj<0||cj>=ny) {
+        aj=step_div(cj,ny);
+        y-=aj*by;x-=aj*bxy;cj-=aj*ny;
+    } else aj=0;
 
-	// Remap particle in the x direction if necessary
-	ci=step_int(x*xsp);
-	if(ci<0||ci>=nx) {
-		ai=step_div(ci,nx);
-		x-=ai*bx;ci-=ai*nx;
-	} else ai=0;
+    // Remap particle in the x direction if necessary
+    ci=step_int(x*xsp);
+    if(ci<0||ci>=nx) {
+        ai=step_div(ci,nx);
+        x-=ai*bx;ci-=ai*nx;
+    } else ai=0;
 
-	cj+=ey;ck+=ez;
-	ijk=ci+nx*(cj+oy*ck);
+    cj+=ey;ck+=ez;
+    ijk=ci+nx*(cj+oy*ck);
 }
 
 /** Takes a vector and finds the particle whose Voronoi cell contains that
@@ -301,27 +301,27 @@ inline void container_periodic_base::remap(int &ai,int &aj,int &ak,int &ci,int &
  * \return True if a particle was found. If the container has no particles,
  * then the search will not find a Voronoi cell and false is returned. */
 bool container_periodic::find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid) {
-	int ai,aj,ak,ci,cj,ck,ijk;
-	particle_record w;
-	double mrs;
+    int ai,aj,ak,ci,cj,ck,ijk;
+    particle_record w;
+    double mrs;
 
-	// Remap the vector into the primary domain and then search for the
-	// Voronoi cell that it is within
-	remap(ai,aj,ak,ci,cj,ck,x,y,z,ijk);
-	vc.find_voronoi_cell(x,y,z,ci,cj,ck,ijk,w,mrs);
+    // Remap the vector into the primary domain and then search for the
+    // Voronoi cell that it is within
+    remap(ai,aj,ak,ci,cj,ck,x,y,z,ijk);
+    vc.find_voronoi_cell(x,y,z,ci,cj,ck,ijk,w,mrs);
 
-	if(w.ijk!=-1) {
+    if(w.ijk!=-1) {
 
-		// Assemble the position vector of the particle to be returned,
-		// applying a periodic remapping if necessary
-		ci+=w.di;if(ci<0||ci>=nx) ai+=step_div(ci,nx);
-		rx=p[w.ijk][3*w.l]+ak*bxz+aj*bxy+ai*bx;
-		ry=p[w.ijk][3*w.l+1]+ak*byz+aj*by;
-		rz=p[w.ijk][3*w.l+2]+ak*bz;
-		pid=id[w.ijk][w.l];
-		return true;
-	}
-	return false;
+        // Assemble the position vector of the particle to be returned,
+        // applying a periodic remapping if necessary
+        ci+=w.di;if(ci<0||ci>=nx) ai+=step_div(ci,nx);
+        rx=p[w.ijk][3*w.l]+ak*bxz+aj*bxy+ai*bx;
+        ry=p[w.ijk][3*w.l+1]+ak*byz+aj*by;
+        rz=p[w.ijk][3*w.l+2]+ak*bz;
+        pid=id[w.ijk][w.l];
+        return true;
+    }
+    return false;
 }
 
 /** Takes a vector and finds the particle whose Voronoi cell contains that
@@ -335,61 +335,61 @@ bool container_periodic::find_voronoi_cell(double x,double y,double z,double &rx
  * \return True if a particle was found. If the container has no particles,
  * then the search will not find a Voronoi cell and false is returned. */
 bool container_periodic_poly::find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid) {
-	int ai,aj,ak,ci,cj,ck,ijk;
-	particle_record w;
-	double mrs;
+    int ai,aj,ak,ci,cj,ck,ijk;
+    particle_record w;
+    double mrs;
 
-	// Remap the vector into the primary domain and then search for the
-	// Voronoi cell that it is within
-	remap(ai,aj,ak,ci,cj,ck,x,y,z,ijk);
-	vc.find_voronoi_cell(x,y,z,ci,cj,ck,ijk,w,mrs);
+    // Remap the vector into the primary domain and then search for the
+    // Voronoi cell that it is within
+    remap(ai,aj,ak,ci,cj,ck,x,y,z,ijk);
+    vc.find_voronoi_cell(x,y,z,ci,cj,ck,ijk,w,mrs);
 
-	if(w.ijk!=-1) {
+    if(w.ijk!=-1) {
 
-		// Assemble the position vector of the particle to be returned,
-		// applying a periodic remapping if necessary
-		ci+=w.di;if(ci<0||ci>=nx) ai+=step_div(ci,nx);
-		rx=p[w.ijk][4*w.l]+ak*bxz+aj*bxy+ai*bx;
-		ry=p[w.ijk][4*w.l+1]+ak*byz+aj*by;
-		rz=p[w.ijk][4*w.l+2]+ak*bz;
-		pid=id[w.ijk][w.l];
-		return true;
-	}
-	return false;
+        // Assemble the position vector of the particle to be returned,
+        // applying a periodic remapping if necessary
+        ci+=w.di;if(ci<0||ci>=nx) ai+=step_div(ci,nx);
+        rx=p[w.ijk][4*w.l]+ak*bxz+aj*bxy+ai*bx;
+        ry=p[w.ijk][4*w.l+1]+ak*byz+aj*by;
+        rz=p[w.ijk][4*w.l+2]+ak*bz;
+        pid=id[w.ijk][w.l];
+        return true;
+    }
+    return false;
 }
 
 /** Increase memory for a particular region.
  * \param[in] i the index of the region to reallocate. */
 void container_periodic_base::add_particle_memory(int i) {
 
-	// Handle the case when no memory has been allocated for this block
-	if(mem[i]==0) {
-		mem[i]=init_mem;
-		id[i]=new int[init_mem];
-		p[i]=new double[ps*init_mem];
-		return;
-	}
+    // Handle the case when no memory has been allocated for this block
+    if(mem[i]==0) {
+        mem[i]=init_mem;
+        id[i]=new int[init_mem];
+        p[i]=new double[ps*init_mem];
+        return;
+    }
 
-	// Otherwise, double the memory allocation for this block. Carry out a
-	// check on the memory allocation size, and print a status message if
-	// requested.
-	int l,nmem(mem[i]<<1);
-	if(nmem>max_particle_memory)
-		voro_fatal_error("Absolute maximum memory allocation exceeded",VOROPP_MEMORY_ERROR);
+    // Otherwise, double the memory allocation for this block. Carry out a
+    // check on the memory allocation size, and print a status message if
+    // requested.
+    int l,nmem(mem[i]<<1);
+    if(nmem>max_particle_memory)
+        voro_fatal_error("Absolute maximum memory allocation exceeded",VOROPP_MEMORY_ERROR);
 #if VOROPP_VERBOSE >=3
-	fprintf(stderr,"Particle memory in region %d scaled up to %d\n",i,nmem);
+    fprintf(stderr,"Particle memory in region %d scaled up to %d\n",i,nmem);
 #endif
 
-	// Allocate new memory and copy in the contents of the old arrays
-	int *idp=new int[nmem];
-	for(l=0;l<co[i];l++) idp[l]=id[i][l];
-	double *pp=new double[ps*nmem];
-	for(l=0;l<ps*co[i];l++) pp[l]=p[i][l];
+    // Allocate new memory and copy in the contents of the old arrays
+    int *idp=new int[nmem];
+    for(l=0;l<co[i];l++) idp[l]=id[i][l];
+    double *pp=new double[ps*nmem];
+    for(l=0;l<ps*co[i];l++) pp[l]=p[i][l];
 
-	// Update pointers and delete old arrays
-	mem[i]=nmem;
-	delete [] id[i];id[i]=idp;
-	delete [] p[i];p[i]=pp;
+    // Update pointers and delete old arrays
+    mem[i]=nmem;
+    delete [] id[i];id[i]=idp;
+    delete [] p[i];p[i]=pp;
 }
 
 /** Import a list of particles from an open file stream into the container.
@@ -398,10 +398,10 @@ void container_periodic_base::add_particle_memory(int i) {
  * causes a fatal error.
  * \param[in] fp the file handle to read from. */
 void container_periodic::import(FILE *fp) {
-	int i,j;
-	double x,y,z;
-	while((j=fscanf(fp,"%d %lg %lg %lg",&i,&x,&y,&z))==4) put(i,x,y,z);
-	if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
+    int i,j;
+    double x,y,z;
+    while((j=fscanf(fp,"%d %lg %lg %lg",&i,&x,&y,&z))==4) put(i,x,y,z);
+    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
 }
 
 /** Import a list of particles from an open file stream, also storing the order
@@ -411,10 +411,10 @@ void container_periodic::import(FILE *fp) {
  * \param[in,out] vo a reference to an ordering class to use.
  * \param[in] fp the file handle to read from. */
 void container_periodic::import(particle_order &vo,FILE *fp) {
-	int i,j;
-	double x,y,z;
-	while((j=fscanf(fp,"%d %lg %lg %lg",&i,&x,&y,&z))==4) put(vo,i,x,y,z);
-	if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
+    int i,j;
+    double x,y,z;
+    while((j=fscanf(fp,"%d %lg %lg %lg",&i,&x,&y,&z))==4) put(vo,i,x,y,z);
+    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
 }
 
 /** Import a list of particles from an open file stream into the container.
@@ -423,10 +423,10 @@ void container_periodic::import(particle_order &vo,FILE *fp) {
  * routine causes a fatal error.
  * \param[in] fp the file handle to read from. */
 void container_periodic_poly::import(FILE *fp) {
-	int i,j;
-	double x,y,z,r;
-	while((j=fscanf(fp,"%d %lg %lg %lg %lg",&i,&x,&y,&z,&r))==5) put(i,x,y,z,r);
-	if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
+    int i,j;
+    double x,y,z,r;
+    while((j=fscanf(fp,"%d %lg %lg %lg %lg",&i,&x,&y,&z,&r))==5) put(i,x,y,z,r);
+    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
 }
 
 /** Import a list of particles from an open file stream, also storing the order
@@ -436,66 +436,30 @@ void container_periodic_poly::import(FILE *fp) {
  * \param[in,out] vo a reference to an ordering class to use.
  * \param[in] fp the file handle to read from. */
 void container_periodic_poly::import(particle_order &vo,FILE *fp) {
-	int i,j;
-	double x,y,z,r;
-	while((j=fscanf(fp,"%d %lg %lg %lg %lg",&i,&x,&y,&z,&r))==5) put(vo,i,x,y,z,r);
-	if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
+    int i,j;
+    double x,y,z,r;
+    while((j=fscanf(fp,"%d %lg %lg %lg %lg",&i,&x,&y,&z,&r))==5) put(vo,i,x,y,z,r);
+    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
 }
 
 /** Outputs the a list of all the container regions along with the number of
  * particles stored within each. */
 void container_periodic_base::region_count() {
-	int i,j,k,*cop=co;
-	for(k=0;k<nz;k++) for(j=0;j<ny;j++) for(i=0;i<nx;i++)
-		printf("Region (%d,%d,%d): %d particles\n",i,j,k,*(cop++));
+    int i,j,k,*cop=co;
+    for(k=0;k<nz;k++) for(j=0;j<ny;j++) for(i=0;i<nx;i++)
+        printf("Region (%d,%d,%d): %d particles\n",i,j,k,*(cop++));
 }
 
 /** Clears a container of particles. */
 void container_periodic::clear() {
-	for(int *cop=co;cop<co+nxyz;cop++) *cop=0;
+    for(int *cop=co;cop<co+nxyz;cop++) *cop=0;
 }
 
 /** Clears a container of particles, also clearing resetting the maximum radius
  * to zero. */
 void container_periodic_poly::clear() {
-	for(int *cop=co;cop<co+nxyz;cop++) *cop=0;
-	max_radius=0;
-}
-
-/** Computes all the Voronoi cells and saves customized information about them.
- * \param[in] format the custom output string to use.
- * \param[in] fp a file handle to write to. */
-void container_periodic::print_custom(const char *format,FILE *fp) {
-	c_loop_all_periodic vl(*this);
-	print_custom(vl,format,fp);
-}
-
-/** Computes all the Voronoi cells and saves customized
- * information about them.
- * \param[in] format the custom output string to use.
- * \param[in] fp a file handle to write to. */
-void container_periodic_poly::print_custom(const char *format,FILE *fp) {
-	c_loop_all_periodic vl(*this);
-	print_custom(vl,format,fp);
-}
-
-/** Computes all the Voronoi cells and saves customized information about them.
- * \param[in] format the custom output string to use.
- * \param[in] filename the name of the file to write to. */
-void container_periodic::print_custom(const char *format,const char *filename) {
-	FILE *fp=safe_fopen(filename,"w");
-	print_custom(format,fp);
-	fclose(fp);
-}
-
-/** Computes all the Voronoi cells and saves customized
- * information about them
- * \param[in] format the custom output string to use.
- * \param[in] filename the name of the file to write to. */
-void container_periodic_poly::print_custom(const char *format,const char *filename) {
-	FILE *fp=safe_fopen(filename,"w");
-	print_custom(format,fp);
-	fclose(fp);
+    for(int *cop=co;cop<co+nxyz;cop++) *cop=0;
+    max_radius=0;
 }
 
 /** Computes all of the Voronoi cells in the container, but does nothing
@@ -503,10 +467,10 @@ void container_periodic_poly::print_custom(const char *format,const char *filena
  * of the Voronoi algorithm, without any additional calculations such as
  * volume evaluation or cell output. */
 void container_periodic::compute_all_cells() {
-	voronoicell c(*this);
-	c_loop_all_periodic vl(*this);
-	if(vl.start()) do compute_cell(c,vl);
-	while(vl.inc());
+    voronoicell c(*this);
+    c_loop_all_periodic vl(*this);
+    if(vl.start()) do compute_cell(c,vl);
+    while(vl.inc());
 }
 
 /** Computes all of the Voronoi cells in the container, but does nothing
@@ -514,9 +478,9 @@ void container_periodic::compute_all_cells() {
  * of the Voronoi algorithm, without any additional calculations such as
  * volume evaluation or cell output. */
 void container_periodic_poly::compute_all_cells() {
-	voronoicell c(*this);
-	c_loop_all_periodic vl(*this);
-	if(vl.start()) do compute_cell(c,vl);while(vl.inc());
+    voronoicell c(*this);
+    c_loop_all_periodic vl(*this);
+    if(vl.start()) do compute_cell(c,vl);while(vl.inc());
 }
 
 /** Calculates all of the Voronoi cells and sums their volumes. In most cases
@@ -524,11 +488,11 @@ void container_periodic_poly::compute_all_cells() {
  * of the container to numerical precision.
  * \return The sum of all of the computed Voronoi volumes. */
 double container_periodic::sum_cell_volumes() {
-	voronoicell c(*this);
-	double vol=0;
-	c_loop_all_periodic vl(*this);
-	if(vl.start()) do if(compute_cell(c,vl)) vol+=c.volume();while(vl.inc());
-	return vol;
+    voronoicell c(*this);
+    double vol=0;
+    c_loop_all_periodic vl(*this);
+    if(vl.start()) do if(compute_cell(c,vl)) vol+=c.volume();while(vl.inc());
+    return vol;
 }
 
 /** Calculates all of the Voronoi cells and sums their volumes. In most cases
@@ -536,39 +500,39 @@ double container_periodic::sum_cell_volumes() {
  * of the container to numerical precision.
  * \return The sum of all of the computed Voronoi volumes. */
 double container_periodic_poly::sum_cell_volumes() {
-	voronoicell c(*this);
-	double vol=0;
-	c_loop_all_periodic vl(*this);
-	if(vl.start()) do if(compute_cell(c,vl)) vol+=c.volume();while(vl.inc());
-	return vol;
+    voronoicell c(*this);
+    double vol=0;
+    c_loop_all_periodic vl(*this);
+    if(vl.start()) do if(compute_cell(c,vl)) vol+=c.volume();while(vl.inc());
+    return vol;
 }
 
 /** This routine creates all periodic images of the particles. It is meant for
  * diagnostic purposes only, since usually periodic images are dynamically
  * created in when they are referenced. */
 void container_periodic_base::create_all_images() {
-	int i,j,k;
-	for(k=0;k<oz;k++) for(j=0;j<oy;j++) for(i=0;i<nx;i++) create_periodic_image(i,j,k);
+    int i,j,k;
+    for(k=0;k<oz;k++) for(j=0;j<oy;j++) for(i=0;i<nx;i++) create_periodic_image(i,j,k);
 }
 
 /** Checks that the particles within each block lie within that block's bounds.
  * This is useful for diagnosing problems with periodic image computation. */
 void container_periodic_base::check_compartmentalized() {
-	int c,l,i,j,k;
-	double mix,miy,miz,max,may,maz,*pp;
-	for(k=l=0;k<oz;k++) for(j=0;j<oy;j++) for(i=0;i<nx;i++,l++) if(mem[l]>0) {
+    int c,l,i,j,k;
+    double mix,miy,miz,max,may,maz,*pp;
+    for(k=l=0;k<oz;k++) for(j=0;j<oy;j++) for(i=0;i<nx;i++,l++) if(mem[l]>0) {
 
-		// Compute the block's bounds, adding in a small tolerance
-		mix=i*boxx-tolerance;max=mix+boxx+tolerance;
-		miy=(j-ey)*boxy-tolerance;may=miy+boxy+tolerance;
-		miz=(k-ez)*boxz-tolerance;maz=miz+boxz+tolerance;
+        // Compute the block's bounds, adding in a small tolerance
+        mix=i*boxx-tolerance;max=mix+boxx+tolerance;
+        miy=(j-ey)*boxy-tolerance;may=miy+boxy+tolerance;
+        miz=(k-ez)*boxz-tolerance;maz=miz+boxz+tolerance;
 
-		// Print entries for any particles that lie outside the block's
-		// bounds
-		for(pp=p[l],c=0;c<co[l];c++,pp+=ps) if(*pp<mix||*pp>max||pp[1]<miy||pp[1]>may||pp[2]<miz||pp[2]>maz)
-			printf("%d %d %d %d %f %f %f %f %f %f %f %f %f\n",
-			       id[l][c],i,j,k,*pp,pp[1],pp[2],mix,max,miy,may,miz,maz);
-	}
+        // Print entries for any particles that lie outside the block's
+        // bounds
+        for(pp=p[l],c=0;c<co[l];c++,pp+=ps) if(*pp<mix||*pp>max||pp[1]<miy||pp[1]>may||pp[2]<miz||pp[2]>maz)
+            printf("%d %d %d %d %f %f %f %f %f %f %f %f %f\n",
+                   id[l][c],i,j,k,*pp,pp[1],pp[2],mix,max,miy,may,miz,maz);
+    }
 }
 
 /** Creates particles within an image block that is aligned with the primary
@@ -579,47 +543,47 @@ void container_periodic_base::check_compartmentalized() {
  * \param[in] (di,dj,dk) the index of the block to consider. The z index must
  *			 satisfy ez<=dk<wz. */
 void container_periodic_base::create_side_image(int di,int dj,int dk) {
-	int l,dijk=di+nx*(dj+oy*dk),odijk,ima=step_div(dj-ey,ny);
-	int qua=di+step_int(-ima*bxy*xsp),quadiv=step_div(qua,nx);
-	int fi=qua-quadiv*nx,fijk=fi+nx*(dj-ima*ny+oy*dk);
-	double dis=ima*bxy+quadiv*bx,switchx=di*boxx-ima*bxy-quadiv*bx,adis;
+    int l,dijk=di+nx*(dj+oy*dk),odijk,ima=step_div(dj-ey,ny);
+    int qua=di+step_int(-ima*bxy*xsp),quadiv=step_div(qua,nx);
+    int fi=qua-quadiv*nx,fijk=fi+nx*(dj-ima*ny+oy*dk);
+    double dis=ima*bxy+quadiv*bx,switchx=di*boxx-ima*bxy-quadiv*bx,adis;
 
-	// Left image computation
-	if((img[dijk]&1)==0) {
-		if(di>0) {
-			odijk=dijk-1;adis=dis;
-		} else {
-			odijk=dijk+nx-1;adis=dis+bx;
-		}
-		img[odijk]|=2;
-		for(l=0;l<co[fijk];l++) {
-			if(p[fijk][ps*l]>switchx) put_image(dijk,fijk,l,dis,by*ima,0);
-			else put_image(odijk,fijk,l,adis,by*ima,0);
-		}
-	}
+    // Left image computation
+    if((img[dijk]&1)==0) {
+        if(di>0) {
+            odijk=dijk-1;adis=dis;
+        } else {
+            odijk=dijk+nx-1;adis=dis+bx;
+        }
+        img[odijk]|=2;
+        for(l=0;l<co[fijk];l++) {
+            if(p[fijk][ps*l]>switchx) put_image(dijk,fijk,l,dis,by*ima,0);
+            else put_image(odijk,fijk,l,adis,by*ima,0);
+        }
+    }
 
-	// Right image computation
-	if((img[dijk]&2)==0) {
-		if(fi==nx-1) {
-			fijk+=1-nx;switchx+=(1-nx)*boxx;dis+=bx;
-		} else {
-			fijk++;switchx+=boxx;
-		}
-		if(di==nx-1) {
-			odijk=dijk-nx+1;adis=dis-bx;
-		} else {
-			odijk=dijk+1;adis=dis;
-		}
-		img[odijk]|=1;
-		for(l=0;l<co[fijk];l++) {
-			if(p[fijk][ps*l]<switchx) put_image(dijk,fijk,l,dis,by*ima,0);
-			else put_image(odijk,fijk,l,adis,by*ima,0);
-		}
-	}
+    // Right image computation
+    if((img[dijk]&2)==0) {
+        if(fi==nx-1) {
+            fijk+=1-nx;switchx+=(1-nx)*boxx;dis+=bx;
+        } else {
+            fijk++;switchx+=boxx;
+        }
+        if(di==nx-1) {
+            odijk=dijk-nx+1;adis=dis-bx;
+        } else {
+            odijk=dijk+1;adis=dis;
+        }
+        img[odijk]|=1;
+        for(l=0;l<co[fijk];l++) {
+            if(p[fijk][ps*l]<switchx) put_image(dijk,fijk,l,dis,by*ima,0);
+            else put_image(odijk,fijk,l,adis,by*ima,0);
+        }
+    }
 
-	// All contributions to the block now added, so set both two bits of
-	// the image information
-	img[dijk]=3;
+    // All contributions to the block now added, so set both two bits of
+    // the image information
+    img[dijk]=3;
 }
 
 /** Creates particles within an image block that is not aligned with the
@@ -631,128 +595,128 @@ void container_periodic_base::create_side_image(int di,int dj,int dk) {
  * \param[in] (di,dj,dk) the index of the block to consider. The z index must
  *			 satisfy dk<ez or dk>=wz. */
 void container_periodic_base::create_vertical_image(int di,int dj,int dk) {
-	int l,dijk=di+nx*(dj+oy*dk),dijkl,dijkr,ima=step_div(dk-ez,nz);
-	int qj=dj+step_int(-ima*byz*ysp),qjdiv=step_div(qj-ey,ny);
-	int qi=di+step_int((-ima*bxz-qjdiv*bxy)*xsp),qidiv=step_div(qi,nx);
-	int fi=qi-qidiv*nx,fj=qj-qjdiv*ny,fijk=fi+nx*(fj+oy*(dk-ima*nz)),fijk2;
-	double disy=ima*byz+qjdiv*by,switchy=(dj-ey)*boxy-ima*byz-qjdiv*by;
-	double disx=ima*bxz+qjdiv*bxy+qidiv*bx,switchx=di*boxx-ima*bxz-qjdiv*bxy-qidiv*bx;
-	double switchx2,disxl,disxr,disx2,disxr2;
+    int l,dijk=di+nx*(dj+oy*dk),dijkl,dijkr,ima=step_div(dk-ez,nz);
+    int qj=dj+step_int(-ima*byz*ysp),qjdiv=step_div(qj-ey,ny);
+    int qi=di+step_int((-ima*bxz-qjdiv*bxy)*xsp),qidiv=step_div(qi,nx);
+    int fi=qi-qidiv*nx,fj=qj-qjdiv*ny,fijk=fi+nx*(fj+oy*(dk-ima*nz)),fijk2;
+    double disy=ima*byz+qjdiv*by,switchy=(dj-ey)*boxy-ima*byz-qjdiv*by;
+    double disx=ima*bxz+qjdiv*bxy+qidiv*bx,switchx=di*boxx-ima*bxz-qjdiv*bxy-qidiv*bx;
+    double switchx2,disxl,disxr,disx2,disxr2;
 
-	if(di==0) {dijkl=dijk+nx-1;disxl=disx+bx;}
-	else {dijkl=dijk-1;disxl=disx;}
+    if(di==0) {dijkl=dijk+nx-1;disxl=disx+bx;}
+    else {dijkl=dijk-1;disxl=disx;}
 
-	if(di==nx-1) {dijkr=dijk-nx+1;disxr=disx-bx;}
-	else {dijkr=dijk+1;disxr=disx;}
+    if(di==nx-1) {dijkr=dijk-nx+1;disxr=disx-bx;}
+    else {dijkr=dijk+1;disxr=disx;}
 
-	// Down-left image computation
-	bool y_exist=dj!=0;
-	if((img[dijk]&1)==0) {
-		img[dijkl]|=2;
-		if(y_exist) {
-			img[dijkl-nx]|=8;
-			img[dijk-nx]|=4;
-		}
-		for(l=0;l<co[fijk];l++) {
-			if(p[fijk][ps*l+1]>switchy) {
-				if(p[fijk][ps*l]>switchx) put_image(dijk,fijk,l,disx,disy,bz*ima);
-				else put_image(dijkl,fijk,l,disxl,disy,bz*ima);
-			} else {
-				if(!y_exist) continue;
-				if(p[fijk][ps*l]>switchx) put_image(dijk-nx,fijk,l,disx,disy,bz*ima);
-				else put_image(dijkl-nx,fijk,l,disxl,disy,bz*ima);
-			}
-		}
-	}
+    // Down-left image computation
+    bool y_exist=dj!=0;
+    if((img[dijk]&1)==0) {
+        img[dijkl]|=2;
+        if(y_exist) {
+            img[dijkl-nx]|=8;
+            img[dijk-nx]|=4;
+        }
+        for(l=0;l<co[fijk];l++) {
+            if(p[fijk][ps*l+1]>switchy) {
+                if(p[fijk][ps*l]>switchx) put_image(dijk,fijk,l,disx,disy,bz*ima);
+                else put_image(dijkl,fijk,l,disxl,disy,bz*ima);
+            } else {
+                if(!y_exist) continue;
+                if(p[fijk][ps*l]>switchx) put_image(dijk-nx,fijk,l,disx,disy,bz*ima);
+                else put_image(dijkl-nx,fijk,l,disxl,disy,bz*ima);
+            }
+        }
+    }
 
-	// Down-right image computation
-	if((img[dijk]&2)==0) {
-		if(fi==nx-1) {
-			fijk2=fijk+1-nx;switchx2=switchx+(1-nx)*boxx;disx2=disx+bx;disxr2=disxr+bx;
-		} else {
-			fijk2=fijk+1;switchx2=switchx+boxx;disx2=disx;disxr2=disxr;
-		}
-		img[dijkr]|=1;
-		if(y_exist) {
-			img[dijkr-nx]|=4;
-			img[dijk-nx]|=8;
-		}
-		for(l=0;l<co[fijk2];l++) {
-			if(p[fijk2][ps*l+1]>switchy) {
-				if(p[fijk2][ps*l]>switchx2) put_image(dijkr,fijk2,l,disxr2,disy,bz*ima);
-				else put_image(dijk,fijk2,l,disx2,disy,bz*ima);
-			} else {
-				if(!y_exist) continue;
-				if(p[fijk2][ps*l]>switchx2) put_image(dijkr-nx,fijk2,l,disxr2,disy,bz*ima);
-				else put_image(dijk-nx,fijk2,l,disx2,disy,bz*ima);
-			}
-		}
-	}
+    // Down-right image computation
+    if((img[dijk]&2)==0) {
+        if(fi==nx-1) {
+            fijk2=fijk+1-nx;switchx2=switchx+(1-nx)*boxx;disx2=disx+bx;disxr2=disxr+bx;
+        } else {
+            fijk2=fijk+1;switchx2=switchx+boxx;disx2=disx;disxr2=disxr;
+        }
+        img[dijkr]|=1;
+        if(y_exist) {
+            img[dijkr-nx]|=4;
+            img[dijk-nx]|=8;
+        }
+        for(l=0;l<co[fijk2];l++) {
+            if(p[fijk2][ps*l+1]>switchy) {
+                if(p[fijk2][ps*l]>switchx2) put_image(dijkr,fijk2,l,disxr2,disy,bz*ima);
+                else put_image(dijk,fijk2,l,disx2,disy,bz*ima);
+            } else {
+                if(!y_exist) continue;
+                if(p[fijk2][ps*l]>switchx2) put_image(dijkr-nx,fijk2,l,disxr2,disy,bz*ima);
+                else put_image(dijk-nx,fijk2,l,disx2,disy,bz*ima);
+            }
+        }
+    }
 
-	// Recomputation of some intermediate quantities for boundary cases
-	if(fj==wy-1) {
-		fijk+=nx*(1-ny)-fi;
-		switchy+=(1-ny)*boxy;
-		disy+=by;
-		qi=di+step_int(-(ima*bxz+(qjdiv+1)*bxy)*xsp);
-		int dqidiv=step_div(qi,nx)-qidiv;qidiv+=dqidiv;
-		fi=qi-qidiv*nx;
-		fijk+=fi;
-		disx+=bxy+bx*dqidiv;
-		disxl+=bxy+bx*dqidiv;
-		disxr+=bxy+bx*dqidiv;
-		switchx-=bxy+bx*dqidiv;
-	} else {
-		fijk+=nx;switchy+=boxy;
-	}
+    // Recomputation of some intermediate quantities for boundary cases
+    if(fj==wy-1) {
+        fijk+=nx*(1-ny)-fi;
+        switchy+=(1-ny)*boxy;
+        disy+=by;
+        qi=di+step_int(-(ima*bxz+(qjdiv+1)*bxy)*xsp);
+        int dqidiv=step_div(qi,nx)-qidiv;qidiv+=dqidiv;
+        fi=qi-qidiv*nx;
+        fijk+=fi;
+        disx+=bxy+bx*dqidiv;
+        disxl+=bxy+bx*dqidiv;
+        disxr+=bxy+bx*dqidiv;
+        switchx-=bxy+bx*dqidiv;
+    } else {
+        fijk+=nx;switchy+=boxy;
+    }
 
-	// Up-left image computation
-	y_exist=dj!=oy-1;
-	if((img[dijk]&4)==0) {
-		img[dijkl]|=8;
-		if(y_exist) {
-			img[dijkl+nx]|=2;
-			img[dijk+nx]|=1;
-		}
-		for(l=0;l<co[fijk];l++) {
-			if(p[fijk][ps*l+1]>switchy) {
-				if(!y_exist) continue;
-				if(p[fijk][ps*l]>switchx) put_image(dijk+nx,fijk,l,disx,disy,bz*ima);
-				else put_image(dijkl+nx,fijk,l,disxl,disy,bz*ima);
-			} else {
-				if(p[fijk][ps*l]>switchx) put_image(dijk,fijk,l,disx,disy,bz*ima);
-				else put_image(dijkl,fijk,l,disxl,disy,bz*ima);
-			}
-		}
-	}
+    // Up-left image computation
+    y_exist=dj!=oy-1;
+    if((img[dijk]&4)==0) {
+        img[dijkl]|=8;
+        if(y_exist) {
+            img[dijkl+nx]|=2;
+            img[dijk+nx]|=1;
+        }
+        for(l=0;l<co[fijk];l++) {
+            if(p[fijk][ps*l+1]>switchy) {
+                if(!y_exist) continue;
+                if(p[fijk][ps*l]>switchx) put_image(dijk+nx,fijk,l,disx,disy,bz*ima);
+                else put_image(dijkl+nx,fijk,l,disxl,disy,bz*ima);
+            } else {
+                if(p[fijk][ps*l]>switchx) put_image(dijk,fijk,l,disx,disy,bz*ima);
+                else put_image(dijkl,fijk,l,disxl,disy,bz*ima);
+            }
+        }
+    }
 
-	// Up-right image computation
-	if((img[dijk]&8)==0) {
-		if(fi==nx-1) {
-			fijk2=fijk+1-nx;switchx2=switchx+(1-nx)*boxx;disx2=disx+bx;disxr2=disxr+bx;
-		} else {
-			fijk2=fijk+1;switchx2=switchx+boxx;disx2=disx;disxr2=disxr;
-		}
-		img[dijkr]|=4;
-		if(y_exist) {
-			img[dijkr+nx]|=1;
-			img[dijk+nx]|=2;
-		}
-		for(l=0;l<co[fijk2];l++) {
-			if(p[fijk2][ps*l+1]>switchy) {
-				if(!y_exist) continue;
-				if(p[fijk2][ps*l]>switchx2) put_image(dijkr+nx,fijk2,l,disxr2,disy,bz*ima);
-				else put_image(dijk+nx,fijk2,l,disx2,disy,bz*ima);
-			} else {
-				if(p[fijk2][ps*l]>switchx2) put_image(dijkr,fijk2,l,disxr2,disy,bz*ima);
-				else put_image(dijk,fijk2,l,disx2,disy,bz*ima);
-			}
-		}
-	}
+    // Up-right image computation
+    if((img[dijk]&8)==0) {
+        if(fi==nx-1) {
+            fijk2=fijk+1-nx;switchx2=switchx+(1-nx)*boxx;disx2=disx+bx;disxr2=disxr+bx;
+        } else {
+            fijk2=fijk+1;switchx2=switchx+boxx;disx2=disx;disxr2=disxr;
+        }
+        img[dijkr]|=4;
+        if(y_exist) {
+            img[dijkr+nx]|=1;
+            img[dijk+nx]|=2;
+        }
+        for(l=0;l<co[fijk2];l++) {
+            if(p[fijk2][ps*l+1]>switchy) {
+                if(!y_exist) continue;
+                if(p[fijk2][ps*l]>switchx2) put_image(dijkr+nx,fijk2,l,disxr2,disy,bz*ima);
+                else put_image(dijk+nx,fijk2,l,disx2,disy,bz*ima);
+            } else {
+                if(p[fijk2][ps*l]>switchx2) put_image(dijkr,fijk2,l,disxr2,disy,bz*ima);
+                else put_image(dijk,fijk2,l,disx2,disy,bz*ima);
+            }
+        }
+    }
 
-	// All contributions to the block now added, so set all four bits of
-	// the image information
-	img[dijk]=15;
+    // All contributions to the block now added, so set all four bits of
+    // the image information
+    img[dijk]=15;
 }
 
 /** Copies a particle position from the primary domain into an image block.
@@ -762,13 +726,13 @@ void container_periodic_base::create_vertical_image(int di,int dj,int dk) {
  * \param[in] l the index of the particle entry within the primary block.
  * \param[in] (dx,dy,dz) the displacement vector to add to the particle. */
 void container_periodic_base::put_image(int reg,int fijk,int l,double dx,double dy,double dz) {
-	if(co[reg]==mem[reg]) add_particle_memory(reg);
-	double *p1=p[reg]+ps*co[reg],*p2=p[fijk]+ps*l;
-	*(p1++)=*(p2++)+dx;
-	*(p1++)=*(p2++)+dy;
-	*p1=*p2+dz;
-	if(ps==4) *(++p1)=*(++p2);
-	id[reg][co[reg]++]=id[fijk][l];
+    if(co[reg]==mem[reg]) add_particle_memory(reg);
+    double *p1=p[reg]+ps*co[reg],*p2=p[fijk]+ps*l;
+    *(p1++)=*(p2++)+dx;
+    *(p1++)=*(p2++)+dy;
+    *p1=*p2+dz;
+    if(ps==4) *(++p1)=*(++p2);
+    id[reg][co[reg]++]=id[fijk][l];
 }
 
 }

--- a/SKIRT/voro/container_prd.cc
+++ b/SKIRT/voro/container_prd.cc
@@ -392,64 +392,6 @@ void container_periodic_base::add_particle_memory(int i) {
     delete [] p[i];p[i]=pp;
 }
 
-/** Import a list of particles from an open file stream into the container.
- * Entries of four numbers (Particle ID, x position, y position, z position)
- * are searched for. If the file cannot be successfully read, then the routine
- * causes a fatal error.
- * \param[in] fp the file handle to read from. */
-void container_periodic::import(FILE *fp) {
-    int i,j;
-    double x,y,z;
-    while((j=fscanf(fp,"%d %lg %lg %lg",&i,&x,&y,&z))==4) put(i,x,y,z);
-    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
-}
-
-/** Import a list of particles from an open file stream, also storing the order
- * of that the particles are read. Entries of four numbers (Particle ID, x
- * position, y position, z position) are searched for. If the file cannot be
- * successfully read, then the routine causes a fatal error.
- * \param[in,out] vo a reference to an ordering class to use.
- * \param[in] fp the file handle to read from. */
-void container_periodic::import(particle_order &vo,FILE *fp) {
-    int i,j;
-    double x,y,z;
-    while((j=fscanf(fp,"%d %lg %lg %lg",&i,&x,&y,&z))==4) put(vo,i,x,y,z);
-    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
-}
-
-/** Import a list of particles from an open file stream into the container.
- * Entries of five numbers (Particle ID, x position, y position, z position,
- * radius) are searched for. If the file cannot be successfully read, then the
- * routine causes a fatal error.
- * \param[in] fp the file handle to read from. */
-void container_periodic_poly::import(FILE *fp) {
-    int i,j;
-    double x,y,z,r;
-    while((j=fscanf(fp,"%d %lg %lg %lg %lg",&i,&x,&y,&z,&r))==5) put(i,x,y,z,r);
-    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
-}
-
-/** Import a list of particles from an open file stream, also storing the order
- * of that the particles are read. Entries of four numbers (Particle ID, x
- * position, y position, z position, radius) are searched for. If the file
- * cannot be successfully read, then the routine causes a fatal error.
- * \param[in,out] vo a reference to an ordering class to use.
- * \param[in] fp the file handle to read from. */
-void container_periodic_poly::import(particle_order &vo,FILE *fp) {
-    int i,j;
-    double x,y,z,r;
-    while((j=fscanf(fp,"%d %lg %lg %lg %lg",&i,&x,&y,&z,&r))==5) put(vo,i,x,y,z,r);
-    if(j!=EOF) voro_fatal_error("File import error",VOROPP_FILE_ERROR);
-}
-
-/** Outputs the a list of all the container regions along with the number of
- * particles stored within each. */
-void container_periodic_base::region_count() {
-    int i,j,k,*cop=co;
-    for(k=0;k<nz;k++) for(j=0;j<ny;j++) for(i=0;i<nx;i++)
-        printf("Region (%d,%d,%d): %d particles\n",i,j,k,*(cop++));
-}
-
 /** Clears a container of particles. */
 void container_periodic::clear() {
     for(int *cop=co;cop<co+nxyz;cop++) *cop=0;
@@ -513,26 +455,6 @@ double container_periodic_poly::sum_cell_volumes() {
 void container_periodic_base::create_all_images() {
     int i,j,k;
     for(k=0;k<oz;k++) for(j=0;j<oy;j++) for(i=0;i<nx;i++) create_periodic_image(i,j,k);
-}
-
-/** Checks that the particles within each block lie within that block's bounds.
- * This is useful for diagnosing problems with periodic image computation. */
-void container_periodic_base::check_compartmentalized() {
-    int c,l,i,j,k;
-    double mix,miy,miz,max,may,maz,*pp;
-    for(k=l=0;k<oz;k++) for(j=0;j<oy;j++) for(i=0;i<nx;i++,l++) if(mem[l]>0) {
-
-        // Compute the block's bounds, adding in a small tolerance
-        mix=i*boxx-tolerance;max=mix+boxx+tolerance;
-        miy=(j-ey)*boxy-tolerance;may=miy+boxy+tolerance;
-        miz=(k-ez)*boxz-tolerance;maz=miz+boxz+tolerance;
-
-        // Print entries for any particles that lie outside the block's
-        // bounds
-        for(pp=p[l],c=0;c<co[l];c++,pp+=ps) if(*pp<mix||*pp>max||pp[1]<miy||pp[1]>may||pp[2]<miz||pp[2]>maz)
-            printf("%d %d %d %d %f %f %f %f %f %f %f %f %f\n",
-                   id[l][c],i,j,k,*pp,pp[1],pp[2],mix,max,miy,may,miz,maz);
-    }
 }
 
 /** Creates particles within an image block that is aligned with the primary

--- a/SKIRT/voro/container_prd.hh
+++ b/SKIRT/voro/container_prd.hh
@@ -95,7 +95,6 @@ class container_periodic_base : public unitcell, public voro_base {
         container_periodic_base(double bx_,double bxy_,double by_,double bxz_,double byz_,double bz_,
                 int nx_,int ny_,int nz_,int init_mem_,int ps);
         ~container_periodic_base();
-        void region_count();
         /** Initializes the Voronoi cell prior to a compute_cell
          * operation for a specific particle being carried out by a
          * voro_compute class. The cell is initialized to be the
@@ -169,7 +168,6 @@ class container_periodic_base : public unitcell, public voro_base {
             return qi+nx*(qj+oy*qk);
         }
         void create_all_images();
-        void check_compartmentalized();
     protected:
         void add_particle_memory(int i);
         void put_locate_block(int &ijk,double &x,double &y,double &z);
@@ -211,34 +209,6 @@ class container_periodic : public container_periodic_base, public radius_mono {
         void put(int n,double x,double y,double z);
         void put(int n,double x,double y,double z,int &ai,int &aj,int &ak);
         void put(particle_order &vo,int n,double x,double y,double z);
-        void import(FILE *fp=stdin);
-        void import(particle_order &vo,FILE *fp=stdin);
-        /** Imports a list of particles from an open file stream into
-         * the container. Entries of four numbers (Particle ID, x
-         * position, y position, z position) are searched for. If the
-         * file cannot be successfully read, then the routine causes a
-         * fatal error.
-         * \param[in] filename the name of the file to open and read
-         *                     from. */
-        inline void import(const char* filename) {
-            FILE *fp=safe_fopen(filename,"r");
-            import(fp);
-            fclose(fp);
-        }
-        /** Imports a list of particles from an open file stream into
-         * the container. Entries of four numbers (Particle ID, x
-         * position, y position, z position) are searched for. In
-         * addition, the order in which particles are read is saved
-         * into an ordering class. If the file cannot be successfully
-         * read, then the routine causes a fatal error.
-         * \param[in,out] vo the ordering class to use.
-         * \param[in] filename the name of the file to open and read
-         *                     from. */
-        inline void import(particle_order &vo,const char* filename) {
-            FILE *fp=safe_fopen(filename,"r");
-            import(vo,fp);
-            fclose(fp);
-        }
         void compute_all_cells();
         double sum_cell_volumes();
         bool find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid);
@@ -304,34 +274,6 @@ class container_periodic_poly : public container_periodic_base, public radius_po
         void put(int n,double x,double y,double z,double r);
         void put(int n,double x,double y,double z,double r,int &ai,int &aj,int &ak);
         void put(particle_order &vo,int n,double x,double y,double z,double r);
-        void import(FILE *fp=stdin);
-        void import(particle_order &vo,FILE *fp=stdin);
-        /** Imports a list of particles from an open file stream into
-         * the container_poly class. Entries of five numbers (Particle
-         * ID, x position, y position, z position, radius) are searched
-         * for. If the file cannot be successfully read, then the
-         * routine causes a fatal error.
-         * \param[in] filename the name of the file to open and read
-         *                     from. */
-        inline void import(const char* filename) {
-            FILE *fp=safe_fopen(filename,"r");
-            import(fp);
-            fclose(fp);
-        }
-        /** Imports a list of particles from an open file stream into
-         * the container_poly class. Entries of five numbers (Particle
-         * ID, x position, y position, z position, radius) are searched
-         * for. In addition, the order in which particles are read is
-         * saved into an ordering class. If the file cannot be
-         * successfully read, then the routine causes a fatal error.
-         * \param[in,out] vo the ordering class to use.
-         * \param[in] filename the name of the file to open and read
-         *                     from. */
-        inline void import(particle_order &vo,const char* filename) {
-            FILE *fp=safe_fopen(filename,"r");
-            import(vo,fp);
-            fclose(fp);
-        }
         void compute_all_cells();
         double sum_cell_volumes();
 

--- a/SKIRT/voro/container_prd.hh
+++ b/SKIRT/voro/container_prd.hh
@@ -41,167 +41,160 @@ namespace voro {
  * about the domain geometry, and the voro_base class, which encapsulates
  * information about the underlying computational grid. */
 class container_periodic_base : public unitcell, public voro_base {
-	public:
-		const double max_len_sq;
-		/** The lower y index (inclusive) of the primary domain within
-		 * the block structure. */
-		int ey;
-		/** The lower z index (inclusive) of the primary domain within
-		 * the block structure. */
-		int ez;
-		/** The upper y index (exclusive) of the primary domain within
-		 * the block structure. */
-		int wy;
-		/** The upper z index (exclusive) of the primary domain within
-		 * the block structure. */
-		int wz;
-		/** The total size of the block structure (including images) in
-		 * the y direction. */
-		int oy;
-		/** The total size of the block structure (including images) in
-		 * the z direction. */
-		int oz;
-		/** The total number of blocks. */
-		int oxyz;
-		/** This array holds the numerical IDs of each particle in each
-		 * computational box. */
-		int **id;
-		/** A two dimensional array holding particle positions. For the
-		 * derived container_poly class, this also holds particle
-		 * radii. */
-		double **p;
-		/** This array holds the number of particles within each
-		 * computational box of the container. */
-		int *co;
-		/** This array holds the maximum amount of particle memory for
-		 * each computational box of the container. If the number of
-		 * particles in a particular box ever approaches this limit,
-		 * more is allocated using the add_particle_memory() function.
-		 */
-		int *mem;
-		/** An array holding information about periodic image
-		 * construction at a given location. */
-		char *img;
-		/** The initial amount of memory to allocate for particles
-		 * for each block. */
-		const int init_mem;
-		/** The amount of memory in the array structure for each
-		 * particle. This is set to 3 when the basic class is
-		 * initialized, so that the array holds (x,y,z) positions. If
-		 * the container class is initialized as part of the derived
-		 * class container_poly, then this is set to 4, to also hold
-		 * the particle radii. */
-		const int ps;
-		container_periodic_base(double bx_,double bxy_,double by_,double bxz_,double byz_,double bz_,
-				int nx_,int ny_,int nz_,int init_mem_,int ps);
-		~container_periodic_base();
-		/** Prints all particles in the container, including those that
-		 * have been constructed in image blocks. */
-		inline void print_all_particles() {
-			int ijk,q;
-			for(ijk=0;ijk<oxyz;ijk++) for(q=0;q<co[ijk];q++)
-				printf("%d %g %g %g\n",id[ijk][q],p[ijk][ps*q],p[ijk][ps*q+1],p[ijk][ps*q+2]);
-		}
-		void region_count();
-		/** Initializes the Voronoi cell prior to a compute_cell
-		 * operation for a specific particle being carried out by a
-		 * voro_compute class. The cell is initialized to be the
-		 * pre-computed unit Voronoi cell based on planes formed by
-		 * periodic images of the particle.
-		 * \param[in,out] c a reference to a voronoicell object.
-		 * \param[in] ijk the block that the particle is within.
-		 * \param[in] q the index of the particle within its block.
-		 * \param[in] (ci,cj,ck) the coordinates of the block in the
-		 * 			 container coordinate system.
-		 * \param[out] (i,j,k) the coordinates of the test block
-		 * 		       relative to the voro_compute
-		 * 		       coordinate system.
-		 * \param[out] (x,y,z) the position of the particle.
-		 * \param[out] disp a block displacement used internally by the
-		 *		    compute_cell routine.
-		 * \return False if the plane cuts applied by walls completely
-		 * removed the cell, true otherwise. */
-		template<class v_cell>
-		inline bool initialize_voronoicell(v_cell &c,int ijk,int q,int ci,int cj,int ck,int &i,int &j,int &k,double &x,double &y,double &z,int &disp) {
-			c=unit_voro;
-			double *pp=p[ijk]+ps*q;
-			x=*(pp++);y=*(pp++);z=*pp;
-			i=nx;j=ey;k=ez;
-			return true;
-		}
-		/** Initializes parameters for a find_voronoi_cell call within
-		 * the voro_compute template.
-		 * \param[in] (ci,cj,ck) the coordinates of the test block in
-		 * 			 the container coordinate system.
-		 * \param[in] ijk the index of the test block
-		 * \param[out] (i,j,k) the coordinates of the test block
-		 * 		       relative to the voro_compute
-		 * 		       coordinate system.
-		 * \param[out] disp a block displacement used internally by the
-		 *		    find_voronoi_cell routine (but not needed
-		 *		    in this instance.) */
-		inline void initialize_search(int ci,int cj,int ck,int ijk,int &i,int &j,int &k,int &disp) {
-			i=nx;j=ey;k=ez;
-		}
-		/** Returns the position of a particle currently being computed
-		 * relative to the computational block that it is within. It is
-		 * used to select the optimal worklist entry to use.
-		 * \param[in] (x,y,z) the position of the particle.
-		 * \param[in] (ci,cj,ck) the block that the particle is within.
-		 * \param[out] (fx,fy,fz) the position relative to the block.
-		 */
-		inline void frac_pos(double x,double y,double z,double ci,double cj,double ck,double &fx,double &fy,double &fz) {
-			fx=x-boxx*ci;
-			fy=y-boxy*(cj-ey);
-			fz=z-boxz*(ck-ez);
-		}
-		/** Calculates the index of block in the container structure
-		 * corresponding to given coordinates.
-		 * \param[in] (ci,cj,ck) the coordinates of the original block
-		 * 			 in the current computation, relative
-		 * 			 to the container coordinate system.
-		 * \param[in] (ei,ej,ek) the displacement of the current block
-		 * 			 from the original block.
-		 * \param[in,out] (qx,qy,qz) the periodic displacement that
-		 * 			     must be added to the particles
-		 * 			     within the computed block.
-		 * \param[in] disp a block displacement used internally by the
-		 * 		    find_voronoi_cell and compute_cell routines
-		 * 		    (but not needed in this instance.)
-		 * \return The block index. */
-		inline int region_index(int ci,int cj,int ck,int ei,int ej,int ek,double &qx,double &qy,double &qz,int &disp) {
-			int qi=ci+(ei-nx),qj=cj+(ej-ey),qk=ck+(ek-ez);
-			int iv(step_div(qi,nx));if(iv!=0) {qx=iv*bx;qi-=nx*iv;} else qx=0;
-			create_periodic_image(qi,qj,qk);
-			return qi+nx*(qj+oy*qk);
-		}
-		void create_all_images();
-		void check_compartmentalized();
-	protected:
-		void add_particle_memory(int i);
-		void put_locate_block(int &ijk,double &x,double &y,double &z);
-		void put_locate_block(int &ijk,double &x,double &y,double &z,int &ai,int &aj,int &ak);
-		/** Creates particles within an image block by copying them
-		 * from the primary domain and shifting them. If the given
-		 * block is aligned with the primary domain in the z-direction,
-		 * the routine calls the simpler create_side_image routine
-		 * where the image block may comprise of particles from up to
-		 * two primary blocks. Otherwise is calls the more complex
-		 * create_vertical_image where the image block may comprise of
-		 * particles from up to four primary blocks.
-		 * \param[in] (di,dj,dk) the coordinates of the image block to
-		 *                       create. */
-		inline void create_periodic_image(int di,int dj,int dk) {
-			if(di<0||di>=nx||dj<0||dj>=oy||dk<0||dk>=oz)
-				voro_fatal_error("Constructing periodic image for nonexistent point",VOROPP_INTERNAL_ERROR);
-			if(dk>=ez&&dk<wz) {
-				if(dj<ey||dj>=wy) create_side_image(di,dj,dk);
-			} else create_vertical_image(di,dj,dk);
-		}
-		void create_side_image(int di,int dj,int dk);
-		void create_vertical_image(int di,int dj,int dk);
-		void put_image(int reg,int fijk,int l,double dx,double dy,double dz);
-		inline void remap(int &ai,int &aj,int &ak,int &ci,int &cj,int &ck,double &x,double &y,double &z,int &ijk);
+    public:
+        const double max_len_sq;
+        /** The lower y index (inclusive) of the primary domain within
+         * the block structure. */
+        int ey;
+        /** The lower z index (inclusive) of the primary domain within
+         * the block structure. */
+        int ez;
+        /** The upper y index (exclusive) of the primary domain within
+         * the block structure. */
+        int wy;
+        /** The upper z index (exclusive) of the primary domain within
+         * the block structure. */
+        int wz;
+        /** The total size of the block structure (including images) in
+         * the y direction. */
+        int oy;
+        /** The total size of the block structure (including images) in
+         * the z direction. */
+        int oz;
+        /** The total number of blocks. */
+        int oxyz;
+        /** This array holds the numerical IDs of each particle in each
+         * computational box. */
+        int **id;
+        /** A two dimensional array holding particle positions. For the
+         * derived container_poly class, this also holds particle
+         * radii. */
+        double **p;
+        /** This array holds the number of particles within each
+         * computational box of the container. */
+        int *co;
+        /** This array holds the maximum amount of particle memory for
+         * each computational box of the container. If the number of
+         * particles in a particular box ever approaches this limit,
+         * more is allocated using the add_particle_memory() function.
+         */
+        int *mem;
+        /** An array holding information about periodic image
+         * construction at a given location. */
+        char *img;
+        /** The initial amount of memory to allocate for particles
+         * for each block. */
+        const int init_mem;
+        /** The amount of memory in the array structure for each
+         * particle. This is set to 3 when the basic class is
+         * initialized, so that the array holds (x,y,z) positions. If
+         * the container class is initialized as part of the derived
+         * class container_poly, then this is set to 4, to also hold
+         * the particle radii. */
+        const int ps;
+        container_periodic_base(double bx_,double bxy_,double by_,double bxz_,double byz_,double bz_,
+                int nx_,int ny_,int nz_,int init_mem_,int ps);
+        ~container_periodic_base();
+        void region_count();
+        /** Initializes the Voronoi cell prior to a compute_cell
+         * operation for a specific particle being carried out by a
+         * voro_compute class. The cell is initialized to be the
+         * pre-computed unit Voronoi cell based on planes formed by
+         * periodic images of the particle.
+         * \param[in,out] c a reference to a voronoicell object.
+         * \param[in] ijk the block that the particle is within.
+         * \param[in] q the index of the particle within its block.
+         * \param[in] (ci,cj,ck) the coordinates of the block in the
+         * 			 container coordinate system.
+         * \param[out] (i,j,k) the coordinates of the test block
+         * 		       relative to the voro_compute
+         * 		       coordinate system.
+         * \param[out] (x,y,z) the position of the particle.
+         * \param[out] disp a block displacement used internally by the
+         *		    compute_cell routine.
+         * \return False if the plane cuts applied by walls completely
+         * removed the cell, true otherwise. */
+        template<class v_cell>
+        inline bool initialize_voronoicell(v_cell &c,int ijk,int q,int ci,int cj,int ck,int &i,int &j,int &k,double &x,double &y,double &z,int &disp) {
+            c=unit_voro;
+            double *pp=p[ijk]+ps*q;
+            x=*(pp++);y=*(pp++);z=*pp;
+            i=nx;j=ey;k=ez;
+            return true;
+        }
+        /** Initializes parameters for a find_voronoi_cell call within
+         * the voro_compute template.
+         * \param[in] (ci,cj,ck) the coordinates of the test block in
+         * 			 the container coordinate system.
+         * \param[in] ijk the index of the test block
+         * \param[out] (i,j,k) the coordinates of the test block
+         * 		       relative to the voro_compute
+         * 		       coordinate system.
+         * \param[out] disp a block displacement used internally by the
+         *		    find_voronoi_cell routine (but not needed
+         *		    in this instance.) */
+        inline void initialize_search(int ci,int cj,int ck,int ijk,int &i,int &j,int &k,int &disp) {
+            i=nx;j=ey;k=ez;
+        }
+        /** Returns the position of a particle currently being computed
+         * relative to the computational block that it is within. It is
+         * used to select the optimal worklist entry to use.
+         * \param[in] (x,y,z) the position of the particle.
+         * \param[in] (ci,cj,ck) the block that the particle is within.
+         * \param[out] (fx,fy,fz) the position relative to the block.
+         */
+        inline void frac_pos(double x,double y,double z,double ci,double cj,double ck,double &fx,double &fy,double &fz) {
+            fx=x-boxx*ci;
+            fy=y-boxy*(cj-ey);
+            fz=z-boxz*(ck-ez);
+        }
+        /** Calculates the index of block in the container structure
+         * corresponding to given coordinates.
+         * \param[in] (ci,cj,ck) the coordinates of the original block
+         * 			 in the current computation, relative
+         * 			 to the container coordinate system.
+         * \param[in] (ei,ej,ek) the displacement of the current block
+         * 			 from the original block.
+         * \param[in,out] (qx,qy,qz) the periodic displacement that
+         * 			     must be added to the particles
+         * 			     within the computed block.
+         * \param[in] disp a block displacement used internally by the
+         * 		    find_voronoi_cell and compute_cell routines
+         * 		    (but not needed in this instance.)
+         * \return The block index. */
+        inline int region_index(int ci,int cj,int ck,int ei,int ej,int ek,double &qx,double &qy,double &qz,int &disp) {
+            int qi=ci+(ei-nx),qj=cj+(ej-ey),qk=ck+(ek-ez);
+            int iv(step_div(qi,nx));if(iv!=0) {qx=iv*bx;qi-=nx*iv;} else qx=0;
+            create_periodic_image(qi,qj,qk);
+            return qi+nx*(qj+oy*qk);
+        }
+        void create_all_images();
+        void check_compartmentalized();
+    protected:
+        void add_particle_memory(int i);
+        void put_locate_block(int &ijk,double &x,double &y,double &z);
+        void put_locate_block(int &ijk,double &x,double &y,double &z,int &ai,int &aj,int &ak);
+        /** Creates particles within an image block by copying them
+         * from the primary domain and shifting them. If the given
+         * block is aligned with the primary domain in the z-direction,
+         * the routine calls the simpler create_side_image routine
+         * where the image block may comprise of particles from up to
+         * two primary blocks. Otherwise is calls the more complex
+         * create_vertical_image where the image block may comprise of
+         * particles from up to four primary blocks.
+         * \param[in] (di,dj,dk) the coordinates of the image block to
+         *                       create. */
+        inline void create_periodic_image(int di,int dj,int dk) {
+            if(di<0||di>=nx||dj<0||dj>=oy||dk<0||dk>=oz)
+                voro_fatal_error("Constructing periodic image for nonexistent point",VOROPP_INTERNAL_ERROR);
+            if(dk>=ez&&dk<wz) {
+                if(dj<ey||dj>=wy) create_side_image(di,dj,dk);
+            } else create_vertical_image(di,dj,dk);
+        }
+        void create_side_image(int di,int dj,int dk);
+        void create_vertical_image(int di,int dj,int dk);
+        void put_image(int reg,int fijk,int l,double dx,double dy,double dz);
+        inline void remap(int &ai,int &aj,int &ak,int &ci,int &cj,int &ck,double &x,double &y,double &z,int &ijk);
 };
 
 /** \brief Extension of the container_periodic_base class for computing regular
@@ -211,218 +204,90 @@ class container_periodic_base : public unitcell, public voro_base {
  * specifically for computing the regular Voronoi tessellation with no
  * dependence on particle radii. */
 class container_periodic : public container_periodic_base, public radius_mono {
-	public:
-		container_periodic(double bx_,double bxy_,double by_,double bxz_,double byz_,double bz_,
-				int nx_,int ny_,int nz_,int init_mem_);
-		void clear();
-		void put(int n,double x,double y,double z);
-		void put(int n,double x,double y,double z,int &ai,int &aj,int &ak);
-		void put(particle_order &vo,int n,double x,double y,double z);
-		void import(FILE *fp=stdin);
-		void import(particle_order &vo,FILE *fp=stdin);
-		/** Imports a list of particles from an open file stream into
-		 * the container. Entries of four numbers (Particle ID, x
-		 * position, y position, z position) are searched for. If the
-		 * file cannot be successfully read, then the routine causes a
-		 * fatal error.
-		 * \param[in] filename the name of the file to open and read
-		 *                     from. */
-		inline void import(const char* filename) {
-			FILE *fp=safe_fopen(filename,"r");
-			import(fp);
-			fclose(fp);
-		}
-		/** Imports a list of particles from an open file stream into
-		 * the container. Entries of four numbers (Particle ID, x
-		 * position, y position, z position) are searched for. In
-		 * addition, the order in which particles are read is saved
-		 * into an ordering class. If the file cannot be successfully
-		 * read, then the routine causes a fatal error.
-		 * \param[in,out] vo the ordering class to use.
-		 * \param[in] filename the name of the file to open and read
-		 *                     from. */
-		inline void import(particle_order &vo,const char* filename) {
-			FILE *fp=safe_fopen(filename,"r");
-			import(vo,fp);
-			fclose(fp);
-		}
-		void compute_all_cells();
-		double sum_cell_volumes();
-		/** Dumps particle IDs and positions to a file.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_particles(c_loop &vl,FILE *fp) {
-			double *pp;
-			if(vl.start()) do {
-				pp=p[vl.ijk]+3*vl.q;
-				fprintf(fp,"%d %g %g %g\n",id[vl.ijk][vl.q],*pp,pp[1],pp[2]);
-			} while(vl.inc());
-		}
-		/** Dumps all of the particle IDs and positions to a file.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_particles(FILE *fp=stdout) {
-			c_loop_all_periodic vl(*this);
-			draw_particles(vl,fp);
-		}
-		/** Dumps all of the particle IDs and positions to a file.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_particles(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_particles(fp);
-			fclose(fp);
-		}
-		/** Dumps particle positions in POV-Ray format.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_particles_pov(c_loop &vl,FILE *fp) {
-			double *pp;
-			if(vl.start()) do {
-				pp=p[vl.ijk]+3*vl.q;
-				fprintf(fp,"// id %d\nsphere{<%g,%g,%g>,s}\n",
-						id[vl.ijk][vl.q],*pp,pp[1],pp[2]);
-			} while(vl.inc());
-		}
-		/** Dumps all particle positions in POV-Ray format.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_particles_pov(FILE *fp=stdout) {
-			c_loop_all_periodic vl(*this);
-			draw_particles_pov(vl,fp);
-		}
-		/** Dumps all particle positions in POV-Ray format.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_particles_pov(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_particles_pov(fp);
-			fclose(fp);
-		}
-		/** Computes Voronoi cells and saves the output in gnuplot
-		 * format.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_cells_gnuplot(c_loop &vl,FILE *fp) {
-			voronoicell c(*this);double *pp;
-			if(vl.start()) do if(compute_cell(c,vl)) {
-				pp=p[vl.ijk]+ps*vl.q;
-				c.draw_gnuplot(*pp,pp[1],pp[2],fp);
-			} while(vl.inc());
-		}
-		/** Computes all Voronoi cells and saves the output in gnuplot
-		 * format.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_cells_gnuplot(FILE *fp=stdout) {
-			c_loop_all_periodic vl(*this);
-			draw_cells_gnuplot(vl,fp);
-		}
-		/** Compute all Voronoi cells and saves the output in gnuplot
-		 * format.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_cells_gnuplot(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_cells_gnuplot(fp);
-			fclose(fp);
-		}
-		/** Computes Voronoi cells and saves the output in POV-Ray
-		 * format.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_cells_pov(c_loop &vl,FILE *fp) {
-			voronoicell c(*this);double *pp;
-			if(vl.start()) do if(compute_cell(c,vl)) {
-				fprintf(fp,"// cell %d\n",id[vl.ijk][vl.q]);
-				pp=p[vl.ijk]+ps*vl.q;
-				c.draw_pov(*pp,pp[1],pp[2],fp);
-			} while(vl.inc());
-		}
-		/** Computes all Voronoi cells and saves the output in POV-Ray
-		 * format.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_cells_pov(FILE *fp=stdout) {
-			c_loop_all_periodic vl(*this);
-			draw_cells_pov(vl,fp);
-		}
-		/** Computes all Voronoi cells and saves the output in POV-Ray
-		 * format.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_cells_pov(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_cells_pov(fp);
-			fclose(fp);
-		}
-		/** Computes the Voronoi cells and saves customized information
-		 * about them.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] format the custom output string to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void print_custom(c_loop &vl,const char *format,FILE *fp) {
-			int ijk,q;double *pp;
-			if(contains_neighbor(format)) {
-				voronoicell_neighbor c(*this);
-				if(vl.start()) do if(compute_cell(c,vl)) {
-					ijk=vl.ijk;q=vl.q;pp=p[ijk]+ps*q;
-					c.output_custom(format,id[ijk][q],*pp,pp[1],pp[2],default_radius,fp);
-				} while(vl.inc());
-			} else {
-				voronoicell c(*this);
-				if(vl.start()) do if(compute_cell(c,vl)) {
-					ijk=vl.ijk;q=vl.q;pp=p[ijk]+ps*q;
-					c.output_custom(format,id[ijk][q],*pp,pp[1],pp[2],default_radius,fp);
-				} while(vl.inc());
-			}
-		}
-		void print_custom(const char *format,FILE *fp=stdout);
-		void print_custom(const char *format,const char *filename);
-		bool find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid);
-		/** Computes the Voronoi cell for a particle currently being
-		 * referenced by a loop class.
-		 * \param[out] c a Voronoi cell class in which to store the
-		 * 		 computed cell.
-		 * \param[in] vl the loop class to use.
-		 * \return True if the cell was computed. If the cell cannot be
-		 * computed because it was removed entirely for some reason,
-		 * then the routine returns false. */
-		template<class v_cell,class c_loop>
-		inline bool compute_cell(v_cell &c,c_loop &vl) {
-			return vc.compute_cell(c,vl.ijk,vl.q,vl.i,vl.j,vl.k);
-		}
-		/** Computes the Voronoi cell for given particle.
-		 * \param[out] c a Voronoi cell class in which to store the
-		 * 		 computed cell.
-		 * \param[in] ijk the block that the particle is within.
-		 * \param[in] q the index of the particle within the block.
-		 * \return True if the cell was computed. If the cell cannot be
-		 * computed because it was removed entirely for some reason,
-		 * then the routine returns false. */
-		template<class v_cell>
-		inline bool compute_cell(v_cell &c,int ijk,int q) {
-			int k(ijk/(nx*oy)),ijkt(ijk-(nx*oy)*k),j(ijkt/nx),i(ijkt-j*nx);
-			return vc.compute_cell(c,ijk,q,i,j,k);
-		}
-		/** Computes the Voronoi cell for a ghost particle at a given
-		 * location.
-		 * \param[out] c a Voronoi cell class in which to store the
-		 * 		 computed cell.
-		 * \param[in] (x,y,z) the location of the ghost particle.
-		 * \return True if the cell was computed. If the cell cannot be
-		 * computed, if it is removed entirely by a wall or boundary
-		 * condition, then the routine returns false. */
-		template<class v_cell>
-		inline bool compute_ghost_cell(v_cell &c,double x,double y,double z) {
-			int ijk;
-			put_locate_block(ijk,x,y,z);
-			double *pp=p[ijk]+3*co[ijk]++;
-			*(pp++)=x;*(pp++)=y;*(pp++)=z;
-			bool q=compute_cell(c,ijk,co[ijk]-1);
-			co[ijk]--;
-			return q;
-		}
-	private:
-		voro_compute<container_periodic> vc;
-		friend class voro_compute<container_periodic>;
+    public:
+        container_periodic(double bx_,double bxy_,double by_,double bxz_,double byz_,double bz_,
+                int nx_,int ny_,int nz_,int init_mem_);
+        void clear();
+        void put(int n,double x,double y,double z);
+        void put(int n,double x,double y,double z,int &ai,int &aj,int &ak);
+        void put(particle_order &vo,int n,double x,double y,double z);
+        void import(FILE *fp=stdin);
+        void import(particle_order &vo,FILE *fp=stdin);
+        /** Imports a list of particles from an open file stream into
+         * the container. Entries of four numbers (Particle ID, x
+         * position, y position, z position) are searched for. If the
+         * file cannot be successfully read, then the routine causes a
+         * fatal error.
+         * \param[in] filename the name of the file to open and read
+         *                     from. */
+        inline void import(const char* filename) {
+            FILE *fp=safe_fopen(filename,"r");
+            import(fp);
+            fclose(fp);
+        }
+        /** Imports a list of particles from an open file stream into
+         * the container. Entries of four numbers (Particle ID, x
+         * position, y position, z position) are searched for. In
+         * addition, the order in which particles are read is saved
+         * into an ordering class. If the file cannot be successfully
+         * read, then the routine causes a fatal error.
+         * \param[in,out] vo the ordering class to use.
+         * \param[in] filename the name of the file to open and read
+         *                     from. */
+        inline void import(particle_order &vo,const char* filename) {
+            FILE *fp=safe_fopen(filename,"r");
+            import(vo,fp);
+            fclose(fp);
+        }
+        void compute_all_cells();
+        double sum_cell_volumes();
+        bool find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid);
+        /** Computes the Voronoi cell for a particle currently being
+         * referenced by a loop class.
+         * \param[out] c a Voronoi cell class in which to store the
+         * 		 computed cell.
+         * \param[in] vl the loop class to use.
+         * \return True if the cell was computed. If the cell cannot be
+         * computed because it was removed entirely for some reason,
+         * then the routine returns false. */
+        template<class v_cell,class c_loop>
+        inline bool compute_cell(v_cell &c,c_loop &vl) {
+            return vc.compute_cell(c,vl.ijk,vl.q,vl.i,vl.j,vl.k);
+        }
+        /** Computes the Voronoi cell for given particle.
+         * \param[out] c a Voronoi cell class in which to store the
+         * 		 computed cell.
+         * \param[in] ijk the block that the particle is within.
+         * \param[in] q the index of the particle within the block.
+         * \return True if the cell was computed. If the cell cannot be
+         * computed because it was removed entirely for some reason,
+         * then the routine returns false. */
+        template<class v_cell>
+        inline bool compute_cell(v_cell &c,int ijk,int q) {
+            int k(ijk/(nx*oy)),ijkt(ijk-(nx*oy)*k),j(ijkt/nx),i(ijkt-j*nx);
+            return vc.compute_cell(c,ijk,q,i,j,k);
+        }
+        /** Computes the Voronoi cell for a ghost particle at a given
+         * location.
+         * \param[out] c a Voronoi cell class in which to store the
+         * 		 computed cell.
+         * \param[in] (x,y,z) the location of the ghost particle.
+         * \return True if the cell was computed. If the cell cannot be
+         * computed, if it is removed entirely by a wall or boundary
+         * condition, then the routine returns false. */
+        template<class v_cell>
+        inline bool compute_ghost_cell(v_cell &c,double x,double y,double z) {
+            int ijk;
+            put_locate_block(ijk,x,y,z);
+            double *pp=p[ijk]+3*co[ijk]++;
+            *(pp++)=x;*(pp++)=y;*(pp++)=z;
+            bool q=compute_cell(c,ijk,co[ijk]-1);
+            co[ijk]--;
+            return q;
+        }
+    private:
+        voro_compute<container_periodic> vc;
+        friend class voro_compute<container_periodic>;
 };
 
 /** \brief Extension of the container_periodic_base class for computing radical
@@ -432,222 +297,93 @@ class container_periodic : public container_periodic_base, public radius_mono {
  * specifically for computing the radical Voronoi tessellation that depends
  * on the particle radii. */
 class container_periodic_poly : public container_periodic_base, public radius_poly {
-	public:
-		container_periodic_poly(double bx_,double bxy_,double by_,double bxz_,double byz_,double bz_,
-				int nx_,int ny_,int nz_,int init_mem_);
-		void clear();
-		void put(int n,double x,double y,double z,double r);
-		void put(int n,double x,double y,double z,double r,int &ai,int &aj,int &ak);
-		void put(particle_order &vo,int n,double x,double y,double z,double r);
-		void import(FILE *fp=stdin);
-		void import(particle_order &vo,FILE *fp=stdin);
-		/** Imports a list of particles from an open file stream into
-		 * the container_poly class. Entries of five numbers (Particle
-		 * ID, x position, y position, z position, radius) are searched
-		 * for. If the file cannot be successfully read, then the
-		 * routine causes a fatal error.
-		 * \param[in] filename the name of the file to open and read
-		 *                     from. */
-		inline void import(const char* filename) {
-			FILE *fp=safe_fopen(filename,"r");
-			import(fp);
-			fclose(fp);
-		}
-		/** Imports a list of particles from an open file stream into
-		 * the container_poly class. Entries of five numbers (Particle
-		 * ID, x position, y position, z position, radius) are searched
-		 * for. In addition, the order in which particles are read is
-		 * saved into an ordering class. If the file cannot be
-		 * successfully read, then the routine causes a fatal error.
-		 * \param[in,out] vo the ordering class to use.
-		 * \param[in] filename the name of the file to open and read
-		 *                     from. */
-		inline void import(particle_order &vo,const char* filename) {
-			FILE *fp=safe_fopen(filename,"r");
-			import(vo,fp);
-			fclose(fp);
-		}
-		void compute_all_cells();
-		double sum_cell_volumes();
-		/** Dumps particle IDs, positions and radii to a file.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_particles(c_loop &vl,FILE *fp) {
-			double *pp;
-			if(vl.start()) do {
-				pp=p[vl.ijk]+4*vl.q;
-				fprintf(fp,"%d %g %g %g %g\n",id[vl.ijk][vl.q],*pp,pp[1],pp[2],pp[3]);
-			} while(vl.inc());
-		}
-		/** Dumps all of the particle IDs, positions and radii to a
-		 * file.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_particles(FILE *fp=stdout) {
-			c_loop_all_periodic vl(*this);
-			draw_particles(vl,fp);
-		}
-		/** Dumps all of the particle IDs, positions and radii to a
-		 * file.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_particles(const char *filename) {
-			FILE *fp=safe_fopen(filename,"w");
-			draw_particles(fp);
-			fclose(fp);
-		}
-		/** Dumps particle positions in POV-Ray format.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_particles_pov(c_loop &vl,FILE *fp) {
-			double *pp;
-			if(vl.start()) do {
-				pp=p[vl.ijk]+4*vl.q;
-				fprintf(fp,"// id %d\nsphere{<%g,%g,%g>,%g}\n",
-						id[vl.ijk][vl.q],*pp,pp[1],pp[2],pp[3]);
-			} while(vl.inc());
-		}
-		/** Dumps all the particle positions in POV-Ray format.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_particles_pov(FILE *fp=stdout) {
-			c_loop_all_periodic vl(*this);
-			draw_particles_pov(vl,fp);
-		}
-		/** Dumps all the particle positions in POV-Ray format.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_particles_pov(const char *filename) {
-			FILE *fp(safe_fopen(filename,"w"));
-			draw_particles_pov(fp);
-			fclose(fp);
-		}
-		/** Computes Voronoi cells and saves the output in gnuplot
-		 * format.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_cells_gnuplot(c_loop &vl,FILE *fp) {
-			voronoicell c(*this);double *pp;
-			if(vl.start()) do if(compute_cell(c,vl)) {
-				pp=p[vl.ijk]+ps*vl.q;
-				c.draw_gnuplot(*pp,pp[1],pp[2],fp);
-			} while(vl.inc());
-		}
-		/** Compute all Voronoi cells and saves the output in gnuplot
-		 * format.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_cells_gnuplot(FILE *fp=stdout) {
-			c_loop_all_periodic vl(*this);
-			draw_cells_gnuplot(vl,fp);
-		}
-		/** Compute all Voronoi cells and saves the output in gnuplot
-		 * format.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_cells_gnuplot(const char *filename) {
-			FILE *fp(safe_fopen(filename,"w"));
-			draw_cells_gnuplot(fp);
-			fclose(fp);
-		}
-		/** Computes Voronoi cells and saves the output in POV-Ray
-		 * format.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void draw_cells_pov(c_loop &vl,FILE *fp) {
-			voronoicell c(*this);double *pp;
-			if(vl.start()) do if(compute_cell(c,vl)) {
-				fprintf(fp,"// cell %d\n",id[vl.ijk][vl.q]);
-				pp=p[vl.ijk]+ps*vl.q;
-				c.draw_pov(*pp,pp[1],pp[2],fp);
-			} while(vl.inc());
-		}
-		/** Computes all Voronoi cells and saves the output in POV-Ray
-		 * format.
-		 * \param[in] fp a file handle to write to. */
-		inline void draw_cells_pov(FILE *fp=stdout) {
-			c_loop_all_periodic vl(*this);
-			draw_cells_pov(vl,fp);
-		}
-		/** Computes all Voronoi cells and saves the output in POV-Ray
-		 * format.
-		 * \param[in] filename the name of the file to write to. */
-		inline void draw_cells_pov(const char *filename) {
-			FILE *fp(safe_fopen(filename,"w"));
-			draw_cells_pov(fp);
-			fclose(fp);
-		}
-		/** Computes the Voronoi cells and saves customized information
-		 * about them.
-		 * \param[in] vl the loop class to use.
-		 * \param[in] format the custom output string to use.
-		 * \param[in] fp a file handle to write to. */
-		template<class c_loop>
-		void print_custom(c_loop &vl,const char *format,FILE *fp) {
-			int ijk,q;double *pp;
-			if(contains_neighbor(format)) {
-				voronoicell_neighbor c(*this);
-				if(vl.start()) do if(compute_cell(c,vl)) {
-					ijk=vl.ijk;q=vl.q;pp=p[ijk]+ps*q;
-					c.output_custom(format,id[ijk][q],*pp,pp[1],pp[2],pp[3],fp);
-				} while(vl.inc());
-			} else {
-				voronoicell c(*this);
-				if(vl.start()) do if(compute_cell(c,vl)) {
-					ijk=vl.ijk;q=vl.q;pp=p[ijk]+ps*q;
-					c.output_custom(format,id[ijk][q],*pp,pp[1],pp[2],pp[3],fp);
-				} while(vl.inc());
-			}
-		}
-		/** Computes the Voronoi cell for a particle currently being
-		 * referenced by a loop class.
-		 * \param[out] c a Voronoi cell class in which to store the
-		 * 		 computed cell.
-		 * \param[in] vl the loop class to use.
-		 * \return True if the cell was computed. If the cell cannot be
-		 * computed because it was removed entirely for some reason,
-		 * then the routine returns false. */
-		template<class v_cell,class c_loop>
-		inline bool compute_cell(v_cell &c,c_loop &vl) {
-			return vc.compute_cell(c,vl.ijk,vl.q,vl.i,vl.j,vl.k);
-		}
-		/** Computes the Voronoi cell for given particle.
-		 * \param[out] c a Voronoi cell class in which to store the
-		 * 		 computed cell.
-		 * \param[in] ijk the block that the particle is within.
-		 * \param[in] q the index of the particle within the block.
-		 * \return True if the cell was computed. If the cell cannot be
-		 * computed because it was removed entirely for some reason,
-		 * then the routine returns false. */
-		template<class v_cell>
-		inline bool compute_cell(v_cell &c,int ijk,int q) {
-			int k(ijk/(nx*oy)),ijkt(ijk-(nx*oy)*k),j(ijkt/nx),i(ijkt-j*nx);
-			return vc.compute_cell(c,ijk,q,i,j,k);
-		}
-		/** Computes the Voronoi cell for a ghost particle at a given
-		 * location.
-		 * \param[out] c a Voronoi cell class in which to store the
-		 * 		 computed cell.
-		 * \param[in] (x,y,z) the location of the ghost particle.
-		 * \param[in] r the radius of the ghost particle.
-		 * \return True if the cell was computed. If the cell cannot be
-		 * computed, if it is removed entirely by a wall or boundary
-		 * condition, then the routine returns false. */
-		template<class v_cell>
-		inline bool compute_ghost_cell(v_cell &c,double x,double y,double z,double r) {
-			int ijk;
-			put_locate_block(ijk,x,y,z);
-			double *pp=p[ijk]+4*co[ijk]++,tm=max_radius;
-			*(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-			if(r>max_radius) max_radius=r;
-			bool q=compute_cell(c,ijk,co[ijk]-1);
-			co[ijk]--;max_radius=tm;
-			return q;
-		}
-		void print_custom(const char *format,FILE *fp=stdout);
-		void print_custom(const char *format,const char *filename);
-		bool find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid);
-	private:
-		voro_compute<container_periodic_poly> vc;
-		friend class voro_compute<container_periodic_poly>;
+    public:
+        container_periodic_poly(double bx_,double bxy_,double by_,double bxz_,double byz_,double bz_,
+                int nx_,int ny_,int nz_,int init_mem_);
+        void clear();
+        void put(int n,double x,double y,double z,double r);
+        void put(int n,double x,double y,double z,double r,int &ai,int &aj,int &ak);
+        void put(particle_order &vo,int n,double x,double y,double z,double r);
+        void import(FILE *fp=stdin);
+        void import(particle_order &vo,FILE *fp=stdin);
+        /** Imports a list of particles from an open file stream into
+         * the container_poly class. Entries of five numbers (Particle
+         * ID, x position, y position, z position, radius) are searched
+         * for. If the file cannot be successfully read, then the
+         * routine causes a fatal error.
+         * \param[in] filename the name of the file to open and read
+         *                     from. */
+        inline void import(const char* filename) {
+            FILE *fp=safe_fopen(filename,"r");
+            import(fp);
+            fclose(fp);
+        }
+        /** Imports a list of particles from an open file stream into
+         * the container_poly class. Entries of five numbers (Particle
+         * ID, x position, y position, z position, radius) are searched
+         * for. In addition, the order in which particles are read is
+         * saved into an ordering class. If the file cannot be
+         * successfully read, then the routine causes a fatal error.
+         * \param[in,out] vo the ordering class to use.
+         * \param[in] filename the name of the file to open and read
+         *                     from. */
+        inline void import(particle_order &vo,const char* filename) {
+            FILE *fp=safe_fopen(filename,"r");
+            import(vo,fp);
+            fclose(fp);
+        }
+        void compute_all_cells();
+        double sum_cell_volumes();
+
+        /** Computes the Voronoi cell for a particle currently being
+         * referenced by a loop class.
+         * \param[out] c a Voronoi cell class in which to store the
+         * 		 computed cell.
+         * \param[in] vl the loop class to use.
+         * \return True if the cell was computed. If the cell cannot be
+         * computed because it was removed entirely for some reason,
+         * then the routine returns false. */
+        template<class v_cell,class c_loop>
+        inline bool compute_cell(v_cell &c,c_loop &vl) {
+            return vc.compute_cell(c,vl.ijk,vl.q,vl.i,vl.j,vl.k);
+        }
+        /** Computes the Voronoi cell for given particle.
+         * \param[out] c a Voronoi cell class in which to store the
+         * 		 computed cell.
+         * \param[in] ijk the block that the particle is within.
+         * \param[in] q the index of the particle within the block.
+         * \return True if the cell was computed. If the cell cannot be
+         * computed because it was removed entirely for some reason,
+         * then the routine returns false. */
+        template<class v_cell>
+        inline bool compute_cell(v_cell &c,int ijk,int q) {
+            int k(ijk/(nx*oy)),ijkt(ijk-(nx*oy)*k),j(ijkt/nx),i(ijkt-j*nx);
+            return vc.compute_cell(c,ijk,q,i,j,k);
+        }
+        /** Computes the Voronoi cell for a ghost particle at a given
+         * location.
+         * \param[out] c a Voronoi cell class in which to store the
+         * 		 computed cell.
+         * \param[in] (x,y,z) the location of the ghost particle.
+         * \param[in] r the radius of the ghost particle.
+         * \return True if the cell was computed. If the cell cannot be
+         * computed, if it is removed entirely by a wall or boundary
+         * condition, then the routine returns false. */
+        template<class v_cell>
+        inline bool compute_ghost_cell(v_cell &c,double x,double y,double z,double r) {
+            int ijk;
+            put_locate_block(ijk,x,y,z);
+            double *pp=p[ijk]+4*co[ijk]++,tm=max_radius;
+            *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
+            if(r>max_radius) max_radius=r;
+            bool q=compute_cell(c,ijk,co[ijk]-1);
+            co[ijk]--;max_radius=tm;
+            return q;
+        }
+        bool find_voronoi_cell(double x,double y,double z,double &rx,double &ry,double &rz,int &pid);
+    private:
+        voro_compute<container_periodic_poly> vc;
+        friend class voro_compute<container_periodic_poly>;
 };
 
 }

--- a/SKIRT/voro/unitcell.cc
+++ b/SKIRT/voro/unitcell.cc
@@ -24,73 +24,73 @@ namespace voro {
  * \param[in] (bxz_,byz_,bz_) The x, y, and z coordinates of the third unit
  *                            vector. */
 unitcell::unitcell(double bx_,double bxy_,double by_,double bxz_,double byz_,double bz_)
-	: bx(bx_), bxy(bxy_), by(by_), bxz(bxz_), byz(byz_), bz(bz_),
-	unit_voro(max_unit_voro_shells*max_unit_voro_shells*4*(bx*bx+by*by+bz*bz)) {
-	int i,j,l=1;
+    : bx(bx_), bxy(bxy_), by(by_), bxz(bxz_), byz(byz_), bz(bz_),
+    unit_voro(max_unit_voro_shells*max_unit_voro_shells*4*(bx*bx+by*by+bz*bz)) {
+    int i,j,l=1;
 
-	// Initialize the Voronoi cell to be a very large rectangular box
-	const double ucx=max_unit_voro_shells*bx,ucy=max_unit_voro_shells*by,ucz=max_unit_voro_shells*bz;
-	unit_voro.init(-ucx,ucx,-ucy,ucy,-ucz,ucz);
+    // Initialize the Voronoi cell to be a very large rectangular box
+    const double ucx=max_unit_voro_shells*bx,ucy=max_unit_voro_shells*by,ucz=max_unit_voro_shells*bz;
+    unit_voro.init(-ucx,ucx,-ucy,ucy,-ucz,ucz);
 
-	// Repeatedly cut the cell by shells of periodic image particles
-	while(l<2*max_unit_voro_shells) {
+    // Repeatedly cut the cell by shells of periodic image particles
+    while(l<2*max_unit_voro_shells) {
 
-		// Check to see if any of the planes from the current shell
-		// will cut the cell
-		if(unit_voro_intersect(l)) {
+        // Check to see if any of the planes from the current shell
+        // will cut the cell
+        if(unit_voro_intersect(l)) {
 
-			// If they do, apply the plane cuts from the current
-			// shell
-			unit_voro_apply(l,0,0);
-			for(i=1;i<l;i++) {
-				unit_voro_apply(l,i,0);
-				unit_voro_apply(-l,i,0);
-			}
-			for(i=-l;i<=l;i++) unit_voro_apply(i,l,0);
-			for(i=1;i<l;i++) for(j=-l+1;j<=l;j++) {
-				unit_voro_apply(l,j,i);
-				unit_voro_apply(-j,l,i);
-				unit_voro_apply(-l,-j,i);
-				unit_voro_apply(j,-l,i);
-			}
-			for(i=-l;i<=l;i++) for(j=-l;j<=l;j++) unit_voro_apply(i,j,l);
-		} else {
+            // If they do, apply the plane cuts from the current
+            // shell
+            unit_voro_apply(l,0,0);
+            for(i=1;i<l;i++) {
+                unit_voro_apply(l,i,0);
+                unit_voro_apply(-l,i,0);
+            }
+            for(i=-l;i<=l;i++) unit_voro_apply(i,l,0);
+            for(i=1;i<l;i++) for(j=-l+1;j<=l;j++) {
+                unit_voro_apply(l,j,i);
+                unit_voro_apply(-j,l,i);
+                unit_voro_apply(-l,-j,i);
+                unit_voro_apply(j,-l,i);
+            }
+            for(i=-l;i<=l;i++) for(j=-l;j<=l;j++) unit_voro_apply(i,j,l);
+        } else {
 
-			// Calculate a bound on the maximum y and z coordinates
-			// that could possibly cut the cell. This is based upon
-			// a geometric result that particles with z>l can't cut
-			// a cell lying within the paraboloid
-			// z<=(l*l-x*x-y*y)/(2*l). It is always a tighter bound
-			// than the one based on computing the maximum radius
-			// of a Voronoi cell vertex.
-			max_uv_y=max_uv_z=0;
-			double y,z,q,*pts=unit_voro.pts,*pp=pts;
-			while(pp<pts+4*unit_voro.p) {
-				q=*(pp++);y=*(pp++);z=*pp;pp+=2;q=sqrt(q*q+y*y+z*z);
-				if(y+q>max_uv_y) max_uv_y=y+q;
-				if(z+q>max_uv_z) max_uv_z=z+q;
-			}
-			max_uv_z*=0.5;
-			max_uv_y*=0.5;
-			return;
-		}
-		l++;
-	}
+            // Calculate a bound on the maximum y and z coordinates
+            // that could possibly cut the cell. This is based upon
+            // a geometric result that particles with z>l can't cut
+            // a cell lying within the paraboloid
+            // z<=(l*l-x*x-y*y)/(2*l). It is always a tighter bound
+            // than the one based on computing the maximum radius
+            // of a Voronoi cell vertex.
+            max_uv_y=max_uv_z=0;
+            double y,z,q,*pts=unit_voro.pts,*pp=pts;
+            while(pp<pts+4*unit_voro.p) {
+                q=*(pp++);y=*(pp++);z=*pp;pp+=2;q=sqrt(q*q+y*y+z*z);
+                if(y+q>max_uv_y) max_uv_y=y+q;
+                if(z+q>max_uv_z) max_uv_z=z+q;
+            }
+            max_uv_z*=0.5;
+            max_uv_y*=0.5;
+            return;
+        }
+        l++;
+    }
 
-	// If the routine makes it here, then the unit cell still hasn't been
-	// completely bounded by the plane cuts. Give the memory error code,
-	// because this is mainly a case of hitting a safe limit, than any
-	// inherent problem.
-	voro_fatal_error("Periodic cell computation failed",VOROPP_MEMORY_ERROR);
+    // If the routine makes it here, then the unit cell still hasn't been
+    // completely bounded by the plane cuts. Give the memory error code,
+    // because this is mainly a case of hitting a safe limit, than any
+    // inherent problem.
+    voro_fatal_error("Periodic cell computation failed",VOROPP_MEMORY_ERROR);
 }
 
 /** Applies a pair of opposing plane cuts from a periodic image point
  * to the unit Voronoi cell.
  * \param[in] (i,j,k) the index of the periodic image to consider. */
 inline void unitcell::unit_voro_apply(int i,int j,int k) {
-	double x=i*bx+j*bxy+k*bxz,y=j*by+k*byz,z=k*bz;
-	unit_voro.plane(x,y,z);
-	unit_voro.plane(-x,-y,-z);
+    double x=i*bx+j*bxy+k*bxz,y=j*by+k*byz,z=k*bz;
+    unit_voro.plane(x,y,z);
+    unit_voro.plane(-x,-y,-z);
 }
 
 /** Calculates whether the unit Voronoi cell intersects a given periodic image
@@ -100,18 +100,18 @@ inline void unitcell::unit_voro_apply(int i,int j,int k) {
  *                 only computed in the case that the two intersect.
  * \return True if they intersect, false otherwise. */
 bool unitcell::intersects_image(double dx,double dy,double dz,double &vol) {
-	const double bxinv=1/bx,byinv=1/by,bzinv=1/bz,ivol=bxinv*byinv*bzinv;
-	voronoicell c;
-	c=unit_voro;
-	dx*=2;dy*=2;dz*=2;
-	if(!c.plane(0,0,bzinv,dz+1)) return false;
-	if(!c.plane(0,0,-bzinv,-dz+1)) return false;
-	if(!c.plane(0,byinv,-byz*byinv*bzinv,dy+1)) return false;
-	if(!c.plane(0,-byinv,byz*byinv*bzinv,-dy+1)) return false;
-	if(!c.plane(bxinv,-bxy*bxinv*byinv,(bxy*byz-by*bxz)*ivol,dx+1)) return false;
-	if(!c.plane(-bxinv,bxy*bxinv*byinv,(-bxy*byz+by*bxz)*ivol,-dx+1)) return false;
-	vol=c.volume()*ivol;
-	return true;
+    const double bxinv=1/bx,byinv=1/by,bzinv=1/bz,ivol=bxinv*byinv*bzinv;
+    voronoicell c;
+    c=unit_voro;
+    dx*=2;dy*=2;dz*=2;
+    if(!c.plane(0,0,bzinv,dz+1)) return false;
+    if(!c.plane(0,0,-bzinv,-dz+1)) return false;
+    if(!c.plane(0,byinv,-byz*byinv*bzinv,dy+1)) return false;
+    if(!c.plane(0,-byinv,byz*byinv*bzinv,-dy+1)) return false;
+    if(!c.plane(bxinv,-bxy*bxinv*byinv,(bxy*byz-by*bxz)*ivol,dx+1)) return false;
+    if(!c.plane(-bxinv,bxy*bxinv*byinv,(-bxy*byz+by*bxz)*ivol,-dx+1)) return false;
+    vol=c.volume()*ivol;
+    return true;
 }
 
 /** Computes a list of periodic domain images that intersect the unit Voronoi cell.
@@ -121,50 +121,50 @@ bool unitcell::intersects_image(double dx,double dy,double dz,double &vol) {
  * \param[out] vd a vector containing the fraction of the Voronoi cell volume
  *                within each corresponding image listed in vi. */
 void unitcell::images(std::vector<int> &vi,std::vector<double> &vd) {
-	const int ms2=max_unit_voro_shells*2+1,mss=ms2*ms2*ms2;
-	bool *a=new bool[mss],*ac=a+max_unit_voro_shells*(1+ms2*(1+ms2)),*ap=a;
-	int i,j,k;
-	double vol;
+    const int ms2=max_unit_voro_shells*2+1,mss=ms2*ms2*ms2;
+    bool *a=new bool[mss],*ac=a+max_unit_voro_shells*(1+ms2*(1+ms2)),*ap=a;
+    int i,j,k;
+    double vol;
 
-	// Initialize mask
-	while(ap<ac) *(ap++)=true;
-	*(ap++)=false;
-	while(ap<a+mss) *(ap++)=true;
+    // Initialize mask
+    while(ap<ac) *(ap++)=true;
+    *(ap++)=false;
+    while(ap<a+mss) *(ap++)=true;
 
-	// Set up the queue and add (0,0,0) image to it
-	std::queue<int> q;
-	q.push(0);q.push(0);q.push(0);
+    // Set up the queue and add (0,0,0) image to it
+    std::queue<int> q;
+    q.push(0);q.push(0);q.push(0);
 
-	while(!q.empty()) {
+    while(!q.empty()) {
 
-		// Read the next entry on the queue
-		i=q.front();q.pop();
-		j=q.front();q.pop();
-		k=q.front();q.pop();
+        // Read the next entry on the queue
+        i=q.front();q.pop();
+        j=q.front();q.pop();
+        k=q.front();q.pop();
 
-		// Check intersection of this image
-		if(intersects_image(i,j,k,vol)) {
+        // Check intersection of this image
+        if(intersects_image(i,j,k,vol)) {
 
-			// Add this entry to the output vectors
-			vi.push_back(i);
-			vi.push_back(j);
-			vi.push_back(k);
-			vd.push_back(vol);
+            // Add this entry to the output vectors
+            vi.push_back(i);
+            vi.push_back(j);
+            vi.push_back(k);
+            vd.push_back(vol);
 
-			// Add neighbors to the queue if they have not been
-			// tested
-			ap=ac+i+ms2*(j+ms2*k);
-			if(k>-max_unit_voro_shells&&*(ap-ms2*ms2)) {q.push(i);q.push(j);q.push(k-1);*(ap-ms2*ms2)=false;}
-			if(j>-max_unit_voro_shells&&*(ap-ms2)) {q.push(i);q.push(j-1);q.push(k);*(ap-ms2)=false;}
-			if(i>-max_unit_voro_shells&&*(ap-1)) {q.push(i-1);q.push(j);q.push(k);*(ap-1)=false;}
-			if(i<max_unit_voro_shells&&*(ap+1)) {q.push(i+1);q.push(j);q.push(k);*(ap+1)=false;}
-			if(j<max_unit_voro_shells&&*(ap+ms2)) {q.push(i);q.push(j+1);q.push(k);*(ap+ms2)=false;}
-			if(k<max_unit_voro_shells&&*(ap+ms2*ms2)) {q.push(i);q.push(j);q.push(k+1);*(ap+ms2*ms2)=false;}
-		}
-	}
+            // Add neighbors to the queue if they have not been
+            // tested
+            ap=ac+i+ms2*(j+ms2*k);
+            if(k>-max_unit_voro_shells&&*(ap-ms2*ms2)) {q.push(i);q.push(j);q.push(k-1);*(ap-ms2*ms2)=false;}
+            if(j>-max_unit_voro_shells&&*(ap-ms2)) {q.push(i);q.push(j-1);q.push(k);*(ap-ms2)=false;}
+            if(i>-max_unit_voro_shells&&*(ap-1)) {q.push(i-1);q.push(j);q.push(k);*(ap-1)=false;}
+            if(i<max_unit_voro_shells&&*(ap+1)) {q.push(i+1);q.push(j);q.push(k);*(ap+1)=false;}
+            if(j<max_unit_voro_shells&&*(ap+ms2)) {q.push(i);q.push(j+1);q.push(k);*(ap+ms2)=false;}
+            if(k<max_unit_voro_shells&&*(ap+ms2*ms2)) {q.push(i);q.push(j);q.push(k+1);*(ap+ms2*ms2)=false;}
+        }
+    }
 
-	// Remove mask memory
-	delete [] a;
+    // Remove mask memory
+    delete [] a;
 }
 
 /** Tests to see if a shell of periodic images could possibly cut the periodic
@@ -172,21 +172,21 @@ void unitcell::images(std::vector<int> &vi,std::vector<double> &vd) {
  * \param[in] l the index of the shell to consider.
  * \return True if a point in the shell cuts the cell, false otherwise. */
 bool unitcell::unit_voro_intersect(int l) {
-	int i,j;
-	if(unit_voro_test(l,0,0)) return true;
-	for(i=1;i<l;i++) {
-		if(unit_voro_test(l,i,0)) return true;
-		if(unit_voro_test(-l,i,0)) return true;
-	}
-	for(i=-l;i<=l;i++) if(unit_voro_test(i,l,0)) return true;
-	for(i=1;i<l;i++) for(j=-l+1;j<=l;j++) {
-		if(unit_voro_test(l,j,i)) return true;
-		if(unit_voro_test(-j,l,i)) return true;
-		if(unit_voro_test(-l,-j,i)) return true;
-		if(unit_voro_test(j,-l,i)) return true;
-	}
-	for(i=-l;i<=l;i++) for(j=-l;j<=l;j++) if(unit_voro_test(i,j,l)) return true;
-	return false;
+    int i,j;
+    if(unit_voro_test(l,0,0)) return true;
+    for(i=1;i<l;i++) {
+        if(unit_voro_test(l,i,0)) return true;
+        if(unit_voro_test(-l,i,0)) return true;
+    }
+    for(i=-l;i<=l;i++) if(unit_voro_test(i,l,0)) return true;
+    for(i=1;i<l;i++) for(j=-l+1;j<=l;j++) {
+        if(unit_voro_test(l,j,i)) return true;
+        if(unit_voro_test(-j,l,i)) return true;
+        if(unit_voro_test(-l,-j,i)) return true;
+        if(unit_voro_test(j,-l,i)) return true;
+    }
+    for(i=-l;i<=l;i++) for(j=-l;j<=l;j++) if(unit_voro_test(i,j,l)) return true;
+    return false;
 }
 
 /** Tests to see if a plane cut from a particular periodic image will cut th
@@ -194,39 +194,9 @@ bool unitcell::unit_voro_intersect(int l) {
  * \param[in] (i,j,k) the index of the periodic image to consider.
  * \return True if the image cuts the cell, false otherwise. */
 inline bool unitcell::unit_voro_test(int i,int j,int k) {
-	double x=i*bx+j*bxy+k*bxz,y=j*by+k*byz,z=k*bz;
-	double rsq=x*x+y*y+z*z;
-	return unit_voro.plane_intersects(x,y,z,rsq);
-}
-
-/** Draws the periodic domain in gnuplot format.
- * \param[in] fp the file handle to write to. */
-void unitcell::draw_domain_gnuplot(FILE *fp) {
-	fprintf(fp,"0 0 0\n%g 0 0\n%g %g 0\n%g %g 0\n",bx,bx+bxy,by,bxy,by);
-	fprintf(fp,"%g %g %g\n%g %g %g\n%g %g %g\n%g %g %g\n",bxy+bxz,by+byz,bz,bx+bxy+bxz,by+byz,bz,bx+bxz,byz,bz,bxz,byz,bz);
-	fprintf(fp,"0 0 0\n%g %g 0\n\n%g %g %g\n%g %g %g\n\n",bxy,by,bxz,byz,bz,bxy+bxz,by+byz,bz);
-	fprintf(fp,"%g 0 0\n%g %g %g\n\n%g %g 0\n%g %g %g\n\n",bx,bx+bxz,byz,bz,bx+bxy,by,bx+bxy+bxz,by+byz,bz);
-}
-
-/** Draws the periodic domain in POV-Ray format.
- * \param[in] fp the file handle to write to. */
-void unitcell::draw_domain_pov(FILE *fp) {
-	fprintf(fp,"cylinder{0,0,0>,<%g,0,0>,rr}\n"
-		   "cylinder{<%g,%g,0>,<%g,%g,0>,rr}\n",bx,bxy,by,bx+bxy,by);
-	fprintf(fp,"cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n"
-		   "cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n",bxz,byz,bz,bx+bxz,byz,bz,bxy+bxz,by+byz,bz,bx+bxy+bxz,by+byz,bz);
-	fprintf(fp,"cylinder{<0,0,0>,<%g,%g,0>,rr}\n"
-		   "cylinder{<%g,0,0>,<%g,%g,0>,rr}\n",bxy,by,bx,bx+bxy,by);
-	fprintf(fp,"cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n"
-		   "cylinder{<%g,%g,%g>,<%g,%g,%g>,rr}\n",bxz,byz,bz,bxy+bxz,by+byz,bz,bx+bxz,byz,bz,bx+bxy+bxz,by+byz,bz);
-	fprintf(fp,"cylinder{<0,0,0>,<%g,%g,%g>,rr}\n"
-		   "cylinder{<%g,0,0>,<%g,%g,%g>,rr}\n",bxz,byz,bz,bx,bx+bxz,byz,bz);
-	fprintf(fp,"cylinder{<%g,%g,0>,<%g,%g,%g>,rr}\n"
-		   "cylinder{<%g,%g,0>,<%g,%g,%g>,rr}\n",bxy,by,bxy+bxz,by+byz,bz,bx+bxy,by,bx+bxy+bxz,by+byz,bz);
-	fprintf(fp,"sphere{<0,0,0>,rr}\nsphere{<%g,0,0>,rr}\n"
-		   "sphere{<%g,%g,0>,rr}\nsphere{<%g,%g,0>,rr}\n",bx,bxy,by,bx+bxy,by);
-	fprintf(fp,"sphere{<%g,%g,%g>,rr}\nsphere{<%g,%g,%g>,rr}\n"
-		   "sphere{<%g,%g,%g>,rr}\nsphere{<%g,%g,%g>,rr}\n",bxz,byz,bz,bx+bxz,byz,bz,bxy+bxz,by+byz,bz,bx+bxy+bxz,by+byz,bz);
+    double x=i*bx+j*bxy+k*bxz,y=j*by+k*byz,z=k*bz;
+    double rsq=x*x+y*y+z*z;
+    return unit_voro.plane_intersects(x,y,z,rsq);
 }
 
 }

--- a/SKIRT/voro/unitcell.hh
+++ b/SKIRT/voro/unitcell.hh
@@ -20,58 +20,42 @@ namespace voro {
 /** \brief Class for computation of the unit Voronoi cell associated with
  * a 3D non-rectangular periodic domain. */
 class unitcell {
-	public:
-		/** The x coordinate of the first vector defining the periodic
-		 * domain. */
-		const double bx;
-		/** The x coordinate of the second vector defining the periodic
-		 * domain. */
-		const double bxy;
-		/** The y coordinate of the second vector defining the periodic
-		 * domain. */
-		const double by;
-		/** The x coordinate of the third vector defining the periodic
-		 * domain. */
-		const double bxz;
-		/** The y coordinate of the third vector defining the periodic
-		 * domain. */
-		const double byz;
-		/** The z coordinate of the third vector defining the periodic
-		 * domain. */
-		const double bz;
-		/** The computed unit Voronoi cell corresponding the given
-		 * 3D non-rectangular periodic domain geometry. */
-		voronoicell unit_voro;
-		unitcell(double bx_,double bxy_,double by_,double bxz_,double byz_,double bz_);
-		/** Draws an outline of the domain in Gnuplot format.
-		 * \param[in] filename the filename to write to. */
-		inline void draw_domain_gnuplot(const char* filename) {
-			FILE *fp(safe_fopen(filename,"w"));
-			draw_domain_gnuplot(fp);
-			fclose(fp);
-		}
-		void draw_domain_gnuplot(FILE *fp=stdout);
-		/** Draws an outline of the domain in Gnuplot format.
-		 * \param[in] filename the filename to write to. */
-		inline void draw_domain_pov(const char* filename) {
-			FILE *fp(safe_fopen(filename,"w"));
-			draw_domain_pov(fp);
-			fclose(fp);
-		}
-		void draw_domain_pov(FILE *fp=stdout);
-		bool intersects_image(double dx,double dy,double dz,double &vol);
-		void images(std::vector<int> &vi,std::vector<double> &vd);
-	protected:
-		/** The maximum y-coordinate that could possibly cut the
-		 * computed unit Voronoi cell. */
-		double max_uv_y;
-		/** The maximum z-coordinate that could possibly cut the
-		 * computed unit Voronoi cell. */
-		double max_uv_z;
-	private:
-		inline void unit_voro_apply(int i,int j,int k);
-		bool unit_voro_intersect(int l);
-		inline bool unit_voro_test(int i,int j,int k);
+    public:
+        /** The x coordinate of the first vector defining the periodic
+         * domain. */
+        const double bx;
+        /** The x coordinate of the second vector defining the periodic
+         * domain. */
+        const double bxy;
+        /** The y coordinate of the second vector defining the periodic
+         * domain. */
+        const double by;
+        /** The x coordinate of the third vector defining the periodic
+         * domain. */
+        const double bxz;
+        /** The y coordinate of the third vector defining the periodic
+         * domain. */
+        const double byz;
+        /** The z coordinate of the third vector defining the periodic
+         * domain. */
+        const double bz;
+        /** The computed unit Voronoi cell corresponding the given
+         * 3D non-rectangular periodic domain geometry. */
+        voronoicell unit_voro;
+        unitcell(double bx_,double bxy_,double by_,double bxz_,double byz_,double bz_);
+        bool intersects_image(double dx,double dy,double dz,double &vol);
+        void images(std::vector<int> &vi,std::vector<double> &vd);
+    protected:
+        /** The maximum y-coordinate that could possibly cut the
+         * computed unit Voronoi cell. */
+        double max_uv_y;
+        /** The maximum z-coordinate that could possibly cut the
+         * computed unit Voronoi cell. */
+        double max_uv_z;
+    private:
+        inline void unit_voro_apply(int i,int j,int k);
+        bool unit_voro_intersect(int l);
+        inline bool unit_voro_test(int i,int j,int k);
 };
 
 }

--- a/SKIRT/voro/v_compute.cc
+++ b/SKIRT/voro/v_compute.cc
@@ -21,13 +21,13 @@ namespace voro {
  * \param[in] (hx_,hy_,hz_) the size of the mask to use. */
 template<class c_class>
 voro_compute<c_class>::voro_compute(c_class &con_,int hx_,int hy_,int hz_) :
-	con(con_), boxx(con_.boxx), boxy(con_.boxy), boxz(con_.boxz),
-	xsp(con_.xsp), ysp(con_.ysp), zsp(con_.zsp),
-	hx(hx_), hy(hy_), hz(hz_), hxy(hx_*hy_), hxyz(hxy*hz_), ps(con_.ps),
-	id(con_.id), p(con_.p), co(con_.co), bxsq(boxx*boxx+boxy*boxy+boxz*boxz),
-	mv(0), qu_size(3*(3+hxy+hz*(hx+hy))), wl(con_.wl), mrad(con_.mrad),
-	mask(new unsigned int[hxyz]), qu(new int[qu_size]), qu_l(qu+qu_size) {
-	reset_mask();
+    con(con_), boxx(con_.boxx), boxy(con_.boxy), boxz(con_.boxz),
+    xsp(con_.xsp), ysp(con_.ysp), zsp(con_.zsp),
+    hx(hx_), hy(hy_), hz(hz_), hxy(hx_*hy_), hxyz(hxy*hz_), ps(con_.ps),
+    id(con_.id), p(con_.p), co(con_.co), bxsq(boxx*boxx+boxy*boxy+boxz*boxz),
+    mv(0), qu_size(3*(3+hxy+hz*(hx+hy))), wl(con_.wl), mrad(con_.mrad),
+    mask(new unsigned int[hxyz]), qu(new int[qu_size]), qu_l(qu+qu_size) {
+    reset_mask();
 }
 
 /** Scans all of the particles within a block to see if any of them have a
@@ -45,15 +45,15 @@ voro_compute<c_class>::voro_compute(c_class &con_,int hx_,int hy_,int hz_) :
  * 		      closer particle is found. */
 template<class c_class>
 inline void voro_compute<c_class>::scan_all(int ijk,double x,double y,double z,int di,int dj,int dk,particle_record &w,double &mrs) {
-	double x1,y1,z1,rs;bool in_block=false;
-	for(int l=0;l<co[ijk];l++) {
-		x1=p[ijk][ps*l]-x;
-		y1=p[ijk][ps*l+1]-y;
-		z1=p[ijk][ps*l+2]-z;
-		rs=con.r_current_sub(x1*x1+y1*y1+z1*z1,ijk,l);
-		if(rs<mrs) {mrs=rs;w.l=l;in_block=true;}
-	}
-	if(in_block) {w.ijk=ijk;w.di=di;w.dj=dj,w.dk=dk;}
+    double x1,y1,z1,rs;bool in_block=false;
+    for(int l=0;l<co[ijk];l++) {
+        x1=p[ijk][ps*l]-x;
+        y1=p[ijk][ps*l+1]-y;
+        z1=p[ijk][ps*l+2]-z;
+        rs=con.r_current_sub(x1*x1+y1*y1+z1*z1,ijk,l);
+        if(rs<mrs) {mrs=rs;w.l=l;in_block=true;}
+    }
+    if(in_block) {w.ijk=ijk;w.di=di;w.dj=dj,w.dk=dk;}
 }
 
 /** Finds the Voronoi cell that given vector is within. For containers that are
@@ -69,162 +69,162 @@ inline void voro_compute<c_class>::scan_all(int ijk,double x,double y,double z,i
  * \param[out] mrs the minimum computed distance. */
 template<class c_class>
 void voro_compute<c_class>::find_voronoi_cell(double x,double y,double z,int ci,int cj,int ck,int ijk,particle_record &w,double &mrs) {
-	double qx=0,qy=0,qz=0,rs;
-	int i,j,k,di,dj,dk,ei,ej,ek,f,g,disp;
-	double fx,fy,fz,mxs,mys,mzs,*radp;
-	unsigned int q,*e,*mijk;
+    double qx=0,qy=0,qz=0,rs;
+    int i,j,k,di,dj,dk,ei,ej,ek,f,g,disp;
+    double fx,fy,fz,mxs,mys,mzs,*radp;
+    unsigned int q,*e,*mijk;
 
-	// Init setup for parameters to return
-	w.ijk=-1;mrs=large_number;
+    // Init setup for parameters to return
+    w.ijk=-1;mrs=large_number;
 
-	con.initialize_search(ci,cj,ck,ijk,i,j,k,disp);
+    con.initialize_search(ci,cj,ck,ijk,i,j,k,disp);
 
-	// Test all particles in the particle's local region first
-	scan_all(ijk,x,y,z,0,0,0,w,mrs);
+    // Test all particles in the particle's local region first
+    scan_all(ijk,x,y,z,0,0,0,w,mrs);
 
-	// Now compute the fractional position of the particle within its
-	// region and store it in (fx,fy,fz). We use this to compute an index
-	// (di,dj,dk) of which subregion the particle is within.
-	unsigned int m1,m2;
-	con.frac_pos(x,y,z,ci,cj,ck,fx,fy,fz);
-	di=int(fx*xsp*wl_fgrid);dj=int(fy*ysp*wl_fgrid);dk=int(fz*zsp*wl_fgrid);
+    // Now compute the fractional position of the particle within its
+    // region and store it in (fx,fy,fz). We use this to compute an index
+    // (di,dj,dk) of which subregion the particle is within.
+    unsigned int m1,m2;
+    con.frac_pos(x,y,z,ci,cj,ck,fx,fy,fz);
+    di=int(fx*xsp*wl_fgrid);dj=int(fy*ysp*wl_fgrid);dk=int(fz*zsp*wl_fgrid);
 
-	// The indices (di,dj,dk) tell us which worklist to use, to test the
-	// blocks in the optimal order. But we only store worklists for the
-	// eighth of the region where di, dj, and dk are all less than half the
-	// full grid. The rest of the cases are handled by symmetry. In this
-	// section, we detect for these cases, by reflecting high values of di,
-	// dj, and dk. For these cases, a mask is constructed in m1 and m2
-	// which is used to flip the worklist information when it is loaded.
-	if(di>=wl_hgrid) {
-		mxs=boxx-fx;
-		m1=127+(3<<21);m2=1+(1<<21);di=wl_fgrid-1-di;if(di<0) di=0;
-	} else {m1=m2=0;mxs=fx;}
-	if(dj>=wl_hgrid) {
-		mys=boxy-fy;
-		m1|=(127<<7)+(3<<24);m2|=(1<<7)+(1<<24);dj=wl_fgrid-1-dj;if(dj<0) dj=0;
-	} else mys=fy;
-	if(dk>=wl_hgrid) {
-		mzs=boxz-fz;
-		m1|=(127<<14)+(3<<27);m2|=(1<<14)+(1<<27);dk=wl_fgrid-1-dk;if(dk<0) dk=0;
-	} else mzs=fz;
+    // The indices (di,dj,dk) tell us which worklist to use, to test the
+    // blocks in the optimal order. But we only store worklists for the
+    // eighth of the region where di, dj, and dk are all less than half the
+    // full grid. The rest of the cases are handled by symmetry. In this
+    // section, we detect for these cases, by reflecting high values of di,
+    // dj, and dk. For these cases, a mask is constructed in m1 and m2
+    // which is used to flip the worklist information when it is loaded.
+    if(di>=wl_hgrid) {
+        mxs=boxx-fx;
+        m1=127+(3<<21);m2=1+(1<<21);di=wl_fgrid-1-di;if(di<0) di=0;
+    } else {m1=m2=0;mxs=fx;}
+    if(dj>=wl_hgrid) {
+        mys=boxy-fy;
+        m1|=(127<<7)+(3<<24);m2|=(1<<7)+(1<<24);dj=wl_fgrid-1-dj;if(dj<0) dj=0;
+    } else mys=fy;
+    if(dk>=wl_hgrid) {
+        mzs=boxz-fz;
+        m1|=(127<<14)+(3<<27);m2|=(1<<14)+(1<<27);dk=wl_fgrid-1-dk;if(dk<0) dk=0;
+    } else mzs=fz;
 
-	// Do a quick test to account for the case when the minimum radius is
-	// small enought that no other blocks need to be considered
-	rs=con.r_max_add(mrs);
-	if(mxs*mxs>rs&&mys*mys>rs&&mzs*mzs>rs) return;
+    // Do a quick test to account for the case when the minimum radius is
+    // small enought that no other blocks need to be considered
+    rs=con.r_max_add(mrs);
+    if(mxs*mxs>rs&&mys*mys>rs&&mzs*mzs>rs) return;
 
-	// Now compute which worklist we are going to use, and set radp and e to
-	// point at the right offsets
-	ijk=di+wl_hgrid*(dj+wl_hgrid*dk);
-	radp=mrad+ijk*wl_seq_length;
-	e=(const_cast<unsigned int*> (wl))+ijk*wl_seq_length;
+    // Now compute which worklist we are going to use, and set radp and e to
+    // point at the right offsets
+    ijk=di+wl_hgrid*(dj+wl_hgrid*dk);
+    radp=mrad+ijk*wl_seq_length;
+    e=(const_cast<unsigned int*> (wl))+ijk*wl_seq_length;
 
-	// Read in how many items in the worklist can be tested without having to
-	// worry about writing to the mask
-	f=e[0];g=0;
-	do {
+    // Read in how many items in the worklist can be tested without having to
+    // worry about writing to the mask
+    f=e[0];g=0;
+    do {
 
-		// If mrs is less than the minimum distance to any untested
-		// block, then we are done
-		if(con.r_max_add(mrs)<radp[g]) return;
-		g++;
+        // If mrs is less than the minimum distance to any untested
+        // block, then we are done
+        if(con.r_max_add(mrs)<radp[g]) return;
+        g++;
 
-		// Load in a block off the worklist, permute it with the
-		// symmetry mask, and decode its position. These are all
-		// integer bit operations so they should run very fast.
-		q=e[g];q^=m1;q+=m2;
-		di=q&127;di-=64;
-		dj=(q>>7)&127;dj-=64;
-		dk=(q>>14)&127;dk-=64;
+        // Load in a block off the worklist, permute it with the
+        // symmetry mask, and decode its position. These are all
+        // integer bit operations so they should run very fast.
+        q=e[g];q^=m1;q+=m2;
+        di=q&127;di-=64;
+        dj=(q>>7)&127;dj-=64;
+        dk=(q>>14)&127;dk-=64;
 
-		// Check that the worklist position is in range
-		ei=di+i;if(ei<0||ei>=hx) continue;
-		ej=dj+j;if(ej<0||ej>=hy) continue;
-		ek=dk+k;if(ek<0||ek>=hz) continue;
+        // Check that the worklist position is in range
+        ei=di+i;if(ei<0||ei>=hx) continue;
+        ej=dj+j;if(ej<0||ej>=hy) continue;
+        ek=dk+k;if(ek<0||ek>=hz) continue;
 
-		// Call the compute_min_max_radius() function. This returns
-		// true if the minimum distance to the block is bigger than the
-		// current mrs, in which case we skip this block and move on.
-		// Otherwise, it computes the maximum distance to the block and
-		// returns it in crs.
-		if(compute_min_radius(di,dj,dk,fx,fy,fz,mrs)) continue;
+        // Call the compute_min_max_radius() function. This returns
+        // true if the minimum distance to the block is bigger than the
+        // current mrs, in which case we skip this block and move on.
+        // Otherwise, it computes the maximum distance to the block and
+        // returns it in crs.
+        if(compute_min_radius(di,dj,dk,fx,fy,fz,mrs)) continue;
 
-		// Now compute which region we are going to loop over, adding a
-		// displacement for the periodic cases
-		ijk=con.region_index(ci,cj,ck,ei,ej,ek,qx,qy,qz,disp);
+        // Now compute which region we are going to loop over, adding a
+        // displacement for the periodic cases
+        ijk=con.region_index(ci,cj,ck,ei,ej,ek,qx,qy,qz,disp);
 
-		// If mrs is bigger than the maximum distance to the block,
-		// then we have to test all particles in the block for
-		// intersections. Otherwise, we do additional checks and skip
-		// those particles which can't possibly intersect the block.
-		scan_all(ijk,x-qx,y-qy,z-qz,di,dj,dk,w,mrs);
-	} while(g<f);
+        // If mrs is bigger than the maximum distance to the block,
+        // then we have to test all particles in the block for
+        // intersections. Otherwise, we do additional checks and skip
+        // those particles which can't possibly intersect the block.
+        scan_all(ijk,x-qx,y-qy,z-qz,di,dj,dk,w,mrs);
+    } while(g<f);
 
-	// Update mask value and initialize queue
-	mv++;
-	if(mv==0) {reset_mask();mv=1;}
-	int *qu_s=qu,*qu_e=qu;
+    // Update mask value and initialize queue
+    mv++;
+    if(mv==0) {reset_mask();mv=1;}
+    int *qu_s=qu,*qu_e=qu;
 
-	while(g<wl_seq_length-1) {
+    while(g<wl_seq_length-1) {
 
-		// If mrs is less than the minimum distance to any untested
-		// block, then we are done
-		if(con.r_max_add(mrs)<radp[g]) return;
-		g++;
+        // If mrs is less than the minimum distance to any untested
+        // block, then we are done
+        if(con.r_max_add(mrs)<radp[g]) return;
+        g++;
 
-		// Load in a block off the worklist, permute it with the
-		// symmetry mask, and decode its position. These are all
-		// integer bit operations so they should run very fast.
-		q=e[g];q^=m1;q+=m2;
-		di=q&127;di-=64;
-		dj=(q>>7)&127;dj-=64;
-		dk=(q>>14)&127;dk-=64;
+        // Load in a block off the worklist, permute it with the
+        // symmetry mask, and decode its position. These are all
+        // integer bit operations so they should run very fast.
+        q=e[g];q^=m1;q+=m2;
+        di=q&127;di-=64;
+        dj=(q>>7)&127;dj-=64;
+        dk=(q>>14)&127;dk-=64;
 
-		// Compute the position in the mask of the current block. If
-		// this lies outside the mask, then skip it. Otherwise, mark
-		// it.
-		ei=di+i;if(ei<0||ei>=hx) continue;
-		ej=dj+j;if(ej<0||ej>=hy) continue;
-		ek=dk+k;if(ek<0||ek>=hz) continue;
-		mijk=mask+ei+hx*(ej+hy*ek);
-		*mijk=mv;
+        // Compute the position in the mask of the current block. If
+        // this lies outside the mask, then skip it. Otherwise, mark
+        // it.
+        ei=di+i;if(ei<0||ei>=hx) continue;
+        ej=dj+j;if(ej<0||ej>=hy) continue;
+        ek=dk+k;if(ek<0||ek>=hz) continue;
+        mijk=mask+ei+hx*(ej+hy*ek);
+        *mijk=mv;
 
-		// Skip this block if it is further away than the current
-		// minimum radius
-		if(compute_min_radius(di,dj,dk,fx,fy,fz,mrs)) continue;
+        // Skip this block if it is further away than the current
+        // minimum radius
+        if(compute_min_radius(di,dj,dk,fx,fy,fz,mrs)) continue;
 
-		// Now compute which region we are going to loop over, adding a
-		// displacement for the periodic cases
-		ijk=con.region_index(ci,cj,ck,ei,ej,ek,qx,qy,qz,disp);
-		scan_all(ijk,x-qx,y-qy,z-qz,di,dj,dk,w,mrs);
+        // Now compute which region we are going to loop over, adding a
+        // displacement for the periodic cases
+        ijk=con.region_index(ci,cj,ck,ei,ej,ek,qx,qy,qz,disp);
+        scan_all(ijk,x-qx,y-qy,z-qz,di,dj,dk,w,mrs);
 
-		if(qu_e>qu_l-18) add_list_memory(qu_s,qu_e);
-		scan_bits_mask_add(q,mijk,ei,ej,ek,qu_e);
-	}
+        if(qu_e>qu_l-18) add_list_memory(qu_s,qu_e);
+        scan_bits_mask_add(q,mijk,ei,ej,ek,qu_e);
+    }
 
-	// Do a check to see if we've reached the radius cutoff
-	if(con.r_max_add(mrs)<radp[g]) return;
+    // Do a check to see if we've reached the radius cutoff
+    if(con.r_max_add(mrs)<radp[g]) return;
 
-	// We were unable to completely compute the cell based on the blocks in
-	// the worklist, so now we have to go block by block, reading in items
-	// off the list
-	while(qu_s!=qu_e) {
+    // We were unable to completely compute the cell based on the blocks in
+    // the worklist, so now we have to go block by block, reading in items
+    // off the list
+    while(qu_s!=qu_e) {
 
-		// Read the next entry of the queue
-		if(qu_s==qu_l) qu_s=qu;
-		ei=*(qu_s++);ej=*(qu_s++);ek=*(qu_s++);
-		di=ei-i;dj=ej-j;dk=ek-k;
-		if(compute_min_radius(di,dj,dk,fx,fy,fz,mrs)) continue;
+        // Read the next entry of the queue
+        if(qu_s==qu_l) qu_s=qu;
+        ei=*(qu_s++);ej=*(qu_s++);ek=*(qu_s++);
+        di=ei-i;dj=ej-j;dk=ek-k;
+        if(compute_min_radius(di,dj,dk,fx,fy,fz,mrs)) continue;
 
-		ijk=con.region_index(ci,cj,ck,ei,ej,ek,qx,qy,qz,disp);
-		scan_all(ijk,x-qx,y-qy,z-qz,di,dj,dk,w,mrs);
+        ijk=con.region_index(ci,cj,ck,ei,ej,ek,qx,qy,qz,disp);
+        scan_all(ijk,x-qx,y-qy,z-qz,di,dj,dk,w,mrs);
 
-		// Test the neighbors of the current block, and add them to the
-		// block list if they haven't already been tested
-		if((qu_s<=qu_e?(qu_l-qu_e)+(qu_s-qu):qu_s-qu_e)<18) add_list_memory(qu_s,qu_e);
-		add_to_mask(ei,ej,ek,qu_e);
-	}
+        // Test the neighbors of the current block, and add them to the
+        // block list if they haven't already been tested
+        if((qu_s<=qu_e?(qu_l-qu_e)+(qu_s-qu):qu_s-qu_e)<18) add_list_memory(qu_s,qu_e);
+        add_to_mask(ei,ej,ek,qu_e);
+    }
 }
 
 /** Scans the six orthogonal neighbors of a given block and adds them to the
@@ -234,13 +234,13 @@ void voro_compute<c_class>::find_voronoi_cell(double x,double y,double z,int ci,
  * \param[in,out] qu_e a pointer to the end of the queue. */
 template<class c_class>
 inline void voro_compute<c_class>::add_to_mask(int ei,int ej,int ek,int *&qu_e) {
-	unsigned int *mijk=mask+ei+hx*(ej+hy*ek);
-	if(ek>0) if(*(mijk-hxy)!=mv) {if(qu_e==qu_l) qu_e=qu;*(mijk-hxy)=mv;*(qu_e++)=ei;*(qu_e++)=ej;*(qu_e++)=ek-1;}
-	if(ej>0) if(*(mijk-hx)!=mv) {if(qu_e==qu_l) qu_e=qu;*(mijk-hx)=mv;*(qu_e++)=ei;*(qu_e++)=ej-1;*(qu_e++)=ek;}
-	if(ei>0) if(*(mijk-1)!=mv) {if(qu_e==qu_l) qu_e=qu;*(mijk-1)=mv;*(qu_e++)=ei-1;*(qu_e++)=ej;*(qu_e++)=ek;}
-	if(ei<hx-1) if(*(mijk+1)!=mv) {if(qu_e==qu_l) qu_e=qu;*(mijk+1)=mv;*(qu_e++)=ei+1;*(qu_e++)=ej;*(qu_e++)=ek;}
-	if(ej<hy-1) if(*(mijk+hx)!=mv) {if(qu_e==qu_l) qu_e=qu;*(mijk+hx)=mv;*(qu_e++)=ei;*(qu_e++)=ej+1;*(qu_e++)=ek;}
-	if(ek<hz-1) if(*(mijk+hxy)!=mv) {if(qu_e==qu_l) qu_e=qu;*(mijk+hxy)=mv;*(qu_e++)=ei;*(qu_e++)=ej;*(qu_e++)=ek+1;}
+    unsigned int *mijk=mask+ei+hx*(ej+hy*ek);
+    if(ek>0) if(*(mijk-hxy)!=mv) {if(qu_e==qu_l) qu_e=qu;*(mijk-hxy)=mv;*(qu_e++)=ei;*(qu_e++)=ej;*(qu_e++)=ek-1;}
+    if(ej>0) if(*(mijk-hx)!=mv) {if(qu_e==qu_l) qu_e=qu;*(mijk-hx)=mv;*(qu_e++)=ei;*(qu_e++)=ej-1;*(qu_e++)=ek;}
+    if(ei>0) if(*(mijk-1)!=mv) {if(qu_e==qu_l) qu_e=qu;*(mijk-1)=mv;*(qu_e++)=ei-1;*(qu_e++)=ej;*(qu_e++)=ek;}
+    if(ei<hx-1) if(*(mijk+1)!=mv) {if(qu_e==qu_l) qu_e=qu;*(mijk+1)=mv;*(qu_e++)=ei+1;*(qu_e++)=ej;*(qu_e++)=ek;}
+    if(ej<hy-1) if(*(mijk+hx)!=mv) {if(qu_e==qu_l) qu_e=qu;*(mijk+hx)=mv;*(qu_e++)=ei;*(qu_e++)=ej+1;*(qu_e++)=ek;}
+    if(ek<hz-1) if(*(mijk+hxy)!=mv) {if(qu_e==qu_l) qu_e=qu;*(mijk+hxy)=mv;*(qu_e++)=ei;*(qu_e++)=ej;*(qu_e++)=ek+1;}
 }
 
 /** Scans a worklist entry and adds any blocks to the queue
@@ -248,25 +248,25 @@ inline void voro_compute<c_class>::add_to_mask(int ei,int ej,int ek,int *&qu_e) 
  * \param[in,out] qu_e a pointer to the end of the queue. */
 template<class c_class>
 inline void voro_compute<c_class>::scan_bits_mask_add(unsigned int q,unsigned int *mijk,int ei,int ej,int ek,int *&qu_e) {
-	const unsigned int b1=1<<21,b2=1<<22,b3=1<<24,b4=1<<25,b5=1<<27,b6=1<<28;
-	if((q&b2)==b2) {
-		if(ei>0) {*(mijk-1)=mv;*(qu_e++)=ei-1;*(qu_e++)=ej;*(qu_e++)=ek;}
-		if((q&b1)==0&&ei<hx-1) {*(mijk+1)=mv;*(qu_e++)=ei+1;*(qu_e++)=ej;*(qu_e++)=ek;}
-	} else if((q&b1)==b1&&ei<hx-1) {*(mijk+1)=mv;*(qu_e++)=ei+1;*(qu_e++)=ej;*(qu_e++)=ek;}
-	if((q&b4)==b4) {
-		if(ej>0) {*(mijk-hx)=mv;*(qu_e++)=ei;*(qu_e++)=ej-1;*(qu_e++)=ek;}
-		if((q&b3)==0&&ej<hy-1) {*(mijk+hx)=mv;*(qu_e++)=ei;*(qu_e++)=ej+1;*(qu_e++)=ek;}
-	} else if((q&b3)==b3&&ej<hy-1) {*(mijk+hx)=mv;*(qu_e++)=ei;*(qu_e++)=ej+1;*(qu_e++)=ek;}
-	if((q&b6)==b6) {
-		if(ek>0) {*(mijk-hxy)=mv;*(qu_e++)=ei;*(qu_e++)=ej;*(qu_e++)=ek-1;}
-		if((q&b5)==0&&ek<hz-1) {*(mijk+hxy)=mv;*(qu_e++)=ei;*(qu_e++)=ej;*(qu_e++)=ek+1;}
-	} else if((q&b5)==b5&&ek<hz-1) {*(mijk+hxy)=mv;*(qu_e++)=ei;*(qu_e++)=ej;*(qu_e++)=ek+1;}
+    const unsigned int b1=1<<21,b2=1<<22,b3=1<<24,b4=1<<25,b5=1<<27,b6=1<<28;
+    if((q&b2)==b2) {
+        if(ei>0) {*(mijk-1)=mv;*(qu_e++)=ei-1;*(qu_e++)=ej;*(qu_e++)=ek;}
+        if((q&b1)==0&&ei<hx-1) {*(mijk+1)=mv;*(qu_e++)=ei+1;*(qu_e++)=ej;*(qu_e++)=ek;}
+    } else if((q&b1)==b1&&ei<hx-1) {*(mijk+1)=mv;*(qu_e++)=ei+1;*(qu_e++)=ej;*(qu_e++)=ek;}
+    if((q&b4)==b4) {
+        if(ej>0) {*(mijk-hx)=mv;*(qu_e++)=ei;*(qu_e++)=ej-1;*(qu_e++)=ek;}
+        if((q&b3)==0&&ej<hy-1) {*(mijk+hx)=mv;*(qu_e++)=ei;*(qu_e++)=ej+1;*(qu_e++)=ek;}
+    } else if((q&b3)==b3&&ej<hy-1) {*(mijk+hx)=mv;*(qu_e++)=ei;*(qu_e++)=ej+1;*(qu_e++)=ek;}
+    if((q&b6)==b6) {
+        if(ek>0) {*(mijk-hxy)=mv;*(qu_e++)=ei;*(qu_e++)=ej;*(qu_e++)=ek-1;}
+        if((q&b5)==0&&ek<hz-1) {*(mijk+hxy)=mv;*(qu_e++)=ei;*(qu_e++)=ej;*(qu_e++)=ek+1;}
+    } else if((q&b5)==b5&&ek<hz-1) {*(mijk+hxy)=mv;*(qu_e++)=ei;*(qu_e++)=ej;*(qu_e++)=ek+1;}
 }
 
 /** This routine computes a Voronoi cell for a single particle in the
  * container. It can be called by the user, but is also forms the core part of
- * several of the main functions, such as store_cell_volumes(), print_all(),
- * and the drawing routines. The algorithm constructs the cell by testing over
+ * several of the main functions, such as store_cell_volumes().
+ * The algorithm constructs the cell by testing over
  * the neighbors of the particle, working outwards until it reaches those
  * particles which could not possibly intersect the cell. For maximum
  * efficiency, this algorithm is divided into three parts. In the first
@@ -289,335 +289,335 @@ inline void voro_compute<c_class>::scan_bits_mask_add(unsigned int q,unsigned in
 template<class c_class>
 template<class v_cell>
 bool voro_compute<c_class>::compute_cell(v_cell &c,int ijk,int s,int ci,int cj,int ck) {
-	static const int count_list[8]={7,11,15,19,26,35,45,59},*count_e=count_list+8;
-	double x,y,z,x1,y1,z1,qx=0,qy=0,qz=0;
-	double xlo,ylo,zlo,xhi,yhi,zhi,x2,y2,z2,rs;
-	int i,j,k,di,dj,dk,ei,ej,ek,f,g,l,disp;
-	double fx,fy,fz,gxs,gys,gzs,*radp;
-	unsigned int q,*e,*mijk;
+    static const int count_list[8]={7,11,15,19,26,35,45,59},*count_e=count_list+8;
+    double x,y,z,x1,y1,z1,qx=0,qy=0,qz=0;
+    double xlo,ylo,zlo,xhi,yhi,zhi,x2,y2,z2,rs;
+    int i,j,k,di,dj,dk,ei,ej,ek,f,g,l,disp;
+    double fx,fy,fz,gxs,gys,gzs,*radp;
+    unsigned int q,*e,*mijk;
 
-	if(!con.initialize_voronoicell(c,ijk,s,ci,cj,ck,i,j,k,x,y,z,disp)) return false;
-	con.r_init(ijk,s);
+    if(!con.initialize_voronoicell(c,ijk,s,ci,cj,ck,i,j,k,x,y,z,disp)) return false;
+    con.r_init(ijk,s);
 
-	// Initialize the Voronoi cell to fill the entire container
-	double crs,mrs;
+    // Initialize the Voronoi cell to fill the entire container
+    double crs,mrs;
 
-	int next_count=3,*count_p=(const_cast<int*> (count_list));
+    int next_count=3,*count_p=(const_cast<int*> (count_list));
 
-	// Test all particles in the particle's local region first
-	for(l=0;l<s;l++) {
-		x1=p[ijk][ps*l]-x;
-		y1=p[ijk][ps*l+1]-y;
-		z1=p[ijk][ps*l+2]-z;
-		rs=con.r_scale(x1*x1+y1*y1+z1*z1,ijk,l);
-		if(!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
-	}
-	l++;
-	while(l<co[ijk]) {
-		x1=p[ijk][ps*l]-x;
-		y1=p[ijk][ps*l+1]-y;
-		z1=p[ijk][ps*l+2]-z;
-		rs=con.r_scale(x1*x1+y1*y1+z1*z1,ijk,l);
-		if(!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
-		l++;
-	}
+    // Test all particles in the particle's local region first
+    for(l=0;l<s;l++) {
+        x1=p[ijk][ps*l]-x;
+        y1=p[ijk][ps*l+1]-y;
+        z1=p[ijk][ps*l+2]-z;
+        rs=con.r_scale(x1*x1+y1*y1+z1*z1,ijk,l);
+        if(!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
+    }
+    l++;
+    while(l<co[ijk]) {
+        x1=p[ijk][ps*l]-x;
+        y1=p[ijk][ps*l+1]-y;
+        z1=p[ijk][ps*l+2]-z;
+        rs=con.r_scale(x1*x1+y1*y1+z1*z1,ijk,l);
+        if(!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
+        l++;
+    }
 
-	// Now compute the maximum distance squared from the cell center to a
-	// vertex. This is used to cut off the calculation since we only need
-	// to test out to twice this range.
-	mrs=c.max_radius_squared();
+    // Now compute the maximum distance squared from the cell center to a
+    // vertex. This is used to cut off the calculation since we only need
+    // to test out to twice this range.
+    mrs=c.max_radius_squared();
 
-	// Now compute the fractional position of the particle within its
-	// region and store it in (fx,fy,fz). We use this to compute an index
-	// (di,dj,dk) of which subregion the particle is within.
-	unsigned int m1,m2;
-	con.frac_pos(x,y,z,ci,cj,ck,fx,fy,fz);
-	di=int(fx*xsp*wl_fgrid);dj=int(fy*ysp*wl_fgrid);dk=int(fz*zsp*wl_fgrid);
+    // Now compute the fractional position of the particle within its
+    // region and store it in (fx,fy,fz). We use this to compute an index
+    // (di,dj,dk) of which subregion the particle is within.
+    unsigned int m1,m2;
+    con.frac_pos(x,y,z,ci,cj,ck,fx,fy,fz);
+    di=int(fx*xsp*wl_fgrid);dj=int(fy*ysp*wl_fgrid);dk=int(fz*zsp*wl_fgrid);
 
-	// The indices (di,dj,dk) tell us which worklist to use, to test the
-	// blocks in the optimal order. But we only store worklists for the
-	// eighth of the region where di, dj, and dk are all less than half the
-	// full grid. The rest of the cases are handled by symmetry. In this
-	// section, we detect for these cases, by reflecting high values of di,
-	// dj, and dk. For these cases, a mask is constructed in m1 and m2
-	// which is used to flip the worklist information when it is loaded.
-	if(di>=wl_hgrid) {
-		gxs=fx;
-		m1=127+(3<<21);m2=1+(1<<21);di=wl_fgrid-1-di;if(di<0) di=0;
-	} else {m1=m2=0;gxs=boxx-fx;}
-	if(dj>=wl_hgrid) {
-		gys=fy;
-		m1|=(127<<7)+(3<<24);m2|=(1<<7)+(1<<24);dj=wl_fgrid-1-dj;if(dj<0) dj=0;
-	} else gys=boxy-fy;
-	if(dk>=wl_hgrid) {
-		gzs=fz;
-		m1|=(127<<14)+(3<<27);m2|=(1<<14)+(1<<27);dk=wl_fgrid-1-dk;if(dk<0) dk=0;
-	} else gzs=boxz-fz;
-	gxs*=gxs;gys*=gys;gzs*=gzs;
+    // The indices (di,dj,dk) tell us which worklist to use, to test the
+    // blocks in the optimal order. But we only store worklists for the
+    // eighth of the region where di, dj, and dk are all less than half the
+    // full grid. The rest of the cases are handled by symmetry. In this
+    // section, we detect for these cases, by reflecting high values of di,
+    // dj, and dk. For these cases, a mask is constructed in m1 and m2
+    // which is used to flip the worklist information when it is loaded.
+    if(di>=wl_hgrid) {
+        gxs=fx;
+        m1=127+(3<<21);m2=1+(1<<21);di=wl_fgrid-1-di;if(di<0) di=0;
+    } else {m1=m2=0;gxs=boxx-fx;}
+    if(dj>=wl_hgrid) {
+        gys=fy;
+        m1|=(127<<7)+(3<<24);m2|=(1<<7)+(1<<24);dj=wl_fgrid-1-dj;if(dj<0) dj=0;
+    } else gys=boxy-fy;
+    if(dk>=wl_hgrid) {
+        gzs=fz;
+        m1|=(127<<14)+(3<<27);m2|=(1<<14)+(1<<27);dk=wl_fgrid-1-dk;if(dk<0) dk=0;
+    } else gzs=boxz-fz;
+    gxs*=gxs;gys*=gys;gzs*=gzs;
 
-	// Now compute which worklist we are going to use, and set radp and e to
-	// point at the right offsets
-	ijk=di+wl_hgrid*(dj+wl_hgrid*dk);
-	radp=mrad+ijk*wl_seq_length;
-	e=(const_cast<unsigned int*> (wl))+ijk*wl_seq_length;
+    // Now compute which worklist we are going to use, and set radp and e to
+    // point at the right offsets
+    ijk=di+wl_hgrid*(dj+wl_hgrid*dk);
+    radp=mrad+ijk*wl_seq_length;
+    e=(const_cast<unsigned int*> (wl))+ijk*wl_seq_length;
 
-	// Read in how many items in the worklist can be tested without having to
-	// worry about writing to the mask
-	f=e[0];g=0;
-	do {
+    // Read in how many items in the worklist can be tested without having to
+    // worry about writing to the mask
+    f=e[0];g=0;
+    do {
 
-		// At the intervals specified by count_list, we recompute the
-		// maximum radius squared
-		if(g==next_count) {
-			mrs=c.max_radius_squared();
-			if(count_p!=count_e) next_count=*(count_p++);
-		}
+        // At the intervals specified by count_list, we recompute the
+        // maximum radius squared
+        if(g==next_count) {
+            mrs=c.max_radius_squared();
+            if(count_p!=count_e) next_count=*(count_p++);
+        }
 
-		// If mrs is less than the minimum distance to any untested
-		// block, then we are done
-		if(con.r_ctest(radp[g],mrs)) return true;
-		g++;
+        // If mrs is less than the minimum distance to any untested
+        // block, then we are done
+        if(con.r_ctest(radp[g],mrs)) return true;
+        g++;
 
-		// Load in a block off the worklist, permute it with the
-		// symmetry mask, and decode its position. These are all
-		// integer bit operations so they should run very fast.
-		q=e[g];q^=m1;q+=m2;
-		di=q&127;di-=64;
-		dj=(q>>7)&127;dj-=64;
-		dk=(q>>14)&127;dk-=64;
+        // Load in a block off the worklist, permute it with the
+        // symmetry mask, and decode its position. These are all
+        // integer bit operations so they should run very fast.
+        q=e[g];q^=m1;q+=m2;
+        di=q&127;di-=64;
+        dj=(q>>7)&127;dj-=64;
+        dk=(q>>14)&127;dk-=64;
 
-		// Check that the worklist position is in range
-		ei=di+i;if(ei<0||ei>=hx) continue;
-		ej=dj+j;if(ej<0||ej>=hy) continue;
-		ek=dk+k;if(ek<0||ek>=hz) continue;
+        // Check that the worklist position is in range
+        ei=di+i;if(ei<0||ei>=hx) continue;
+        ej=dj+j;if(ej<0||ej>=hy) continue;
+        ek=dk+k;if(ek<0||ek>=hz) continue;
 
-		// Call the compute_min_max_radius() function. This returns
-		// true if the minimum distance to the block is bigger than the
-		// current mrs, in which case we skip this block and move on.
-		// Otherwise, it computes the maximum distance to the block and
-		// returns it in crs.
-		if(compute_min_max_radius(di,dj,dk,fx,fy,fz,gxs,gys,gzs,crs,mrs)) continue;
+        // Call the compute_min_max_radius() function. This returns
+        // true if the minimum distance to the block is bigger than the
+        // current mrs, in which case we skip this block and move on.
+        // Otherwise, it computes the maximum distance to the block and
+        // returns it in crs.
+        if(compute_min_max_radius(di,dj,dk,fx,fy,fz,gxs,gys,gzs,crs,mrs)) continue;
 
-		// Now compute which region we are going to loop over, adding a
-		// displacement for the periodic cases
-		ijk=con.region_index(ci,cj,ck,ei,ej,ek,qx,qy,qz,disp);
+        // Now compute which region we are going to loop over, adding a
+        // displacement for the periodic cases
+        ijk=con.region_index(ci,cj,ck,ei,ej,ek,qx,qy,qz,disp);
 
-		// If mrs is bigger than the maximum distance to the block,
-		// then we have to test all particles in the block for
-		// intersections. Otherwise, we do additional checks and skip
-		// those particles which can't possibly intersect the block.
-		if(co[ijk]>0) {
-			l=0;x2=x-qx;y2=y-qy;z2=z-qz;
-			if(!con.r_ctest(crs,mrs)) {
-				do {
-					x1=p[ijk][ps*l]-x2;
-					y1=p[ijk][ps*l+1]-y2;
-					z1=p[ijk][ps*l+2]-z2;
-					rs=con.r_scale(x1*x1+y1*y1+z1*z1,ijk,l);
-					if(!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
-					l++;
-				} while (l<co[ijk]);
-			} else {
-				do {
-					x1=p[ijk][ps*l]-x2;
-					y1=p[ijk][ps*l+1]-y2;
-					z1=p[ijk][ps*l+2]-z2;
-					rs=x1*x1+y1*y1+z1*z1;
-					if(con.r_scale_check(rs,mrs,ijk,l)&&!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
-					l++;
-				} while (l<co[ijk]);
-			}
-		}
-	} while(g<f);
+        // If mrs is bigger than the maximum distance to the block,
+        // then we have to test all particles in the block for
+        // intersections. Otherwise, we do additional checks and skip
+        // those particles which can't possibly intersect the block.
+        if(co[ijk]>0) {
+            l=0;x2=x-qx;y2=y-qy;z2=z-qz;
+            if(!con.r_ctest(crs,mrs)) {
+                do {
+                    x1=p[ijk][ps*l]-x2;
+                    y1=p[ijk][ps*l+1]-y2;
+                    z1=p[ijk][ps*l+2]-z2;
+                    rs=con.r_scale(x1*x1+y1*y1+z1*z1,ijk,l);
+                    if(!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
+                    l++;
+                } while (l<co[ijk]);
+            } else {
+                do {
+                    x1=p[ijk][ps*l]-x2;
+                    y1=p[ijk][ps*l+1]-y2;
+                    z1=p[ijk][ps*l+2]-z2;
+                    rs=x1*x1+y1*y1+z1*z1;
+                    if(con.r_scale_check(rs,mrs,ijk,l)&&!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
+                    l++;
+                } while (l<co[ijk]);
+            }
+        }
+    } while(g<f);
 
-	// If we reach here, we were unable to compute the entire cell using
-	// the first part of the worklist. This section of the algorithm
-	// continues the worklist, but it now starts preparing the mask that we
-	// need if we end up going block by block. We do the same as before,
-	// but we put a mark down on the mask for every block that's tested.
-	// The worklist also contains information about which neighbors of each
-	// block are not also on the worklist, and we start storing those
-	// points in a list in case we have to go block by block. Update the
-	// mask counter, and if it wraps around then reset the whole mask; that
-	// will only happen once every 2^32 tries.
-	mv++;
-	if(mv==0) {reset_mask();mv=1;}
+    // If we reach here, we were unable to compute the entire cell using
+    // the first part of the worklist. This section of the algorithm
+    // continues the worklist, but it now starts preparing the mask that we
+    // need if we end up going block by block. We do the same as before,
+    // but we put a mark down on the mask for every block that's tested.
+    // The worklist also contains information about which neighbors of each
+    // block are not also on the worklist, and we start storing those
+    // points in a list in case we have to go block by block. Update the
+    // mask counter, and if it wraps around then reset the whole mask; that
+    // will only happen once every 2^32 tries.
+    mv++;
+    if(mv==0) {reset_mask();mv=1;}
 
-	// Set the queue pointers
-	int *qu_s=qu,*qu_e=qu;
+    // Set the queue pointers
+    int *qu_s=qu,*qu_e=qu;
 
-	while(g<wl_seq_length-1) {
+    while(g<wl_seq_length-1) {
 
-		// At the intervals specified by count_list, we recompute the
-		// maximum radius squared
-		if(g==next_count) {
-			mrs=c.max_radius_squared();
-			if(count_p!=count_e) next_count=*(count_p++);
-		}
+        // At the intervals specified by count_list, we recompute the
+        // maximum radius squared
+        if(g==next_count) {
+            mrs=c.max_radius_squared();
+            if(count_p!=count_e) next_count=*(count_p++);
+        }
 
-		// If mrs is less than the minimum distance to any untested
-		// block, then we are done
-		if(con.r_ctest(radp[g],mrs)) return true;
-		g++;
+        // If mrs is less than the minimum distance to any untested
+        // block, then we are done
+        if(con.r_ctest(radp[g],mrs)) return true;
+        g++;
 
-		// Load in a block off the worklist, permute it with the
-		// symmetry mask, and decode its position. These are all
-		// integer bit operations so they should run very fast.
-		q=e[g];q^=m1;q+=m2;
-		di=q&127;di-=64;
-		dj=(q>>7)&127;dj-=64;
-		dk=(q>>14)&127;dk-=64;
+        // Load in a block off the worklist, permute it with the
+        // symmetry mask, and decode its position. These are all
+        // integer bit operations so they should run very fast.
+        q=e[g];q^=m1;q+=m2;
+        di=q&127;di-=64;
+        dj=(q>>7)&127;dj-=64;
+        dk=(q>>14)&127;dk-=64;
 
-		// Compute the position in the mask of the current block. If
-		// this lies outside the mask, then skip it. Otherwise, mark
-		// it.
-		ei=di+i;if(ei<0||ei>=hx) continue;
-		ej=dj+j;if(ej<0||ej>=hy) continue;
-		ek=dk+k;if(ek<0||ek>=hz) continue;
-		mijk=mask+ei+hx*(ej+hy*ek);
-		*mijk=mv;
+        // Compute the position in the mask of the current block. If
+        // this lies outside the mask, then skip it. Otherwise, mark
+        // it.
+        ei=di+i;if(ei<0||ei>=hx) continue;
+        ej=dj+j;if(ej<0||ej>=hy) continue;
+        ek=dk+k;if(ek<0||ek>=hz) continue;
+        mijk=mask+ei+hx*(ej+hy*ek);
+        *mijk=mv;
 
-		// Call the compute_min_max_radius() function. This returns
-		// true if the minimum distance to the block is bigger than the
-		// current mrs, in which case we skip this block and move on.
-		// Otherwise, it computes the maximum distance to the block and
-		// returns it in crs.
-		if(compute_min_max_radius(di,dj,dk,fx,fy,fz,gxs,gys,gzs,crs,mrs)) continue;
+        // Call the compute_min_max_radius() function. This returns
+        // true if the minimum distance to the block is bigger than the
+        // current mrs, in which case we skip this block and move on.
+        // Otherwise, it computes the maximum distance to the block and
+        // returns it in crs.
+        if(compute_min_max_radius(di,dj,dk,fx,fy,fz,gxs,gys,gzs,crs,mrs)) continue;
 
-		// Now compute which region we are going to loop over, adding a
-		// displacement for the periodic cases
-		ijk=con.region_index(ci,cj,ck,ei,ej,ek,qx,qy,qz,disp);
+        // Now compute which region we are going to loop over, adding a
+        // displacement for the periodic cases
+        ijk=con.region_index(ci,cj,ck,ei,ej,ek,qx,qy,qz,disp);
 
-		// If mrs is bigger than the maximum distance to the block,
-		// then we have to test all particles in the block for
-		// intersections. Otherwise, we do additional checks and skip
-		// those particles which can't possibly intersect the block.
-		if(co[ijk]>0) {
-			l=0;x2=x-qx;y2=y-qy;z2=z-qz;
-			if(!con.r_ctest(crs,mrs)) {
-				do {
-					x1=p[ijk][ps*l]-x2;
-					y1=p[ijk][ps*l+1]-y2;
-					z1=p[ijk][ps*l+2]-z2;
-					rs=con.r_scale(x1*x1+y1*y1+z1*z1,ijk,l);
-					if(!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
-					l++;
-				} while (l<co[ijk]);
-			} else {
-				do {
-					x1=p[ijk][ps*l]-x2;
-					y1=p[ijk][ps*l+1]-y2;
-					z1=p[ijk][ps*l+2]-z2;
-					rs=x1*x1+y1*y1+z1*z1;
-					if(con.r_scale_check(rs,mrs,ijk,l)&&!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
-					l++;
-				} while (l<co[ijk]);
-			}
-		}
+        // If mrs is bigger than the maximum distance to the block,
+        // then we have to test all particles in the block for
+        // intersections. Otherwise, we do additional checks and skip
+        // those particles which can't possibly intersect the block.
+        if(co[ijk]>0) {
+            l=0;x2=x-qx;y2=y-qy;z2=z-qz;
+            if(!con.r_ctest(crs,mrs)) {
+                do {
+                    x1=p[ijk][ps*l]-x2;
+                    y1=p[ijk][ps*l+1]-y2;
+                    z1=p[ijk][ps*l+2]-z2;
+                    rs=con.r_scale(x1*x1+y1*y1+z1*z1,ijk,l);
+                    if(!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
+                    l++;
+                } while (l<co[ijk]);
+            } else {
+                do {
+                    x1=p[ijk][ps*l]-x2;
+                    y1=p[ijk][ps*l+1]-y2;
+                    z1=p[ijk][ps*l+2]-z2;
+                    rs=x1*x1+y1*y1+z1*z1;
+                    if(con.r_scale_check(rs,mrs,ijk,l)&&!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
+                    l++;
+                } while (l<co[ijk]);
+            }
+        }
 
-		// If there might not be enough memory on the list for these
-		// additions, then add more
-		if(qu_e>qu_l-18) add_list_memory(qu_s,qu_e);
+        // If there might not be enough memory on the list for these
+        // additions, then add more
+        if(qu_e>qu_l-18) add_list_memory(qu_s,qu_e);
 
-		// Test the parts of the worklist element which tell us what
-		// neighbors of this block are not on the worklist. Store them
-		// on the block list, and mark the mask.
-		scan_bits_mask_add(q,mijk,ei,ej,ek,qu_e);
-	}
+        // Test the parts of the worklist element which tell us what
+        // neighbors of this block are not on the worklist. Store them
+        // on the block list, and mark the mask.
+        scan_bits_mask_add(q,mijk,ei,ej,ek,qu_e);
+    }
 
-	// Do a check to see if we've reached the radius cutoff
-	if(con.r_ctest(radp[g],mrs)) return true;
+    // Do a check to see if we've reached the radius cutoff
+    if(con.r_ctest(radp[g],mrs)) return true;
 
-	// We were unable to completely compute the cell based on the blocks in
-	// the worklist, so now we have to go block by block, reading in items
-	// off the list
-	while(qu_s!=qu_e) {
+    // We were unable to completely compute the cell based on the blocks in
+    // the worklist, so now we have to go block by block, reading in items
+    // off the list
+    while(qu_s!=qu_e) {
 
-		// If we reached the end of the list memory loop back to the
-		// start
-		if(qu_s==qu_l) qu_s=qu;
+        // If we reached the end of the list memory loop back to the
+        // start
+        if(qu_s==qu_l) qu_s=qu;
 
-		// Read in a block off the list, and compute the upper and lower
-		// coordinates in each of the three dimensions
-		ei=*(qu_s++);ej=*(qu_s++);ek=*(qu_s++);
-		xlo=(ei-i)*boxx-fx;xhi=xlo+boxx;
-		ylo=(ej-j)*boxy-fy;yhi=ylo+boxy;
-		zlo=(ek-k)*boxz-fz;zhi=zlo+boxz;
+        // Read in a block off the list, and compute the upper and lower
+        // coordinates in each of the three dimensions
+        ei=*(qu_s++);ej=*(qu_s++);ek=*(qu_s++);
+        xlo=(ei-i)*boxx-fx;xhi=xlo+boxx;
+        ylo=(ej-j)*boxy-fy;yhi=ylo+boxy;
+        zlo=(ek-k)*boxz-fz;zhi=zlo+boxz;
 
-		// Carry out plane tests to see if any particle in this block
-		// could possibly intersect the cell
-		if(ei>i) {
-			if(ej>j) {
-				if(ek>k) {if(corner_test(c,xlo,ylo,zlo,xhi,yhi,zhi)) continue;}
-				else if(ek<k) {if(corner_test(c,xlo,ylo,zhi,xhi,yhi,zlo)) continue;}
-				else {if(edge_z_test(c,xlo,ylo,zlo,xhi,yhi,zhi)) continue;}
-			} else if(ej<j) {
-				if(ek>k) {if(corner_test(c,xlo,yhi,zlo,xhi,ylo,zhi)) continue;}
-				else if(ek<k) {if(corner_test(c,xlo,yhi,zhi,xhi,ylo,zlo)) continue;}
-				else {if(edge_z_test(c,xlo,yhi,zlo,xhi,ylo,zhi)) continue;}
-			} else {
-				if(ek>k) {if(edge_y_test(c,xlo,ylo,zlo,xhi,yhi,zhi)) continue;}
-				else if(ek<k) {if(edge_y_test(c,xlo,ylo,zhi,xhi,yhi,zlo)) continue;}
-				else {if(face_x_test(c,xlo,ylo,zlo,yhi,zhi)) continue;}
-			}
-		} else if(ei<i) {
-			if(ej>j) {
-				if(ek>k) {if(corner_test(c,xhi,ylo,zlo,xlo,yhi,zhi)) continue;}
-				else if(ek<k) {if(corner_test(c,xhi,ylo,zhi,xlo,yhi,zlo)) continue;}
-				else {if(edge_z_test(c,xhi,ylo,zlo,xlo,yhi,zhi)) continue;}
-			} else if(ej<j) {
-				if(ek>k) {if(corner_test(c,xhi,yhi,zlo,xlo,ylo,zhi)) continue;}
-				else if(ek<k) {if(corner_test(c,xhi,yhi,zhi,xlo,ylo,zlo)) continue;}
-				else {if(edge_z_test(c,xhi,yhi,zlo,xlo,ylo,zhi)) continue;}
-			} else {
-				if(ek>k) {if(edge_y_test(c,xhi,ylo,zlo,xlo,yhi,zhi)) continue;}
-				else if(ek<k) {if(edge_y_test(c,xhi,ylo,zhi,xlo,yhi,zlo)) continue;}
-				else {if(face_x_test(c,xhi,ylo,zlo,yhi,zhi)) continue;}
-			}
-		} else {
-			if(ej>j) {
-				if(ek>k) {if(edge_x_test(c,xlo,ylo,zlo,xhi,yhi,zhi)) continue;}
-				else if(ek<k) {if(edge_x_test(c,xlo,ylo,zhi,xhi,yhi,zlo)) continue;}
-				else {if(face_y_test(c,xlo,ylo,zlo,xhi,zhi)) continue;}
-			} else if(ej<j) {
-				if(ek>k) {if(edge_x_test(c,xlo,yhi,zlo,xhi,ylo,zhi)) continue;}
-				else if(ek<k) {if(edge_x_test(c,xlo,yhi,zhi,xhi,ylo,zlo)) continue;}
-				else {if(face_y_test(c,xlo,yhi,zlo,xhi,zhi)) continue;}
-			} else {
-				if(ek>k) {if(face_z_test(c,xlo,ylo,zlo,xhi,yhi)) continue;}
-				else if(ek<k) {if(face_z_test(c,xlo,ylo,zhi,xhi,yhi)) continue;}
-				else voro_fatal_error("Compute cell routine revisiting central block, which should never\nhappen.",VOROPP_INTERNAL_ERROR);
-			}
-		}
+        // Carry out plane tests to see if any particle in this block
+        // could possibly intersect the cell
+        if(ei>i) {
+            if(ej>j) {
+                if(ek>k) {if(corner_test(c,xlo,ylo,zlo,xhi,yhi,zhi)) continue;}
+                else if(ek<k) {if(corner_test(c,xlo,ylo,zhi,xhi,yhi,zlo)) continue;}
+                else {if(edge_z_test(c,xlo,ylo,zlo,xhi,yhi,zhi)) continue;}
+            } else if(ej<j) {
+                if(ek>k) {if(corner_test(c,xlo,yhi,zlo,xhi,ylo,zhi)) continue;}
+                else if(ek<k) {if(corner_test(c,xlo,yhi,zhi,xhi,ylo,zlo)) continue;}
+                else {if(edge_z_test(c,xlo,yhi,zlo,xhi,ylo,zhi)) continue;}
+            } else {
+                if(ek>k) {if(edge_y_test(c,xlo,ylo,zlo,xhi,yhi,zhi)) continue;}
+                else if(ek<k) {if(edge_y_test(c,xlo,ylo,zhi,xhi,yhi,zlo)) continue;}
+                else {if(face_x_test(c,xlo,ylo,zlo,yhi,zhi)) continue;}
+            }
+        } else if(ei<i) {
+            if(ej>j) {
+                if(ek>k) {if(corner_test(c,xhi,ylo,zlo,xlo,yhi,zhi)) continue;}
+                else if(ek<k) {if(corner_test(c,xhi,ylo,zhi,xlo,yhi,zlo)) continue;}
+                else {if(edge_z_test(c,xhi,ylo,zlo,xlo,yhi,zhi)) continue;}
+            } else if(ej<j) {
+                if(ek>k) {if(corner_test(c,xhi,yhi,zlo,xlo,ylo,zhi)) continue;}
+                else if(ek<k) {if(corner_test(c,xhi,yhi,zhi,xlo,ylo,zlo)) continue;}
+                else {if(edge_z_test(c,xhi,yhi,zlo,xlo,ylo,zhi)) continue;}
+            } else {
+                if(ek>k) {if(edge_y_test(c,xhi,ylo,zlo,xlo,yhi,zhi)) continue;}
+                else if(ek<k) {if(edge_y_test(c,xhi,ylo,zhi,xlo,yhi,zlo)) continue;}
+                else {if(face_x_test(c,xhi,ylo,zlo,yhi,zhi)) continue;}
+            }
+        } else {
+            if(ej>j) {
+                if(ek>k) {if(edge_x_test(c,xlo,ylo,zlo,xhi,yhi,zhi)) continue;}
+                else if(ek<k) {if(edge_x_test(c,xlo,ylo,zhi,xhi,yhi,zlo)) continue;}
+                else {if(face_y_test(c,xlo,ylo,zlo,xhi,zhi)) continue;}
+            } else if(ej<j) {
+                if(ek>k) {if(edge_x_test(c,xlo,yhi,zlo,xhi,ylo,zhi)) continue;}
+                else if(ek<k) {if(edge_x_test(c,xlo,yhi,zhi,xhi,ylo,zlo)) continue;}
+                else {if(face_y_test(c,xlo,yhi,zlo,xhi,zhi)) continue;}
+            } else {
+                if(ek>k) {if(face_z_test(c,xlo,ylo,zlo,xhi,yhi)) continue;}
+                else if(ek<k) {if(face_z_test(c,xlo,ylo,zhi,xhi,yhi)) continue;}
+                else voro_fatal_error("Compute cell routine revisiting central block, which should never\nhappen.",VOROPP_INTERNAL_ERROR);
+            }
+        }
 
-		// Now compute the region that we are going to test over, and
-		// set a displacement vector for the periodic cases
-		ijk=con.region_index(ci,cj,ck,ei,ej,ek,qx,qy,qz,disp);
+        // Now compute the region that we are going to test over, and
+        // set a displacement vector for the periodic cases
+        ijk=con.region_index(ci,cj,ck,ei,ej,ek,qx,qy,qz,disp);
 
-		// Loop over all the elements in the block to test for cuts. It
-		// would be possible to exclude some of these cases by testing
-		// against mrs, but this will probably not save time.
-		if(co[ijk]>0) {
-			l=0;x2=x-qx;y2=y-qy;z2=z-qz;
-			do {
-				x1=p[ijk][ps*l]-x2;
-				y1=p[ijk][ps*l+1]-y2;
-				z1=p[ijk][ps*l+2]-z2;
-				rs=con.r_scale(x1*x1+y1*y1+z1*z1,ijk,l);
-				if(!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
-				l++;
-			} while (l<co[ijk]);
-		}
+        // Loop over all the elements in the block to test for cuts. It
+        // would be possible to exclude some of these cases by testing
+        // against mrs, but this will probably not save time.
+        if(co[ijk]>0) {
+            l=0;x2=x-qx;y2=y-qy;z2=z-qz;
+            do {
+                x1=p[ijk][ps*l]-x2;
+                y1=p[ijk][ps*l+1]-y2;
+                z1=p[ijk][ps*l+2]-z2;
+                rs=con.r_scale(x1*x1+y1*y1+z1*z1,ijk,l);
+                if(!c.nplane(x1,y1,z1,rs,id[ijk][l])) return false;
+                l++;
+            } while (l<co[ijk]);
+        }
 
-		// If there's not much memory on the block list then add more
-		if((qu_s<=qu_e?(qu_l-qu_e)+(qu_s-qu):qu_s-qu_e)<18) add_list_memory(qu_s,qu_e);
+        // If there's not much memory on the block list then add more
+        if((qu_s<=qu_e?(qu_l-qu_e)+(qu_s-qu):qu_s-qu_e)<18) add_list_memory(qu_s,qu_e);
 
-		// Test the neighbors of the current block, and add them to the
-		// block list if they haven't already been tested
-		add_to_mask(ei,ej,ek,qu_e);
-	}
+        // Test the neighbors of the current block, and add them to the
+        // block list if they haven't already been tested
+        add_to_mask(ei,ej,ek,qu_e);
+    }
 
-	return true;
+    return true;
 }
 
 /** This function checks to see whether a particular block can possibly have
@@ -632,14 +632,14 @@ bool voro_compute<c_class>::compute_cell(v_cell &c,int ijk,int s,int ci,int cj,i
 template<class c_class>
 template<class v_cell>
 bool voro_compute<c_class>::corner_test(v_cell &c,double xl,double yl,double zl,double xh,double yh,double zh) {
-	con.r_prime(xl*xl+yl*yl+zl*zl);
-	if(c.plane_intersects_guess(xh,yl,zl,con.r_cutoff(xl*xh+yl*yl+zl*zl))) return false;
-	if(c.plane_intersects(xh,yh,zl,con.r_cutoff(xl*xh+yl*yh+zl*zl))) return false;
-	if(c.plane_intersects(xl,yh,zl,con.r_cutoff(xl*xl+yl*yh+zl*zl))) return false;
-	if(c.plane_intersects(xl,yh,zh,con.r_cutoff(xl*xl+yl*yh+zl*zh))) return false;
-	if(c.plane_intersects(xl,yl,zh,con.r_cutoff(xl*xl+yl*yl+zl*zh))) return false;
-	if(c.plane_intersects(xh,yl,zh,con.r_cutoff(xl*xh+yl*yl+zl*zh))) return false;
-	return true;
+    con.r_prime(xl*xl+yl*yl+zl*zl);
+    if(c.plane_intersects_guess(xh,yl,zl,con.r_cutoff(xl*xh+yl*yl+zl*zl))) return false;
+    if(c.plane_intersects(xh,yh,zl,con.r_cutoff(xl*xh+yl*yh+zl*zl))) return false;
+    if(c.plane_intersects(xl,yh,zl,con.r_cutoff(xl*xl+yl*yh+zl*zl))) return false;
+    if(c.plane_intersects(xl,yh,zh,con.r_cutoff(xl*xl+yl*yh+zl*zh))) return false;
+    if(c.plane_intersects(xl,yl,zh,con.r_cutoff(xl*xl+yl*yl+zl*zh))) return false;
+    if(c.plane_intersects(xh,yl,zh,con.r_cutoff(xl*xh+yl*yl+zl*zh))) return false;
+    return true;
 }
 
 /** This function checks to see whether a particular block can possibly have
@@ -657,14 +657,14 @@ bool voro_compute<c_class>::corner_test(v_cell &c,double xl,double yl,double zl,
 template<class c_class>
 template<class v_cell>
 inline bool voro_compute<c_class>::edge_x_test(v_cell &c,double x0,double yl,double zl,double x1,double yh,double zh) {
-	con.r_prime(yl*yl+zl*zl);
-	if(c.plane_intersects_guess(x0,yl,zh,con.r_cutoff(yl*yl+zl*zh))) return false;
-	if(c.plane_intersects(x1,yl,zh,con.r_cutoff(yl*yl+zl*zh))) return false;
-	if(c.plane_intersects(x1,yl,zl,con.r_cutoff(yl*yl+zl*zl))) return false;
-	if(c.plane_intersects(x0,yl,zl,con.r_cutoff(yl*yl+zl*zl))) return false;
-	if(c.plane_intersects(x0,yh,zl,con.r_cutoff(yl*yh+zl*zl))) return false;
-	if(c.plane_intersects(x1,yh,zl,con.r_cutoff(yl*yh+zl*zl))) return false;
-	return true;
+    con.r_prime(yl*yl+zl*zl);
+    if(c.plane_intersects_guess(x0,yl,zh,con.r_cutoff(yl*yl+zl*zh))) return false;
+    if(c.plane_intersects(x1,yl,zh,con.r_cutoff(yl*yl+zl*zh))) return false;
+    if(c.plane_intersects(x1,yl,zl,con.r_cutoff(yl*yl+zl*zl))) return false;
+    if(c.plane_intersects(x0,yl,zl,con.r_cutoff(yl*yl+zl*zl))) return false;
+    if(c.plane_intersects(x0,yh,zl,con.r_cutoff(yl*yh+zl*zl))) return false;
+    if(c.plane_intersects(x1,yh,zl,con.r_cutoff(yl*yh+zl*zl))) return false;
+    return true;
 }
 
 /** This function checks to see whether a particular block can possibly have
@@ -682,14 +682,14 @@ inline bool voro_compute<c_class>::edge_x_test(v_cell &c,double x0,double yl,dou
 template<class c_class>
 template<class v_cell>
 inline bool voro_compute<c_class>::edge_y_test(v_cell &c,double xl,double y0,double zl,double xh,double y1,double zh) {
-	con.r_prime(xl*xl+zl*zl);
-	if(c.plane_intersects_guess(xl,y0,zh,con.r_cutoff(xl*xl+zl*zh))) return false;
-	if(c.plane_intersects(xl,y1,zh,con.r_cutoff(xl*xl+zl*zh))) return false;
-	if(c.plane_intersects(xl,y1,zl,con.r_cutoff(xl*xl+zl*zl))) return false;
-	if(c.plane_intersects(xl,y0,zl,con.r_cutoff(xl*xl+zl*zl))) return false;
-	if(c.plane_intersects(xh,y0,zl,con.r_cutoff(xl*xh+zl*zl))) return false;
-	if(c.plane_intersects(xh,y1,zl,con.r_cutoff(xl*xh+zl*zl))) return false;
-	return true;
+    con.r_prime(xl*xl+zl*zl);
+    if(c.plane_intersects_guess(xl,y0,zh,con.r_cutoff(xl*xl+zl*zh))) return false;
+    if(c.plane_intersects(xl,y1,zh,con.r_cutoff(xl*xl+zl*zh))) return false;
+    if(c.plane_intersects(xl,y1,zl,con.r_cutoff(xl*xl+zl*zl))) return false;
+    if(c.plane_intersects(xl,y0,zl,con.r_cutoff(xl*xl+zl*zl))) return false;
+    if(c.plane_intersects(xh,y0,zl,con.r_cutoff(xl*xh+zl*zl))) return false;
+    if(c.plane_intersects(xh,y1,zl,con.r_cutoff(xl*xh+zl*zl))) return false;
+    return true;
 }
 
 /** This function checks to see whether a particular block can possibly have
@@ -706,14 +706,14 @@ inline bool voro_compute<c_class>::edge_y_test(v_cell &c,double xl,double y0,dou
 template<class c_class>
 template<class v_cell>
 inline bool voro_compute<c_class>::edge_z_test(v_cell &c,double xl,double yl,double z0,double xh,double yh,double z1) {
-	con.r_prime(xl*xl+yl*yl);
-	if(c.plane_intersects_guess(xl,yh,z0,con.r_cutoff(xl*xl+yl*yh))) return false;
-	if(c.plane_intersects(xl,yh,z1,con.r_cutoff(xl*xl+yl*yh))) return false;
-	if(c.plane_intersects(xl,yl,z1,con.r_cutoff(xl*xl+yl*yl))) return false;
-	if(c.plane_intersects(xl,yl,z0,con.r_cutoff(xl*xl+yl*yl))) return false;
-	if(c.plane_intersects(xh,yl,z0,con.r_cutoff(xl*xh+yl*yl))) return false;
-	if(c.plane_intersects(xh,yl,z1,con.r_cutoff(xl*xh+yl*yl))) return false;
-	return true;
+    con.r_prime(xl*xl+yl*yl);
+    if(c.plane_intersects_guess(xl,yh,z0,con.r_cutoff(xl*xl+yl*yh))) return false;
+    if(c.plane_intersects(xl,yh,z1,con.r_cutoff(xl*xl+yl*yh))) return false;
+    if(c.plane_intersects(xl,yl,z1,con.r_cutoff(xl*xl+yl*yl))) return false;
+    if(c.plane_intersects(xl,yl,z0,con.r_cutoff(xl*xl+yl*yl))) return false;
+    if(c.plane_intersects(xh,yl,z0,con.r_cutoff(xl*xh+yl*yl))) return false;
+    if(c.plane_intersects(xh,yl,z1,con.r_cutoff(xl*xh+yl*yl))) return false;
+    return true;
 }
 
 /** This function checks to see whether a particular block can possibly have
@@ -729,12 +729,12 @@ inline bool voro_compute<c_class>::edge_z_test(v_cell &c,double xl,double yl,dou
 template<class c_class>
 template<class v_cell>
 inline bool voro_compute<c_class>::face_x_test(v_cell &c,double xl,double y0,double z0,double y1,double z1) {
-	con.r_prime(xl*xl);
-	if(c.plane_intersects_guess(xl,y0,z0,con.r_cutoff(xl*xl))) return false;
-	if(c.plane_intersects(xl,y0,z1,con.r_cutoff(xl*xl))) return false;
-	if(c.plane_intersects(xl,y1,z1,con.r_cutoff(xl*xl))) return false;
-	if(c.plane_intersects(xl,y1,z0,con.r_cutoff(xl*xl))) return false;
-	return true;
+    con.r_prime(xl*xl);
+    if(c.plane_intersects_guess(xl,y0,z0,con.r_cutoff(xl*xl))) return false;
+    if(c.plane_intersects(xl,y0,z1,con.r_cutoff(xl*xl))) return false;
+    if(c.plane_intersects(xl,y1,z1,con.r_cutoff(xl*xl))) return false;
+    if(c.plane_intersects(xl,y1,z0,con.r_cutoff(xl*xl))) return false;
+    return true;
 }
 
 /** This function checks to see whether a particular block can possibly have
@@ -750,12 +750,12 @@ inline bool voro_compute<c_class>::face_x_test(v_cell &c,double xl,double y0,dou
 template<class c_class>
 template<class v_cell>
 inline bool voro_compute<c_class>::face_y_test(v_cell &c,double x0,double yl,double z0,double x1,double z1) {
-	con.r_prime(yl*yl);
-	if(c.plane_intersects_guess(x0,yl,z0,con.r_cutoff(yl*yl))) return false;
-	if(c.plane_intersects(x0,yl,z1,con.r_cutoff(yl*yl))) return false;
-	if(c.plane_intersects(x1,yl,z1,con.r_cutoff(yl*yl))) return false;
-	if(c.plane_intersects(x1,yl,z0,con.r_cutoff(yl*yl))) return false;
-	return true;
+    con.r_prime(yl*yl);
+    if(c.plane_intersects_guess(x0,yl,z0,con.r_cutoff(yl*yl))) return false;
+    if(c.plane_intersects(x0,yl,z1,con.r_cutoff(yl*yl))) return false;
+    if(c.plane_intersects(x1,yl,z1,con.r_cutoff(yl*yl))) return false;
+    if(c.plane_intersects(x1,yl,z0,con.r_cutoff(yl*yl))) return false;
+    return true;
 }
 
 /** This function checks to see whether a particular block can possibly have
@@ -771,12 +771,12 @@ inline bool voro_compute<c_class>::face_y_test(v_cell &c,double x0,double yl,dou
 template<class c_class>
 template<class v_cell>
 inline bool voro_compute<c_class>::face_z_test(v_cell &c,double x0,double y0,double zl,double x1,double y1) {
-	con.r_prime(zl*zl);
-	if(c.plane_intersects_guess(x0,y0,zl,con.r_cutoff(zl*zl))) return false;
-	if(c.plane_intersects(x0,y1,zl,con.r_cutoff(zl*zl))) return false;
-	if(c.plane_intersects(x1,y1,zl,con.r_cutoff(zl*zl))) return false;
-	if(c.plane_intersects(x1,y0,zl,con.r_cutoff(zl*zl))) return false;
-	return true;
+    con.r_prime(zl*zl);
+    if(c.plane_intersects_guess(x0,y0,zl,con.r_cutoff(zl*zl))) return false;
+    if(c.plane_intersects(x0,y1,zl,con.r_cutoff(zl*zl))) return false;
+    if(c.plane_intersects(x1,y1,zl,con.r_cutoff(zl*zl))) return false;
+    if(c.plane_intersects(x1,y0,zl,con.r_cutoff(zl*zl))) return false;
+    return true;
 }
 
 /** This routine checks to see whether a point is within a particular distance
@@ -795,169 +795,169 @@ inline bool voro_compute<c_class>::face_z_test(v_cell &c,double x0,double y0,dou
  *         within mrs. */
 template<class c_class>
 bool voro_compute<c_class>::compute_min_max_radius(int di,int dj,int dk,double fx,double fy,double fz,double gxs,double gys,double gzs,double &crs,double mrs) {
-	double xlo,ylo,zlo;
-	if(di>0) {
-		xlo=di*boxx-fx;
-		crs=xlo*xlo;
-		if(dj>0) {
-			ylo=dj*boxy-fy;
-			crs+=ylo*ylo;
-			if(dk>0) {
-				zlo=dk*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=bxsq+2*(boxx*xlo+boxy*ylo+boxz*zlo);
-			} else if(dk<0) {
-				zlo=(dk+1)*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=bxsq+2*(boxx*xlo+boxy*ylo-boxz*zlo);
-			} else {
-				if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxx*(2*xlo+boxx)+boxy*(2*ylo+boxy)+gzs;
-			}
-		} else if(dj<0) {
-			ylo=(dj+1)*boxy-fy;
-			crs+=ylo*ylo;
-			if(dk>0) {
-				zlo=dk*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=bxsq+2*(boxx*xlo-boxy*ylo+boxz*zlo);
-			} else if(dk<0) {
-				zlo=(dk+1)*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=bxsq+2*(boxx*xlo-boxy*ylo-boxz*zlo);
-			} else {
-				if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxx*(2*xlo+boxx)+boxy*(-2*ylo+boxy)+gzs;
-			}
-		} else {
-			if(dk>0) {
-				zlo=dk*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxz*(2*zlo+boxz);
-			} else if(dk<0) {
-				zlo=(dk+1)*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxz*(-2*zlo+boxz);
-			} else {
-				if(con.r_ctest(crs,mrs)) return true;
-				crs+=gzs;
-			}
-			crs+=gys+boxx*(2*xlo+boxx);
-		}
-	} else if(di<0) {
-		xlo=(di+1)*boxx-fx;
-		crs=xlo*xlo;
-		if(dj>0) {
-			ylo=dj*boxy-fy;
-			crs+=ylo*ylo;
-			if(dk>0) {
-				zlo=dk*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=bxsq+2*(-boxx*xlo+boxy*ylo+boxz*zlo);
-			} else if(dk<0) {
-				zlo=(dk+1)*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=bxsq+2*(-boxx*xlo+boxy*ylo-boxz*zlo);
-			} else {
-				if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxx*(-2*xlo+boxx)+boxy*(2*ylo+boxy)+gzs;
-			}
-		} else if(dj<0) {
-			ylo=(dj+1)*boxy-fy;
-			crs+=ylo*ylo;
-			if(dk>0) {
-				zlo=dk*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=bxsq+2*(-boxx*xlo-boxy*ylo+boxz*zlo);
-			} else if(dk<0) {
-				zlo=(dk+1)*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=bxsq+2*(-boxx*xlo-boxy*ylo-boxz*zlo);
-			} else {
-				if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxx*(-2*xlo+boxx)+boxy*(-2*ylo+boxy)+gzs;
-			}
-		} else {
-			if(dk>0) {
-				zlo=dk*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxz*(2*zlo+boxz);
-			} else if(dk<0) {
-				zlo=(dk+1)*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxz*(-2*zlo+boxz);
-			} else {
-				if(con.r_ctest(crs,mrs)) return true;
-				crs+=gzs;
-			}
-			crs+=gys+boxx*(-2*xlo+boxx);
-		}
-	} else {
-		if(dj>0) {
-			ylo=dj*boxy-fy;
-			crs=ylo*ylo;
-			if(dk>0) {
-				zlo=dk*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxz*(2*zlo+boxz);
-			} else if(dk<0) {
-				zlo=(dk+1)*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxz*(-2*zlo+boxz);
-			} else {
-				if(con.r_ctest(crs,mrs)) return true;
-				crs+=gzs;
-			}
-			crs+=boxy*(2*ylo+boxy);
-		} else if(dj<0) {
-			ylo=(dj+1)*boxy-fy;
-			crs=ylo*ylo;
-			if(dk>0) {
-				zlo=dk*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxz*(2*zlo+boxz);
-			} else if(dk<0) {
-				zlo=(dk+1)*boxz-fz;
-				crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxz*(-2*zlo+boxz);
-			} else {
-				if(con.r_ctest(crs,mrs)) return true;
-				crs+=gzs;
-			}
-			crs+=boxy*(-2*ylo+boxy);
-		} else {
-			if(dk>0) {
-				zlo=dk*boxz-fz;crs=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxz*(2*zlo+boxz);
-			} else if(dk<0) {
-				zlo=(dk+1)*boxz-fz;crs=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
-				crs+=boxz*(-2*zlo+boxz);
-			} else {
-				crs=0;
-				voro_fatal_error("Min/max radius function called for central block, which should never\nhappen.",VOROPP_INTERNAL_ERROR);
-			}
-			crs+=gys;
-		}
-		crs+=gxs;
-	}
-	return false;
+    double xlo,ylo,zlo;
+    if(di>0) {
+        xlo=di*boxx-fx;
+        crs=xlo*xlo;
+        if(dj>0) {
+            ylo=dj*boxy-fy;
+            crs+=ylo*ylo;
+            if(dk>0) {
+                zlo=dk*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=bxsq+2*(boxx*xlo+boxy*ylo+boxz*zlo);
+            } else if(dk<0) {
+                zlo=(dk+1)*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=bxsq+2*(boxx*xlo+boxy*ylo-boxz*zlo);
+            } else {
+                if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxx*(2*xlo+boxx)+boxy*(2*ylo+boxy)+gzs;
+            }
+        } else if(dj<0) {
+            ylo=(dj+1)*boxy-fy;
+            crs+=ylo*ylo;
+            if(dk>0) {
+                zlo=dk*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=bxsq+2*(boxx*xlo-boxy*ylo+boxz*zlo);
+            } else if(dk<0) {
+                zlo=(dk+1)*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=bxsq+2*(boxx*xlo-boxy*ylo-boxz*zlo);
+            } else {
+                if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxx*(2*xlo+boxx)+boxy*(-2*ylo+boxy)+gzs;
+            }
+        } else {
+            if(dk>0) {
+                zlo=dk*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxz*(2*zlo+boxz);
+            } else if(dk<0) {
+                zlo=(dk+1)*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxz*(-2*zlo+boxz);
+            } else {
+                if(con.r_ctest(crs,mrs)) return true;
+                crs+=gzs;
+            }
+            crs+=gys+boxx*(2*xlo+boxx);
+        }
+    } else if(di<0) {
+        xlo=(di+1)*boxx-fx;
+        crs=xlo*xlo;
+        if(dj>0) {
+            ylo=dj*boxy-fy;
+            crs+=ylo*ylo;
+            if(dk>0) {
+                zlo=dk*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=bxsq+2*(-boxx*xlo+boxy*ylo+boxz*zlo);
+            } else if(dk<0) {
+                zlo=(dk+1)*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=bxsq+2*(-boxx*xlo+boxy*ylo-boxz*zlo);
+            } else {
+                if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxx*(-2*xlo+boxx)+boxy*(2*ylo+boxy)+gzs;
+            }
+        } else if(dj<0) {
+            ylo=(dj+1)*boxy-fy;
+            crs+=ylo*ylo;
+            if(dk>0) {
+                zlo=dk*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=bxsq+2*(-boxx*xlo-boxy*ylo+boxz*zlo);
+            } else if(dk<0) {
+                zlo=(dk+1)*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=bxsq+2*(-boxx*xlo-boxy*ylo-boxz*zlo);
+            } else {
+                if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxx*(-2*xlo+boxx)+boxy*(-2*ylo+boxy)+gzs;
+            }
+        } else {
+            if(dk>0) {
+                zlo=dk*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxz*(2*zlo+boxz);
+            } else if(dk<0) {
+                zlo=(dk+1)*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxz*(-2*zlo+boxz);
+            } else {
+                if(con.r_ctest(crs,mrs)) return true;
+                crs+=gzs;
+            }
+            crs+=gys+boxx*(-2*xlo+boxx);
+        }
+    } else {
+        if(dj>0) {
+            ylo=dj*boxy-fy;
+            crs=ylo*ylo;
+            if(dk>0) {
+                zlo=dk*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxz*(2*zlo+boxz);
+            } else if(dk<0) {
+                zlo=(dk+1)*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxz*(-2*zlo+boxz);
+            } else {
+                if(con.r_ctest(crs,mrs)) return true;
+                crs+=gzs;
+            }
+            crs+=boxy*(2*ylo+boxy);
+        } else if(dj<0) {
+            ylo=(dj+1)*boxy-fy;
+            crs=ylo*ylo;
+            if(dk>0) {
+                zlo=dk*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxz*(2*zlo+boxz);
+            } else if(dk<0) {
+                zlo=(dk+1)*boxz-fz;
+                crs+=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxz*(-2*zlo+boxz);
+            } else {
+                if(con.r_ctest(crs,mrs)) return true;
+                crs+=gzs;
+            }
+            crs+=boxy*(-2*ylo+boxy);
+        } else {
+            if(dk>0) {
+                zlo=dk*boxz-fz;crs=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxz*(2*zlo+boxz);
+            } else if(dk<0) {
+                zlo=(dk+1)*boxz-fz;crs=zlo*zlo;if(con.r_ctest(crs,mrs)) return true;
+                crs+=boxz*(-2*zlo+boxz);
+            } else {
+                crs=0;
+                voro_fatal_error("Min/max radius function called for central block, which should never\nhappen.",VOROPP_INTERNAL_ERROR);
+            }
+            crs+=gys;
+        }
+        crs+=gxs;
+    }
+    return false;
 }
 
 template<class c_class>
 bool voro_compute<c_class>::compute_min_radius(int di,int dj,int dk,double fx,double fy,double fz,double mrs) {
-	double t,crs;
+    double t,crs;
 
-	if(di>0) {t=di*boxx-fx;crs=t*t;}
-	else if(di<0) {t=(di+1)*boxx-fx;crs=t*t;}
-	else crs=0;
+    if(di>0) {t=di*boxx-fx;crs=t*t;}
+    else if(di<0) {t=(di+1)*boxx-fx;crs=t*t;}
+    else crs=0;
 
-	if(dj>0) {t=dj*boxy-fy;crs+=t*t;}
-	else if(dj<0) {t=(dj+1)*boxy-fy;crs+=t*t;}
+    if(dj>0) {t=dj*boxy-fy;crs+=t*t;}
+    else if(dj<0) {t=(dj+1)*boxy-fy;crs+=t*t;}
 
-	if(dk>0) {t=dk*boxz-fz;crs+=t*t;}
-	else if(dk<0) {t=(dk+1)*boxz-fz;crs+=t*t;}
+    if(dk>0) {t=dk*boxz-fz;crs+=t*t;}
+    else if(dk<0) {t=(dk+1)*boxz-fz;crs+=t*t;}
 
-	return crs>con.r_max_add(mrs);
+    return crs>con.r_max_add(mrs);
 }
 
 /** Adds memory to the queue.
@@ -965,22 +965,22 @@ bool voro_compute<c_class>::compute_min_radius(int di,int dj,int dk,double fx,do
  * \param[in,out] qu_e a reference to the queue end pointer. */
 template<class c_class>
 inline void voro_compute<c_class>::add_list_memory(int*& qu_s,int*& qu_e) {
-	qu_size<<=1;
-	int *qu_n=new int[qu_size],*qu_c=qu_n;
+    qu_size<<=1;
+    int *qu_n=new int[qu_size],*qu_c=qu_n;
 #if VOROPP_VERBOSE >=2
-	fprintf(stderr,"List memory scaled up to %d\n",qu_size);
+    fprintf(stderr,"List memory scaled up to %d\n",qu_size);
 #endif
-	if(qu_s<=qu_e) {
-		while(qu_s<qu_e) *(qu_c++)=*(qu_s++);
-	} else {
-		while(qu_s<qu_l) *(qu_c++)=*(qu_s++);
-		qu_s=qu;
-		while(qu_s<qu_e) *(qu_c++)=*(qu_s++);
-	}
-	delete [] qu;
-	qu_s=qu=qu_n;
-	qu_l=qu+qu_size;
-	qu_e=qu_c;
+    if(qu_s<=qu_e) {
+        while(qu_s<qu_e) *(qu_c++)=*(qu_s++);
+    } else {
+        while(qu_s<qu_l) *(qu_c++)=*(qu_s++);
+        qu_s=qu;
+        while(qu_s<qu_e) *(qu_c++)=*(qu_s++);
+    }
+    delete [] qu;
+    qu_s=qu=qu_n;
+    qu_l=qu+qu_size;
+    qu_e=qu_c;
 }
 
 // Explicit template instantiation

--- a/SMILE/fundamentals/Basics.hpp
+++ b/SMILE/fundamentals/Basics.hpp
@@ -9,7 +9,7 @@
 ////////////////////////////////////////////////////////////////////
 
 // Define this macro before including the system headers to silence warnings on Windows
-// about the C library functions that could cause buffer overruns, such as sprintf()
+// about C library functions that Microsoft considers to be unsafe, such as getenv()
 #define _CRT_SECURE_NO_WARNINGS
 
 // Define this macro before including the <cmath> system header to force the Windows

--- a/SMILE/fundamentals/StringUtils.cpp
+++ b/SMILE/fundamentals/StringUtils.cpp
@@ -388,7 +388,7 @@ string StringUtils::toString(double value)
 
     // start with a regular semi-smart conversion
     char buf[20];
-    sprintf(buf, "%1.10g", value);
+    snprintf(buf, sizeof(buf), "%1.10g", value);
     string result(buf);
 
     // remove leading zeroes and the + sign in the exponent
@@ -432,7 +432,7 @@ string StringUtils::toString(double value, char format, int precision, int width
     // perform the conversion
     char formatString[] = {'%', '1', '.', '*', format, 0};
     char result[30];
-    sprintf(result, formatString, precision, value);
+    snprintf(result, sizeof(result), formatString, precision, value);
 
     // pad if needed
     return padLeft(result, static_cast<size_t>(max(width, 1)), pad);

--- a/SMILE/fundamentals/System.cpp
+++ b/SMILE/fundamentals/System.cpp
@@ -145,7 +145,7 @@ namespace
 
 void System::initialize(int argc, char** argv)
 {
-    // Force standard locale so that sprintf and stream formatting always produces the same result
+    // Force standard locale so that snprintf and stream formatting always produces the same result
     std::locale::global(std::locale::classic());  // this may or may not affect C locale so do this first
     setlocale(LC_ALL, "C");
 
@@ -363,7 +363,7 @@ string System::timestamp(bool iso8601)
     system_clock::duration since_epoch = now_tp.time_since_epoch();
     since_epoch -= duration_cast<seconds>(since_epoch);
     milliseconds millis = duration_cast<milliseconds>(since_epoch);
-    sprintf(resultBuf + milliOffset, "%03d", static_cast<int>(millis.count()));
+    snprintf(resultBuf + milliOffset, sizeof(resultBuf) - milliOffset, "%03d", static_cast<int>(millis.count()));
 
     return resultBuf;
 }


### PR DESCRIPTION
**Motivation**
Recent compiler versions produce a warning about the use of the standard library function `sprintf` because the function does not know the length of its output buffer and thus may write past the end of the provided buffer.

**Description**
This pull request represents a technical update to avoid these warnings (no features are introduced or changed):
 - in our own code, the few uses of `sprintf` are replaced by the use of `snprintf`, a safe alternative introduced to the standard library some time ago.
 - in the Voro++ code, all functions related to text output are removed (these functions heavily use `sprintf` but are never invoked in SKIRT).

**Tests**
All functional tests still work.
