### PR TITLE
Allow MakeUp to be built with Qt6 (as well as Qt5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ cmake_minimum_required(VERSION 3.2.2 FATAL_ERROR)
 # define a user-configurable option to build SKIRT
 option(BUILD_SKIRT "build SKIRT, advanced radiative transfer" ON)
 
-# define a user-configurable option to build MakeUp, which requires Qt5
-option(BUILD_MAKE_UP "build MakeUp, desktop GUI wizard - requires Qt5")
+# define a user-configurable option to build MakeUp, which requires Qt
+option(BUILD_MAKE_UP "build MakeUp, desktop GUI wizard - requires Qt5 or Qt6")
 
 # define a user-configurable option to build doxstyle
 option(BUILD_DOX_STYLE "build doxstyle, documentation block streamliner")

--- a/MakeUp/main/CMakeLists.txt
+++ b/MakeUp/main/CMakeLists.txt
@@ -10,8 +10,9 @@
 # set the target name
 set(TARGET MakeUp)
 
-# enable Qt functionality
-find_package(Qt5Widgets)
+# enable Qt functionality, supporting Qt5 and Qt6
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -41,7 +42,7 @@ endif()
 
 # create the executable target
 add_executable(${TARGET} ${SOURCES} ${HEADERS})
-target_link_libraries (${TARGET} Qt5::Widgets)
+target_link_libraries (${TARGET} Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets)
 
 # add SMILE library dependencies
 target_link_libraries(${TARGET} wizard fundamentals build)

--- a/SMILE/wizard/BasicChoiceWizardPane.cpp
+++ b/SMILE/wizard/BasicChoiceWizardPane.cpp
@@ -35,7 +35,7 @@ BasicChoiceWizardPane::BasicChoiceWizardPane(bool initialOpenExisting, string in
     _buttonGroup = new QButtonGroup;
 
     // connect the button group to ourselves, and ourselves to the target
-    connect(_buttonGroup, SIGNAL(buttonClicked(int)), this, SLOT(setBasicChoice(int)));
+    connect(_buttonGroup, SIGNAL(buttonClicked(QAbstractButton*)), this, SLOT(setBasicChoice(QAbstractButton*)));
     connect(this, SIGNAL(basicChoiceWasChanged(bool, string, string)), target,
             SLOT(setBasicChoice(bool, string, string)));
 
@@ -87,8 +87,9 @@ BasicChoiceWizardPane::BasicChoiceWizardPane(bool initialOpenExisting, string in
 
 ////////////////////////////////////////////////////////////////////
 
-void BasicChoiceWizardPane::setBasicChoice(int buttonIndex)
+void BasicChoiceWizardPane::setBasicChoice(QAbstractButton* /*button*/)
 {
+    int buttonIndex = _buttonGroup->checkedId();
     bool openExisting = (buttonIndex % 2) != 0;
     string schemaName = _schemaNames[buttonIndex >> 1];
 

--- a/SMILE/wizard/BasicChoiceWizardPane.hpp
+++ b/SMILE/wizard/BasicChoiceWizardPane.hpp
@@ -8,6 +8,7 @@
 
 #include "Basics.hpp"
 #include <QWidget>
+class QAbstractButton;
 class QButtonGroup;
 class QLabel;
 class QPushButton;
@@ -43,7 +44,7 @@ public slots:
         buttons. If the current hierarchy is dirty, and the new choice differs from the previous
         one, the function asks for confirmation from the user before actually updating the choice.
         If the new choice is the same as the previous one, the function does nothing. */
-    void setBasicChoice(int buttonIndex);
+    void setBasicChoice(QAbstractButton* button);
 
     /** This function allows the user to select a new directory containing the SMILE schema library
         in reaction to a user click on the corresponding push button. The function stores the new

--- a/SMILE/wizard/BoolPropertyWizardPane.cpp
+++ b/SMILE/wizard/BoolPropertyWizardPane.cpp
@@ -9,6 +9,7 @@
 #include <QLabel>
 #include <QRadioButton>
 #include <QVBoxLayout>
+#include <QVariant>
 
 ////////////////////////////////////////////////////////////////////
 
@@ -41,7 +42,8 @@ BoolPropertyWizardPane::BoolPropertyWizardPane(std::unique_ptr<PropertyHandler> 
         // add the choice button the group and to the layout
         auto choiceButton = new QRadioButton(QString("No") + (isDefault ? "  [default]" : ""));
         choiceButton->setFocusPolicy(Qt::NoFocus);
-        buttonGroup->addButton(choiceButton, 0);
+        choiceButton->setProperty("boolValue", false);
+        buttonGroup->addButton(choiceButton);
         layout->addWidget(choiceButton);
 
         // if this button corresponds to the current value, select it
@@ -60,7 +62,8 @@ BoolPropertyWizardPane::BoolPropertyWizardPane(std::unique_ptr<PropertyHandler> 
         // add the choice button the group and to the layout
         auto choiceButton = new QRadioButton(QString("Yes") + (isDefault ? "  [default]" : ""));
         choiceButton->setFocusPolicy(Qt::NoFocus);
-        buttonGroup->addButton(choiceButton, 1);
+        choiceButton->setProperty("boolValue", true);
+        buttonGroup->addButton(choiceButton);
         layout->addWidget(choiceButton);
 
         // if this button corresponds to the current value, select it
@@ -72,7 +75,7 @@ BoolPropertyWizardPane::BoolPropertyWizardPane(std::unique_ptr<PropertyHandler> 
     }
 
     // connect the button group to ourselves
-    connect(buttonGroup, SIGNAL(buttonClicked(int)), this, SLOT(updateValueFor(int)));
+    connect(buttonGroup, SIGNAL(buttonClicked(QAbstractButton*)), this, SLOT(updateValueFor(QAbstractButton*)));
 
     // finalize the layout and assign it to ourselves
     layout->addStretch();
@@ -81,11 +84,11 @@ BoolPropertyWizardPane::BoolPropertyWizardPane(std::unique_ptr<PropertyHandler> 
 
 ////////////////////////////////////////////////////////////////////
 
-void BoolPropertyWizardPane::updateValueFor(int buttonID)
+void BoolPropertyWizardPane::updateValueFor(QAbstractButton* button)
 {
     auto hdlr = handlerCast<BoolPropertyHandler>();
 
-    bool newValue = buttonID ? true : false;
+    bool newValue = button->property("boolValue").toBool();
     if (!hdlr->isConfigured() || hdlr->value() != newValue)
     {
         hdlr->setValue(newValue);

--- a/SMILE/wizard/BoolPropertyWizardPane.hpp
+++ b/SMILE/wizard/BoolPropertyWizardPane.hpp
@@ -7,6 +7,7 @@
 #define BOOLPROPERTYWIZARDPANE_HPP
 
 #include "PropertyWizardPane.hpp"
+class QAbstractButton;
 
 ////////////////////////////////////////////////////////////////////
 
@@ -29,7 +30,7 @@ public:
 public slots:
     /** This function stores the value corresponding to the specified button into the target
         property. */
-    void updateValueFor(int buttonID);
+    void updateValueFor(QAbstractButton* button);
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SMILE/wizard/CMakeLists.txt
+++ b/SMILE/wizard/CMakeLists.txt
@@ -10,8 +10,9 @@
 # set the target name
 set(TARGET wizard)
 
-# enable Qt functionality
-find_package(Qt5Widgets)
+# enable Qt functionality, supporting Qt5 and Qt6
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -23,7 +24,7 @@ file(GLOB HEADERS "*.hpp")
 add_library(${TARGET} STATIC ${SOURCES} ${HEADERS})
 
 # add SMILE library and Qt5 dependencies
-target_link_libraries(${TARGET} serialize schema fundamentals Qt5::Widgets)
+target_link_libraries(${TARGET} serialize schema fundamentals Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets)
 include_directories(../serialize ../schema ../fundamentals)
 
 # adjust C++ compiler flags to our needs


### PR DESCRIPTION
**Description**
This pull request updates the CMake build procedure for MakeUp to support both Qt5 and Qt6 framework versions, and replaces the use of some obsolete signals in the MakeUp wizard with equivalent code that works on both Qt5 and Qt6.

**Motivation**
This allows MakeUp to be used with Qt6, which has been available for quite a while now.

