### PR TITLE
Add annulus and donut geometries

### DIFF
--- a/SKIRT/core/AnnulusGeometry.cpp
+++ b/SKIRT/core/AnnulusGeometry.cpp
@@ -38,8 +38,7 @@ double AnnulusGeometry::density(double R, double z) const
 
 double AnnulusGeometry::randomCylRadius() const
 {
-    double X = random()->uniform();
-    return _Rmin + X * (_Rmax - _Rmin);
+    return sqrt(_Rmin * _Rmin + (_Rmax - _Rmin) * (_Rmax + _Rmin) * random()->uniform());
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/AnnulusGeometry.cpp
+++ b/SKIRT/core/AnnulusGeometry.cpp
@@ -1,0 +1,70 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "AnnulusGeometry.hpp"
+#include "FatalError.hpp"
+#include "Random.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void AnnulusGeometry::setupSelfBefore()
+{
+    SepAxGeometry::setupSelfBefore();
+
+    // verify property values
+    if (_Rmin >= _Rmax) throw FATALERROR("The radius of the central cavity should be smaller than the outer radius");
+
+    // calculate the uniform density
+    _rho0 = 1.0 / ((_Rmax * _Rmax - _Rmin * _Rmin) * M_PI * _h);
+}
+
+////////////////////////////////////////////////////////////////////
+
+double AnnulusGeometry::density(double R, double z) const
+{
+    double absz = fabs(z);
+    if (R > _Rmax)
+        return 0.0;
+    else if (absz > _h / 2.0)
+        return 0.0;
+    else if (R < _Rmin)
+        return 0.0;
+    return _rho0;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double AnnulusGeometry::randomCylRadius() const
+{
+    double X = random()->uniform();
+    return _Rmin + X * (_Rmax - _Rmin);
+}
+
+////////////////////////////////////////////////////////////////////
+
+double AnnulusGeometry::randomZ() const
+{
+    double X = random()->uniform();
+    return (X - 0.5) * _h;
+}
+
+//////////////////////////////////////////////////////////////////////
+
+double AnnulusGeometry::SigmaR() const
+{
+    return _rho0 * (_Rmax - _Rmin);
+}
+
+//////////////////////////////////////////////////////////////////////
+
+double AnnulusGeometry::SigmaZ() const
+{
+    if (_Rmin > 0.0)
+        return 0.0;
+    else
+        return _rho0 * _h;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/AnnulusGeometry.hpp
+++ b/SKIRT/core/AnnulusGeometry.hpp
@@ -1,0 +1,93 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef ANNULUSGEOMETRY_HPP
+#define ANNULUSGEOMETRY_HPP
+
+#include "SepAxGeometry.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** The AnnulusGeometry class is a subclass of the SepAxGeometry class, and describes a uniform
+    cylindrical geometry with a cylindrical hole. This geometry can model geometrically thin
+    accretion disks with an inner truncation at \f$R_{\text{min}}\f$, or could be used to build
+    multi-zone disks by combining many annuli.
+
+    In formula, this is easily expressed in cylindrical coordinates as \f[ \rho(R, z) = \rho_0\
+    \quad\text{for } R_{\text{min}}<R<R_{\text{max}} \text{ and } -\frac{h}{2}<z<\frac{h}{2}. \f]
+
+    The model has three free parameters: the cylinder height \f$h\f$, the radial outer radius
+    \f$R_{\text{max}}\f$ and the inner truncation radius \f$R_{\text{min}}\f$. */
+class AnnulusGeometry : public SepAxGeometry
+{
+    ITEM_CONCRETE(AnnulusGeometry, SepAxGeometry, "an annulus geometry")
+
+        PROPERTY_DOUBLE(minRadius, "the inner radius of the annulus")
+        ATTRIBUTE_QUANTITY(minRadius, "length")
+        ATTRIBUTE_MIN_VALUE(minRadius, "[0")
+        ATTRIBUTE_DEFAULT_VALUE(minRadius, "0")
+
+        PROPERTY_DOUBLE(maxRadius, "the outer radius of the annulus")
+        ATTRIBUTE_QUANTITY(maxRadius, "length")
+        ATTRIBUTE_MIN_VALUE(maxRadius, "]0")
+
+        PROPERTY_DOUBLE(height, "the annulus height")
+        ATTRIBUTE_QUANTITY(height, "length")
+        ATTRIBUTE_MIN_VALUE(height, "]0")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function verifies the validity of the parameters and calculates the uniform density
+        \f$\rho_0\f$. This density is set by the normalisation condition that the total mass equals
+        one, i.e. \f[ \rho_0 = \frac{1}{V} = \frac{1}{(R_{\text{max}}^2 - R_{\text{min}}^2) \pi h}.
+        \f] */
+    void setupSelfBefore() override;
+
+    //======================== Other Functions =======================
+
+    /** This function returns the density \f$\rho(R,z)\f$ at the cylindrical radius \f$R\f$ and
+        height \f$z\f$. It just implements the geometry definition. */
+    double density(double R, double z) const override;
+
+    /** This function returns the cylindrical radius \f$R\f$ of a random position drawn from the
+        geometry, by picking a uniform deviate \f${\cal{X}}\f$ and setting \f$R = R_{\text{min}} +
+        {\cal{X}} (R_{\text{max}} - R_{\text{min}})\f$. */
+    double randomCylRadius() const override;
+
+    /** This function returns the height \f$z\f$ of a random position drawn from the geometry, by
+        picking a uniform deviate \f${\cal{X}}\f$ and setting \f$z = -\frac{h}{2} + {\cal{X}} h\f$.
+        */
+    double randomZ() const override;
+
+    /** This function returns the surface density along a line in the equatorial plane starting at
+        the centre of the coordinate system, i.e. \f[ \Sigma_R = \int_0^\infty \rho(R,0)\,
+        {\text{d}}R. \f] For the annulus geometry, we find \f[ \Sigma_R = \rho_0 (R_{\text{max}} -
+        R_{\text{min}}). \f] */
+    double SigmaR() const override;
+
+    /** This function returns the surface density along the Z-axis, i.e. the integration of the
+        density along the entire Z-axis, \f[ \Sigma_Z = \int_{-\infty}^\infty \rho(0,z)\,
+        {\text{d}}z.\f] For the annulus geometry, we find \f[ \Sigma_Z = \rho_0 h. \f] If there is
+        an inner hole (\f$R_{\text{min}}>0\f$), obviously \f$\Sigma_Z=0\f$. */
+    double SigmaZ() const override;
+
+    //======================== Data Members ========================
+
+private:
+    // aliases to discoverable data members for ease of notation and backwards compatibility
+    const double& _Rmin{_minRadius};
+    const double& _Rmax{_maxRadius};
+    const double& _h{_height};
+
+    // data members initialized during setup
+    double _rho0{0.};
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/AnnulusGeometry.hpp
+++ b/SKIRT/core/AnnulusGeometry.hpp
@@ -55,8 +55,8 @@ protected:
     double density(double R, double z) const override;
 
     /** This function returns the cylindrical radius \f$R\f$ of a random position drawn from the
-        geometry, by picking a uniform deviate \f${\cal{X}}\f$ and setting \f$R = R_{\text{min}} +
-        {\cal{X}} (R_{\text{max}} - R_{\text{min}})\f$. */
+        geometry, by picking a uniform deviate \f${\cal{X}}\f$ and setting \f$R =
+        \sqrt{R_\text{min}^2 + {\cal{X}}_1\,(R_\text{max}^2-R_\text{min}^2)} \f$. */
     double randomCylRadius() const override;
 
     /** This function returns the height \f$z\f$ of a random position drawn from the geometry, by

--- a/SKIRT/core/Cylinder2DSpatialGrid.hpp
+++ b/SKIRT/core/Cylinder2DSpatialGrid.hpp
@@ -75,7 +75,7 @@ public:
         axisymmetric grid, the function first determines the radial and vertical bin indices
         \f$i\f$ and \f$k\f$ that correspond to the index \f$m\f$. Then a random radius \f$R\f$, a
         random azimuth \f$\phi\f$, and a random height \f$z\f$ are determined using \f[
-        \begin{split} R &= \sqrt{R_i^2 + {\cal{X}}_1\,(R_{i+1}-R_i)^2} \\ \phi &= 2\pi\,{\cal{X}}_2
+        \begin{split} R &= \sqrt{R_i^2 + {\cal{X}}_1\,(R_{i+1}^2-R_i^2)} \\ \phi &= 2\pi\,{\cal{X}}_2
         \\ z &= z_k + {\cal{X}}_3\, (z_{k+1}-z_k), \end{split} \f] with \f${\cal{X}}_1\f$,
         \f${\cal{X}}_2\f$ and \f${\cal{X}}_3\f$ three uniform deviates. A position with these
         cylindrical coordinates is returned. */

--- a/SKIRT/core/DonutGeometry.cpp
+++ b/SKIRT/core/DonutGeometry.cpp
@@ -1,0 +1,76 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "DonutGeometry.hpp"
+#include "FatalError.hpp"
+#include "Random.hpp"
+
+//////////////////////////////////////////////////////////////////////
+
+void DonutGeometry::setupSelfBefore()
+{
+    AxGeometry::setupSelfBefore();
+
+    // verify property values
+    if (_r0 > _R0)
+        throw FATALERROR(
+            "The radius in the equatorial plane should not be smaller than the radius in the azimuthal plane");
+
+    // determine the normalization factor
+    _A = 0.5 / M_PI / M_PI / _r0 / _r0 / _R0;
+
+    // store the small circle radius squared
+    _r02 = _r0 * _r0;
+}
+
+//////////////////////////////////////////////////////////////////////
+
+double DonutGeometry::density(double R, double z) const
+{
+    // calculate the distance squared from the small circle centre
+    double d2 = (_R0 - R) * (_R0 - R) + z * z;
+
+    // the density is zero outside the ring torus geometry
+    if (d2 >= _r02) return 0.0;
+
+    // the density is uniform inside the ring torus geometry
+    else
+        return _A;
+}
+
+//////////////////////////////////////////////////////////////////////
+
+Position DonutGeometry::generatePosition() const
+{
+    // generate a uniform azimuthal angle
+    double phi = 2.0 * M_PI * random()->uniform();
+
+    // generate a uniform position in the azimuthal plane circle
+    double theta = 2.0 * M_PI * random()->uniform();
+    double r = _r0 * sqrt(random()->uniform());
+
+    // convert circle position to global cylindrical coordinates
+    double z = r * sin(theta);
+    double R = _R0 + r * cos(theta);
+
+    // return position
+    return Position(R, phi, z, Position::CoordinateSystem::CYLINDRICAL);
+}
+
+//////////////////////////////////////////////////////////////////////
+
+double DonutGeometry::SigmaR() const
+{
+    return _A * 2 * _r0;
+}
+
+//////////////////////////////////////////////////////////////////////
+
+double DonutGeometry::SigmaZ() const
+{
+    return 0.0;
+}
+
+//////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/DonutGeometry.hpp
+++ b/SKIRT/core/DonutGeometry.hpp
@@ -1,0 +1,91 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef DONUTGEOMETRY_HPP
+#define DONUTGEOMETRY_HPP
+
+#include "AxGeometry.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** The DonutGeometry class is a subclass of the AxGeometry class and describes the geometry of an
+    axisymmetric ring torus (i.e. a doughnut geometry) of uniform density. This ring torus geometry
+    is often used to model the dusty gas in the equatorial plane of active galactic nuclei (AGN),
+    to explain the observed variety of AGN types as a distribution of observed system orientations
+    relative to this obscuring torus of gas and dust; see Antonucci (1993, ARA&A, 31, 473), Urry &
+    Padovani (1995, PASP, 107, 803) and Netzer (2015, ARA&A, 53, 365).
+
+    The ring torus geometry is obtained by revolving a circle of radius \f$r_{\text{small}}\f$
+    about an axis that is co-planar with this circle, at a radius \f$r_{\text{large}}\f$. Inside
+    this surface of revolution the density has a constant value, and outside this surface the
+    density is zero. In formula, this is easily expressed in cylindrical coordinates as \f[ \rho(R,
+    z) = A\ \quad\text{for } \sqrt{(R-r_{\text{large}})^2 + z^2}<r_{\text{small}}. \f] There are
+    two free parameters describing this torus geometry: the torus radius in the azimuthal plane
+    \f$r_{\text{small}}\f$ and the torus radius in the equatorial plane \f$r_{\text{large}}\f$. */
+class DonutGeometry : public AxGeometry
+{
+    ITEM_CONCRETE(DonutGeometry, AxGeometry, "a donut torus geometry")
+
+        PROPERTY_DOUBLE(largeRadius, "the radius of the torus circle in the equatorial plane")
+        ATTRIBUTE_QUANTITY(largeRadius, "length")
+        ATTRIBUTE_MIN_VALUE(largeRadius, "]0")
+
+        PROPERTY_DOUBLE(smallRadius, "the radius of the torus circle in the azimuthal plane")
+        ATTRIBUTE_QUANTITY(smallRadius, "length")
+        ATTRIBUTE_MIN_VALUE(smallRadius, "]0")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function calculates some frequently used values. The normalization parameter \f$A\f$
+        is set by the normalization condition that total mass equals one, i.e. \f[ A = \frac{1}{V}
+        = \frac{1}{2 \pi^2 r_{\text{large}} r_{\text{small}}^2}. \f] */
+    void setupSelfBefore() override;
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function returns the density \f$\rho(R,z)\f$ at the cylindrical radius \f$R\f$ and
+        height \f$z\f$. It just implements the geometry definition. */
+    double density(double R, double z) const override;
+
+    /** This function generates a random position from the uniform ring torus geometry. A random
+        azimuth angle \f$\phi\f$ is readily found by choosing a random deviate \f${\cal{X}}\f$ and
+        setting \f$\phi = 2\pi {\cal{X}}\f$. Then, a random position in the small circle in the
+        azimuthal plane is found (in polar coordinates) as \f$ \theta' = 2\pi {\cal{X}}_1 \f$ and
+        \f$ r' = r_{\text{small}} \sqrt{{\cal{X}}_2}\f$, with \f$ {\cal{X}}_1 \f$ and \f$
+        {\cal{X}}_2 \f$ two more random deviates. Finally, these small circle coordinates are
+        transformed to global cylindrical coordinates as \f$z = r' \sin(\theta')\f$ and \f$R =
+        r_{\text{large}} + r' \cos(\theta')\f$. */
+    Position generatePosition() const override;
+
+    /** This function returns the radial surface density, i.e. the integration of the density along
+        a line in the equatorial plane starting at the centre of the coordinate system, \f[
+        \Sigma_R = \int_0^\infty \rho(R,0)\,{\text{d}}R. \f] For this geometry, \f[ \Sigma_R = A\,2
+        r_{\text{small}}. \f] */
+    double SigmaR() const override;
+
+    /** This function returns the Z-axis surface density, i.e. the integration of the density along
+        the entire Z-axis, \f[ \Sigma_Z = \int_{-\infty}^\infty \rho(0,z)\, {\text{d}}z. \f] For
+        this geometry, the integral is simply zero. */
+    double SigmaZ() const override;
+
+    //======================== Data Members ========================
+
+private:
+    // aliases to discoverable data members for ease of notation and backwards compatibility
+    const double& _R0{_largeRadius};
+    const double& _r0{_smallRadius};
+
+    // data members initialized during setup
+    double _A{0.};
+    double _r02{0.};
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -16,6 +16,7 @@
 #include "AllCellsLibrary.hpp"
 #include "AllSkyInstrument.hpp"
 #include "AllSkyProjectionForm.hpp"
+#include "AnnulusGeometry.hpp"
 #include "AtPositionsForm.hpp"
 #include "BandLuminosityNormalization.hpp"
 #include "BlackBodySED.hpp"
@@ -55,6 +56,7 @@
 #include "DensityProbe.hpp"
 #include "DensityTreePolicy.hpp"
 #include "DiscreteWavelengthDistribution.hpp"
+#include "DonutGeometry.hpp"
 #include "DraineGraphiteGrainComposition.hpp"
 #include "DraineIonizedPAHGrainComposition.hpp"
 #include "DraineLiDustMix.hpp"
@@ -407,6 +409,8 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<BrokenExpDiskGeometry>();
     ItemRegistry::add<RingGeometry>();
     ItemRegistry::add<TorusGeometry>();
+    ItemRegistry::add<DonutGeometry>();
+    ItemRegistry::add<AnnulusGeometry>();
     ItemRegistry::add<TTauriDiskGeometry>();
     ItemRegistry::add<ConicalShellGeometry>();
     ItemRegistry::add<ParaboloidGeometry>();


### PR DESCRIPTION
**Description**
This update adds two basic 2D geometries to the built-in library:
- The `AnnulusGeometry` describes a uniform cylindrical disk with a cylindrical hole.
- The `DonutGeometry` describes an axisymmetric ring torus (i.e. a doughnut) of uniform density.

**Motivation**
These geometries are often used to model medium components of active galactic nuclei. However, they are implemented as generic elements of the SKIRT geometry library and can thus be used to model both media and sources.

**Tests**
New functional tests were added.

**Context**
These geometries were contributed by @BertVdM.