### PR TITLE
Limit negative optical depth for NonLTE line gas mix

### DIFF
--- a/SKIRT/core/NonLTELineGasMix.cpp
+++ b/SKIRT/core/NonLTELineGasMix.cpp
@@ -589,6 +589,13 @@ double NonLTELineGasMix::opacityAbs(double lambda, const MaterialState* state, c
                 }
             }
         }
+
+        // apply lower limit to (negative) optical depth
+        if (opacity < 0.)
+        {
+            double diagonal = 1.7320508 * cbrt(state->volume());  // correct only for cubical cell
+            if (opacity * diagonal < lowestOpticalDepth()) opacity = lowestOpticalDepth() / diagonal;
+        }
     }
     return opacity;
 }

--- a/SKIRT/core/NonLTELineGasMix.hpp
+++ b/SKIRT/core/NonLTELineGasMix.hpp
@@ -190,6 +190,18 @@
     all supported lines are superposed on top of each other. In practice, the implementation
     includes just the terms that have a significant contribution at any given wavelength.
 
+    <b>Limiting negative optical depth</b>
+
+    The formula for the absorption opacity given in the previous section yields a negative value in
+    case the medium exhibits stimulated emission. The explicit absorption technique (see the
+    MonteCarloSimulation class) supports the corresponding negative optical depths along a photon
+    path. However, numerical problems arise if the negative optical depth magnitude becomes too
+    high. This may happen, for example, as a result of Monte Carlo noise, or in the early stages
+    when a simulation has not yet converged.
+
+    Therefore, this class imposes a user-configurable lower limit on the (negative) optical depth
+    along a cell diagonal before returning an absorption opacity. The default limit is -2.
+
     <b>Storing mean intensities</b>
 
     As discussed above, the mean radiation field intensity \f$J_{\lambda,ul}\f$ is determined for
@@ -294,6 +306,12 @@ class NonLTELineGasMix : public EmittingGasMix
         ATTRIBUTE_MAX_VALUE(maxFractionNotConvergedCells, "1]")
         ATTRIBUTE_DEFAULT_VALUE(maxFractionNotConvergedCells, "0.001")
         ATTRIBUTE_DISPLAYED_IF(maxFractionNotConvergedCells, "Level2")
+
+        PROPERTY_DOUBLE(lowestOpticalDepth, "Lower limit of (negative) optical depth along a cell diagonal")
+        ATTRIBUTE_MIN_VALUE(lowestOpticalDepth, "[-10")
+        ATTRIBUTE_MAX_VALUE(lowestOpticalDepth, "0]")
+        ATTRIBUTE_DEFAULT_VALUE(lowestOpticalDepth, "-2")
+        ATTRIBUTE_DISPLAYED_IF(lowestOpticalDepth, "Level3")
 
         PROPERTY_BOOL(storeMeanIntensities, "store the mean radiation field intensity at each transition line")
         ATTRIBUTE_DEFAULT_VALUE(storeMeanIntensities, "false")


### PR DESCRIPTION
** Motivation**
The absorption opacity returned by the `NonLTELineGasMix` class is negative in case the medium exhibits stimulated emission. The explicit absorption technique (see the `MonteCarloSimulation` class) supports the corresponding negative optical depths along a photon path. However, numerical problems arise if the negative optical depth magnitude becomes too high. This may happen, for example, as a result of Monte Carlo noise, or in the early stages when a simulation has not yet converged.

** Description**
With this update, the `NonLTELineGasMix` class imposes a user-configurable lower limit on the (negative) optical depth along a cell diagonal before returning an absorption opacity. The default optical depth limit is -2.

**Tests**
Verified that an example simulation no longer shows infinite or NaN luminosities. All functional tests still work.
