### PR TITLE
Support polarization for Compton scattering

### DIFF
--- a/SKIRT/core/ComptonPhaseFunction.cpp
+++ b/SKIRT/core/ComptonPhaseFunction.cpp
@@ -7,6 +7,16 @@
 #include "Constants.hpp"
 #include "NR.hpp"
 #include "Random.hpp"
+#include "StokesVector.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // arbitrary constants determining the resolution for discretizing the scattering angles
+    constexpr int Nphi = 361;  // phi from 0 to 2 pi, index f
+    constexpr double dphi = 2 * M_PI / (Nphi - 1);
+}
 
 ////////////////////////////////////////////////////////////////////
 
@@ -15,7 +25,7 @@ namespace
     // returns the photon energy scaled to the electron rest energy: h nu / m_e c^2
     double scaledEnergy(double lambda) { return (Constants::h() / Constants::Melectron() / Constants::c()) / lambda; }
 
-    // returns the Compton scattering cross section for a given scaled energy
+    // returns the Compton scattering cross section (relative to the Thomson cross section) for a given scaled energy
     double comptonSection(double x)
     {
         double x2 = x * x;
@@ -39,6 +49,23 @@ void ComptonPhaseFunction::initialize(Random* random, bool includePolarization)
     // cache random number generator and polarization flag
     _random = random;
     _includePolarization = includePolarization;
+
+    if (includePolarization)
+    {
+        // create tables listing phi, phi/(2 pi), sin(2 phi) and 1-cos(2 phi) for a number of f indices
+        _phiv.resize(Nphi);
+        _phi1v.resize(Nphi);
+        _phisv.resize(Nphi);
+        _phicv.resize(Nphi);
+        for (int f = 0; f < Nphi; f++)
+        {
+            double phi = f * dphi;
+            _phiv[f] = phi;
+            _phi1v[f] = phi / (2 * M_PI);
+            _phisv[f] = sin(2 * phi);
+            _phicv[f] = 1 - cos(2 * phi);
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -54,7 +81,7 @@ double ComptonPhaseFunction::sectionSca(double lambda) const
 double ComptonPhaseFunction::phaseFunctionValueForCosine(double x, double costheta) const
 {
     double C = comptonFactor(x, costheta);
-    double sin2theta = (1 - costheta) * (1 + costheta);
+    double sin2theta = (1. - costheta) * (1. + costheta);
     double phase = C * C * C + C - C * C * sin2theta;
     return 0.75 / comptonSection(x) * phase;
 }
@@ -92,17 +119,113 @@ double ComptonPhaseFunction::generateCosineFromPhaseFunction(double x) const
 
 ////////////////////////////////////////////////////////////////////
 
+double ComptonPhaseFunction::phaseFunctionValue(double x, double costheta, double phi, const StokesVector* sv) const
+{
+    double C = comptonFactor(x, costheta);
+    double sin2theta = (1. - costheta) * (1. + costheta);
+    double S12 = -C * C * sin2theta;
+    double S11 = C * C * C + C + S12;
+    double polDegree = sv->linearPolarizationDegree();
+    double polAngle = sv->polarizationAngle();
+    return 0.75 / comptonSection(x) * (S11 + polDegree * S12 * cos(2. * (phi - polAngle)));
+}
+
+////////////////////////////////////////////////////////////////////
+
+double ComptonPhaseFunction::generateAzimuthFromPhaseFunction(double x, const StokesVector* sv, double costheta) const
+{
+    // construct and sample from the normalized cumulative distribution of phi for this wavelength and theta angle
+    double C = comptonFactor(x, costheta);
+    double sin2theta = (1. - costheta) * (1. + costheta);
+    double S12 = -C * C * sin2theta;
+    double S11 = C * C * C + C + S12;
+    double polDegree = sv->linearPolarizationDegree();
+    double polAngle = sv->polarizationAngle();
+    double PF = polDegree * S12 / S11 / (4 * M_PI);
+    double cos2polAngle = cos(2 * polAngle) * PF;
+    double sin2polAngle = sin(2 * polAngle) * PF;
+    double phi = _random->cdfLinLin(_phiv, _phi1v + cos2polAngle * _phisv + sin2polAngle * _phicv);
+    return phi;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void ComptonPhaseFunction::applyMueller(double x, double costheta, StokesVector* sv) const
+{
+    double C = comptonFactor(x, costheta);
+    double C2 = C * C;
+    double C3 = C2 * C;
+    double sin2theta = (1. - costheta) * (1. + costheta);
+    double S12 = -C2 * sin2theta;
+    double S11 = C3 + C + S12;
+    double S22 = C2 * (1. + costheta * costheta);
+    double S33 = 2. * C2 * costheta;
+    double S44 = (C3 + C) * costheta;
+    sv->applyMueller(S11, S12, S22, S33, 0., S44);
+}
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // This helper function returns the angle phi between the previous and current scattering planes
+    // given the normal to the previous scattering plane and the current and new propagation directions
+    // of the photon packet. The function returns a zero angle if the light is unpolarized or when the
+    // current scattering event is completely forward or backward.
+    double angleBetweenScatteringPlanes(Direction np, Direction kc, Direction kn)
+    {
+        Vec nc = Vec::cross(kc, kn);
+        nc /= nc.norm();
+        double cosphi = Vec::dot(np, nc);
+        double sinphi = Vec::dot(Vec::cross(np, nc), kc);
+        double phi = atan2(sinphi, cosphi);
+        if (std::isfinite(phi)) return phi;
+        return 0.;
+    }
+}
+
+////////////////////////////////////////////////////////////////////
+
 void ComptonPhaseFunction::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfk,
                                              Direction bfkobs, Direction bfky, const StokesVector* sv) const
 {
+    // get the scaled energy and the scattering angle cosine
     double x = scaledEnergy(lambda);
-
-    // calculate the value of the phase function
     double costheta = Vec::dot(bfk, bfkobs);
-    double value = phaseFunctionValueForCosine(x, costheta);
 
-    // accumulate the weighted sum in the intensity
-    I += value;
+    if (!_includePolarization)
+    {
+        // calculate the value of the phase function
+        double value = phaseFunctionValueForCosine(x, costheta);
+
+        // accumulate the weighted sum in the intensity
+        I += value;
+    }
+    else
+    {
+        // calculate the value of the material-specific phase function
+        double phi = angleBetweenScatteringPlanes(sv->normal(), bfk, bfkobs);
+        double value = phaseFunctionValue(x, costheta, phi, sv);
+
+        // copy the polarization state so we can change it without affecting the incoming stokes vector
+        StokesVector svnew = *sv;
+
+        // rotate the Stokes vector reference direction into the scattering plane
+        svnew.rotateIntoPlane(bfk, bfkobs);
+
+        // apply the Mueller matrix
+        applyMueller(x, costheta, &svnew);
+
+        // rotate the Stokes vector reference direction parallel to the instrument frame y-axis
+        // it is given bfkobs because the photon is at this point aimed towards the observer
+        svnew.rotateIntoPlane(bfkobs, bfky);
+
+        // acumulate the weighted sum of all Stokes components to support polarization
+        I += value * svnew.stokesI();
+        Q += value * svnew.stokesQ();
+        U += value * svnew.stokesU();
+        V += value * svnew.stokesV();
+    }
 
     // adjust the wavelength
     lambda *= inverseComptonfactor(x, costheta);
@@ -112,16 +235,35 @@ void ComptonPhaseFunction::peeloffScattering(double& I, double& Q, double& U, do
 
 Direction ComptonPhaseFunction::performScattering(double& lambda, Direction bfk, StokesVector* sv) const
 {
+    // get the scaled energy
     double x = scaledEnergy(lambda);
-
-    // sample a scattering angle from the phase function
     double costheta = generateCosineFromPhaseFunction(x);
 
     // adjust the wavelength
     lambda *= inverseComptonfactor(x, costheta);
 
-    // determine the new propagation direction
-    return _random->direction(bfk, costheta);
+    // determine the new propagation direction, and if required, update the polarization state of the photon packet
+    if (!_includePolarization)
+    {
+        return _random->direction(bfk, costheta);
+    }
+    else
+    {
+        // sample the azimuthal scattering angle, given the incoming polarization state amd the inclination cosine
+        double phi = generateAzimuthFromPhaseFunction(x, sv, costheta);
+
+        // rotate the Stokes vector (and the scattering plane) of the photon packet
+        sv->rotateStokes(phi, bfk);
+
+        // apply the Mueller matrix to the Stokes vector of the photon packet
+        applyMueller(x, costheta, sv);
+
+        // rotate the propagation direction in the scattering plane
+        Vec newdir = bfk * costheta + Vec::cross(sv->normal(), bfk) * sin(acos(costheta));
+
+        // normalize the new direction to prevent degradation
+        return Direction(newdir / newdir.norm());
+    }
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ComptonPhaseFunction.cpp
+++ b/SKIRT/core/ComptonPhaseFunction.cpp
@@ -34,10 +34,11 @@ namespace
 
 ////////////////////////////////////////////////////////////////////
 
-void ComptonPhaseFunction::initialize(Random* random)
+void ComptonPhaseFunction::initialize(Random* random, bool includePolarization)
 {
-    // cache random number generator
+    // cache random number generator and polarization flag
     _random = random;
+    _includePolarization = includePolarization;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -91,7 +92,8 @@ double ComptonPhaseFunction::generateCosineFromPhaseFunction(double x) const
 
 ////////////////////////////////////////////////////////////////////
 
-void ComptonPhaseFunction::peeloffScattering(double& I, double& lambda, Direction bfk, Direction bfkobs) const
+void ComptonPhaseFunction::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfk,
+                                             Direction bfkobs, Direction bfky, const StokesVector* sv) const
 {
     double x = scaledEnergy(lambda);
 
@@ -108,7 +110,7 @@ void ComptonPhaseFunction::peeloffScattering(double& I, double& lambda, Directio
 
 ////////////////////////////////////////////////////////////////////
 
-Direction ComptonPhaseFunction::performScattering(double& lambda, Direction bfk) const
+Direction ComptonPhaseFunction::performScattering(double& lambda, Direction bfk, StokesVector* sv) const
 {
     double x = scaledEnergy(lambda);
 

--- a/SKIRT/core/ComptonPhaseFunction.hpp
+++ b/SKIRT/core/ComptonPhaseFunction.hpp
@@ -32,6 +32,8 @@ class StokesVector;
     = \big(1+x(1-\cos \theta)\big)^{-1}\f$. Equivalently, the wavelength change is given by
     \f$\lambda_\mathrm{out} / \lambda_\mathrm{in} = \big(1+x(1-\cos \theta)\big)\f$.
 
+    <b>Unpolarized Compton scattering</b>
+
     The normalized phase function for an interaction with incoming photon energy \f$x\f$ is given
     by:
 
@@ -40,8 +42,6 @@ class StokesVector;
 
     where \f$\theta\f$ is the scattering angle and \f$C(x, \theta)\f$ is the Compton factor defined
     earlier.
-
-    <b>Sampling from the phase function</b>
 
     To draw a random scattering angle from the phase function, we use the algorithm described by
     Hua et al. 1997 (Computers in Physics 11, 660), which is a variation of the technique first
@@ -54,7 +54,58 @@ class StokesVector;
     Compton factor \f$r = 1 + x (1-\cos\theta)\f$. The sampling algorithm draws a random number for
     \f$r\f$, i.e. from the probability distribution for the inverse Compton factor at a given
     energy. The scattering angle can then easily be obtained from the definition of the inverse
-    Compton factor. */
+    Compton factor.
+
+    <b>Polarized Compton scattering</b>
+
+    The Müller matrix describing Compton scattering can be expressed as a function of the
+    scattering angle \f$\theta\f$ and the incoming photon energy \f$x\f$ as follows (Fano 1949):
+
+    \f[ {\bf{M}}(x,\theta) \propto \begin{pmatrix} C^3(x,\theta) + C(x,\theta) -C^2(\theta,
+    x)\sin^2\theta & -C^2(x,\theta)\sin^2\theta & 0 & 0 \\ -C^2(x,\theta)\sin^2\theta &
+    C^2(x,\theta) (1+\cos^2\theta) & 0 & 0 \\ 0 & 0 & 2C^2(x,\theta)\cos\theta & 0 \\ 0 & 0 & 0 &
+    (C^3(x,\theta) + C(x,\theta)) \cos\theta \end{pmatrix}, \f]
+
+    with \f$C(x, \theta)\f$ the Compton factor defined earlier, and assuming a random distribution
+    for the electron spin direction, which causes the non-diagonal terms in the forth row and forth
+    column to be zero (Depaola 2003). This matrix has five independent coefficients and converges
+    to the Müller matrix for Thomson scattering at low photon energies, i.e. for \f$x\to 0\f$ and
+    thus \f$C(x,\theta) \to 1\f$.
+
+    Following the procedure of Peest et al. 2017 Sect 3.3 starting from the above Müller matrix,
+    we obtain the following expression for the normalized phase function:
+
+    \f[ \Phi(x, \theta, \varphi, {\bf{S}}) = \frac{\sigma_\mathrm{T}}{\sigma_\mathrm{C}(x)} \,
+    \frac{3}{4} \left[{\rm S}_{11}(x,\theta) + {\rm S}_{12}(x,\theta)
+    \,P_\text{L}\cos2(\varphi-\gamma)\right], \f]
+
+    with \f$\theta\f$ and \f$\varphi\f$ the inclination and azimuth angle of the scattering
+    geometry, \f$\sigma_\mathrm{C}(x)\f$ the total Compton scattering cross section as defined
+    earlier, \f${\rm S}_{11}(x,\theta)\f$ and \f${\rm S}_{12}(x,\theta)\f$ two of the Compton
+    Müller matrix elements, and \f$P_\text{L}\f$ and \f$\gamma\f$ the incoming photon's linear
+    polarization degree and angle.
+
+    The marginal distribution for \f$\theta\f$ is determined by the first term of this equation
+    (the second term cancels out during the integration over \f$\varphi\f$), which is identical to
+    the univariate distribution for \f$\theta\f$ given earlier for the unpolarized case. We can
+    thus use the same sampling procedure for \f$\theta\f$.
+
+    Once a random \f$\theta\f$ has been selected, we sample an azimuth angle \f$\varphi\f$ from the
+    normalized conditional distribution, again obtained similary as in Peest et al. 2017:
+
+    \f[ \Phi'_\theta(x, \varphi, {\bf{S}}) \propto 1 + \frac{{\rm S}_{12}(x,\theta)} {{\rm
+    S}_{11}(x,\theta)} P_\text{L}\cos2(\varphi-\gamma) \f]
+
+    This expression has the same form as the formula derived for Thomson scattering by Peest et al.
+    2017, but with different matrix elements \f${\rm S}_{11}(x,\theta)\f$ and \f${\rm
+    S}_{12}(x,\theta)\f$. Given a uniform deviate \f$\chi\f$ between 0 and 1, a random
+    \f$\varphi\f$ can be obtained from this distribution by solving the equation
+
+    \f[ \chi = \int_0^\varphi \Phi'_\theta(x, \varphi', {\bf{S}})\, d\varphi' =
+    \frac{1}{2\pi}\left( \varphi + \frac{{{\rm S}_{12}(\theta, x)}}{{\rm S}_{11}(\theta, x)}
+    P_\text{L}\sin\varphi\cos(\varphi-2\gamma)\right), \f]
+
+    which must be inverted for \f$\varphi\f$ numerically. */
 class ComptonPhaseFunction
 {
     //============= Construction - Setup - Destruction =============

--- a/SKIRT/core/ComptonPhaseFunction.hpp
+++ b/SKIRT/core/ComptonPhaseFunction.hpp
@@ -61,8 +61,8 @@ class StokesVector;
     The Müller matrix describing Compton scattering can be expressed as a function of the
     scattering angle \f$\theta\f$ and the incoming photon energy \f$x\f$ as follows (Fano 1949):
 
-    \f[ {\bf{M}}(x,\theta) \propto \begin{pmatrix} C^3(x,\theta) + C(x,\theta) -C^2(\theta,
-    x)\sin^2\theta & -C^2(x,\theta)\sin^2\theta & 0 & 0 \\ -C^2(x,\theta)\sin^2\theta &
+    \f[ {\bf{M}}(x,\theta) \propto \begin{pmatrix} C^3(x,\theta) + C(x,\theta) -C^2(x,\theta)
+    \sin^2\theta & -C^2(x,\theta)\sin^2\theta & 0 & 0 \\ -C^2(x,\theta)\sin^2\theta &
     C^2(x,\theta) (1+\cos^2\theta) & 0 & 0 \\ 0 & 0 & 2C^2(x,\theta)\cos\theta & 0 \\ 0 & 0 & 0 &
     (C^3(x,\theta) + C(x,\theta)) \cos\theta \end{pmatrix}, \f]
 
@@ -141,27 +141,20 @@ private:
 
 private:
     /** This function returns the value of the scattering phase function \f$\Phi(\theta,\phi)\f$
-        for the specified incoming photon energy, the specified scattering angles \f$\theta\f$ and
-        \f$\phi\f$, and the specified incoming polarization state. The phase function is normalized
-        as \f[\int\Phi(\theta,\phi) \,\mathrm{d}\Omega =4\pi.\f]
+        for the specified incoming photon energy, the scattering angles \f$\theta\f$ (specified
+        through its cosine) and \f$\phi\f$, and the specified incoming polarization state. The
+        phase function is normalized as \f[\int\Phi(\theta,\phi) \,\mathrm{d}\Omega =4\pi.\f] */
+    double phaseFunctionValue(double x, double costheta, double phi, const StokesVector* sv) const;
 
-        For Compton scattering, ... */
-    double phaseFunctionValue(double x, double theta, double phi, const StokesVector* sv) const;
-
-    /** This function generates random scattering angles \f$\theta\f$ and \f$\phi\f$ sampled from
-        the phase function \f$\Phi(\theta,\phi)\f$ for the specified incoming photon energy and the
-        specified incoming polarization state. The results are returned as a pair of numbers in the
-        order \f$\theta\f$ and \f$\phi\f$.
-
-        For Compton scattering, ... */
-    std::pair<double, double> generateAnglesFromPhaseFunction(double x, const StokesVector* sv) const;
+    /** This function generates a random azimuthal scattering angle \f$\phi\f$ sampled from the
+        marginal phase function for the specified incoming photon energy and incoming polarization
+        state, and given the specified scattering angle cosine \f$\cos\theta\f$. */
+    double generateAzimuthFromPhaseFunction(double x, const StokesVector* sv, double costheta) const;
 
     /** This function applies the Mueller matrix transformation for the specified incoming photon
-        energy and the specified scattering angle \f$\theta\f$ to the given polarization state
-        (which serves as both input and output for the function).
-
-        For Compton scattering, ... */
-    void applyMueller(double x, double theta, StokesVector* sv) const;
+        energy and the specified scattering angle cosine \f$\cos\theta\f$ to the given polarization
+        state (which serves as both input and output for the function). */
+    void applyMueller(double x, double costheta, StokesVector* sv) const;
 
     //======== Perform scattering with or without polarization =======
 
@@ -171,16 +164,14 @@ public:
         outgoing photon packet for the given geometry and incoming wavelength and polarization
         state. The contributions to the Stokes vector components are added to the incoming values
         of the \em I, \em Q, \em U, \em V arguments, and the adjusted wavelength is stored in the
-        \em lambda argument. See the description of the MaterialMix::peeloffScattering() function
-        for more information. */
+        \em lambda argument. */
     void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfk, Direction bfkobs,
                            Direction bfky, const StokesVector* sv) const;
 
-    /** Given the incoming photon packet wavelength, direction  and polarization
-        state this function calculates a
-        randomly sampled new propagation direction for a Compton scattering event, and determines
-        the adjusted wavelength of the outgoing photon packet. The adjusted wavelength is stored in
-        the \em lambda argument, and the direction is returned. */
+    /** Given the incoming photon packet wavelength, direction and polarization state, this
+        function calculates a randomly sampled new propagation direction for a Compton scattering
+        event, and determines the adjusted wavelength of the outgoing photon packet. The adjusted
+        wavelength is stored in the \em lambda argument, and the direction is returned. */
     Direction performScattering(double& lambda, Direction bfk, StokesVector* sv) const;
 
     //======================== Data Members ========================
@@ -189,6 +180,12 @@ private:
     // the simulation's random number generator - initialized by initialize()
     Random* _random{nullptr};
     bool _includePolarization{false};
+
+    // precalculated discretizations - initialized during construction
+    Array _phiv;   // indexed on f
+    Array _phi1v;  // indexed on f
+    Array _phisv;  // indexed on f
+    Array _phicv;  // indexed on f
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ElectronMix.cpp
+++ b/SKIRT/core/ElectronMix.cpp
@@ -196,7 +196,7 @@ void ElectronMix::peeloffScattering(double& I, double& Q, double& U, double& V, 
 
     // perform the scattering event in the electron rest frame
     if (_hasCompton && lambda < comptonWL)
-        _cpf.peeloffScattering(I, lambda, pp->direction(), bfkobs);
+        _cpf.peeloffScattering(I, Q, U, V, lambda, pp->direction(), bfkobs, bfky, pp);
     else
         _dpf.peeloffScattering(I, Q, U, V, pp->direction(), bfkobs, bfky, pp);
 
@@ -225,7 +225,7 @@ void ElectronMix::performScattering(double lambda, const MaterialState* state, P
 
     // determine the new propagation direction, and if required,
     // update the wavelength or the polarization state of the photon packet
-    Direction bfknew = (_hasCompton && lambda < comptonWL) ? _cpf.performScattering(lambda, pp->direction())
+    Direction bfknew = (_hasCompton && lambda < comptonWL) ? _cpf.performScattering(lambda, pp->direction(), pp)
                                                            : _dpf.performScattering(pp->direction(), pp);
 
     // if we have dispersion, adjust the outgoing wavelength from the electron rest frame

--- a/SKIRT/core/ElectronMix.hpp
+++ b/SKIRT/core/ElectronMix.hpp
@@ -16,22 +16,21 @@
     Electrons do not absorb photons. They do, however, significantly scatter photons. This process
     is described by Compton scattering, which converges to Thomson scattering at low photon
     energies. It is meaningful to implement both processes, because the calculations for Compton
-    scattering are substantially slower than those for Thomson scattering.
+    scattering are substantially slower than those for Thomson scattering. If requested by the
+    user, polarization by scattering is fully supported in both regimes.
 
     <b>Compton and Thomson scattering</b>
 
     For wavelengths shorter than 10 nm, this class models Compton scattering, which features a
     wavelength-dependent cross section and phase function, and which causes the photon energy
     (wavelength) to change during the interaction. This process is implemented through the
-    ComptonPhaseFunction class; see that class for more information. The current implementation of
-    Compton scattering does not support polarization.
+    ComptonPhaseFunction class; see that class for more information.
 
     For wavelengths longer than 10nm, the scattering process can be described by elastic and
     wavelength-independent Thomson scattering. The scattering cross section is given by the
     well-known Thomson cross section (a constant) and the phase function is that of a dipole.
     Consequently, this class calls on the DipolePhaseFunction class to implement Thomson
-    scattering; see that class for more information. In this wavelength regime, polarization is
-    fully supported (if enabled by the user).
+    scattering; see that class for more information.
 
     The transition point between Compton and Thomson scattering can be justified as follows. For
     wavelengths much longer than 10 nm, the expression for the Compton cross section becomes
@@ -135,14 +134,14 @@ public:
     double sectionAbs(double lambda) const override;
 
     /** This function returns the scattering cross section per electron
-        \f$\varsigma^{\text{sca}}_{\lambda}\f$ which is constant and equal to the Thomson cross
-        section for all wavelengths \f$\lambda\f$. */
+        \f$\varsigma^{\text{sca}}_{\lambda}\f$ which varies with the wavelength \f$\lambda\f$ for
+        high energies and converges to the constant Thomson cross section at low energies. */
     double sectionSca(double lambda) const override;
 
     /** This function returns the total extinction cross section per electron
         \f$\varsigma^{\text{ext}}_{\lambda} = \varsigma^{\text{abs}}_{\lambda} +
-        \varsigma^{\text{sca}}_{\lambda}\f$ which is constant and equal to the Thomson cross
-        section for all wavelengths \f$\lambda\f$. */
+        \varsigma^{\text{sca}}_{\lambda}\f$. Because the absorption cross section is trivially
+        zero, this equals the scattering cross section. */
     double sectionExt(double lambda) const override;
 
     //======== High-level photon life cycle =======
@@ -152,33 +151,27 @@ public:
     double opacityAbs(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function returns the scattering opacity \f$k^\text{sca}=n\varsigma^\text{sca}\f$ for
-        the given material state. The wavelength and photon properties are not used, because the
-        cross section is considered to be equal to the Thomson cross section for all wavelengths.
-        */
+        the given material state and wavelength. The photon properties are not used because the
+        cross section does not depend on the polarization state of the incoming photon packet. */
     double opacitySca(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function returns the extinction opacity \f$k^\text{ext}=k^\text{abs}+k^\text{sca}\f$
-        for the given material state. The wavelength and photon properties are not used, because
-        the cross section is considered to be equal to the Thomson cross section for all
-        wavelengths. */
+        for the given material state and wavelength. The photon properties are not used because the
+        cross section does not depend on the polarization state of the incoming photon packet. */
     double opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function calculates the contribution of the medium component associated with this
-        material mix to the peel-off photon luminosity, polarization state, and wavelength shift
-        for the given wavelength, geometry, material state, and photon properties. See the
-        description of the MaterialMix::peeloffScattering() function for more information.
-
-        For electrons, the function implements wavelenth-independent dipole scattering without or
-        with support for polarization depending on the user-configured \em includePolarization
-        property. */
+        electron mix to the peel-off photon luminosity, polarization state, and wavelength shift
+        for the given wavelength, geometry, material state, and photon properties. If \em
+        includePolarization has been set to true, the function supports polarization; otherwise it
+        does not. */
     void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
                            const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state and the receiving
-        material mix. For electrons, the function implements wavelenth-independent dipole
-        scattering without or with support for polarization depending on the user-configured \em
-        includePolarization property. */
+        electron mix. If \em includePolarization has been set to true, the function supports
+        polarization; otherwise it does not. */
     void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const override;
 
     //======================== Probing ========================
@@ -195,9 +188,8 @@ public:
     //======================== Data Members ========================
 
 private:
-    // flags initialized during setup
+    // flag initialized during setup
     bool _hasDispersion{false};  // true if thermal velocity dispersion is enabled
-    bool _hasCompton{false};     // true if support for Compton scattering is enabled
 
     // the dipole and Compton phase function helper instances - initialized during setup
     DipolePhaseFunction _dpf;

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -251,7 +251,8 @@ namespace
         {
             if (lambda < comptonWL)
             {
-                _cpf.peeloffScattering(I, lambda, bfk, bfkobs);
+                double Q, U, V;
+                _cpf.peeloffScattering(I, Q, U, V, lambda, bfk, bfkobs, Direction(), nullptr);
             }
             else
             {
@@ -262,7 +263,8 @@ namespace
 
         Direction performScattering(double& lambda, int /*Z*/, Direction bfk) const override
         {
-            return lambda < comptonWL ? _cpf.performScattering(lambda, bfk) : _dpf.performScattering(bfk, nullptr);
+            return lambda < comptonWL ? _cpf.performScattering(lambda, bfk, nullptr)
+                                      : _dpf.performScattering(bfk, nullptr);
         }
     };
 }

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -51,7 +51,7 @@
 
     Electrons bound to the atoms in the gas scatter incoming X-ray photons. This process can be
     elastic (Rayleigh scattering) or inelastic (bound-Compton scattering). The user can select one
-    of four implementations of bound-electron scattering. In increasing order of accuracy and
+    of five implementations of bound-electron scattering. In increasing order of accuracy and
     computational effort, these are:
 
     - \em None: ignore scattering by bound electrons. This approximation works reasonably well for
@@ -62,6 +62,9 @@
     high energies (because the bound-electron scattering cross section approaches that of
     free-electron scattering) and for lower energies (because the total scattering cross section is
     dominated by photo-absorption anyway). However, it is less accurate for intermediate energies.
+
+    - \em FreeWithPolarization: use free-electron Compton scattering with support for polarization.
+    In the current implementation, this is the only option with polarization support.
 
     - \em Good: use the smooth Rayleigh scattering approximation and exact bound-Compton
     scattering. This reflects the implementation by most X-ray codes and can be considered to be a
@@ -143,7 +146,7 @@
 
     <b>Electron scattering</b>
 
-    As described above, this class provides four implementations for the scattering of X-rays
+    As described above, this class provides several implementations for the scattering of X-rays
     photons by the electrons bound to the atoms. These implementations involve four types of
     scattering: free-electron Compton scattering, bound-electron Compton scattering, smooth
     Rayleigh scattering, and anomalous Rayleigh scattering. Note that, in all cases, the listed
@@ -226,9 +229,11 @@ class XRayAtomicGasMix : public MaterialMix
 {
     /** The enumeration type indicating the implementation used for scattering by bound electrons.
         */
-    ENUM_DEF(BoundElectrons, None, Free, Good, Exact)
+    ENUM_DEF(BoundElectrons, None, Free, FreeWithPolarization, Good, Exact)
         ENUM_VAL(BoundElectrons, None, "ignore bound electrons")
         ENUM_VAL(BoundElectrons, Free, "use free-electron Compton scattering")
+        ENUM_VAL(BoundElectrons, FreeWithPolarization,
+                 "use free-electron Compton scattering with support for polarization")
         ENUM_VAL(BoundElectrons, Good, "use smooth Rayleigh scattering and exact bound-Compton scattering")
         ENUM_VAL(BoundElectrons, Exact, "use anomalous Rayleigh scattering and exact bound-Compton scattering")
     ENUM_END()
@@ -280,6 +285,11 @@ public:
     /** This function returns the fundamental material type represented by this material mix, which
         is MaterialType::Gas. */
     MaterialType materialType() const override;
+
+    /** This function returns true if this material mix supports polarization during scattering
+        events. For this class, the function returns true if the \em scatterBoundElectrons property
+        has been set to \c FreeWithPolarization and false otherwise. */
+    bool hasPolarizedScattering() const override;
 
     /** This function returns true, indicating that a scattering interaction for this material mix
         may (and usually does) adjust the wavelength of the interacting photon packet. */

--- a/SKIRT/utils/StokesVector.cpp
+++ b/SKIRT/utils/StokesVector.cpp
@@ -140,13 +140,20 @@ double StokesVector::rotateIntoPlane(Direction k, Direction knew)
 
 //////////////////////////////////////////////////////////////////////
 
+void StokesVector::applyMueller(double S11, double S12, double S22, double S33, double S34, double S44)
+{
+    double I = S11 + S12 * _Q;
+    double Q = S12 + S22 * _Q;
+    double U = S33 * _U + S34 * _V;
+    double V = -S34 * _U + S44 * _V;
+    setPolarized(I, Q, U, V, _normal);
+}
+
+//////////////////////////////////////////////////////////////////////
+
 void StokesVector::applyMueller(double S11, double S12, double S33, double S34)
 {
-    double I = S11 * 1. + S12 * _Q;
-    double Q = S12 * 1. + S11 * _Q;
-    double U = S33 * _U + S34 * _V;
-    double V = -S34 * _U + S33 * _V;
-    setPolarized(I, Q, U, V, _normal);
+    applyMueller(S11, S12, S11, S33, S34, S33);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/StokesVector.hpp
+++ b/SKIRT/utils/StokesVector.hpp
@@ -101,7 +101,17 @@ public:
 
     /** This function adjusts the Stokes vector for a rotation of the reference axis about the
         given flight direction \f$\bf{k}\f$ over the specified angle \f$\phi\f$, clockwise when
-        looking along \f$\bf{k}\f$.*/
+        looking along \f$\bf{k}\f$. Such rotation is described by the transformation matrix
+
+        \f[
+        {\bf{R}} =
+        \begin{pmatrix}
+        1 & 0 & 0 & 0 \\
+        0 & \cos 2\phi & \sin 2\phi & 0 \\
+        0 & -\sin 2\phi & \cos 2\phi & 0 \\
+        0 & 0 & 0 & 1
+        \end{pmatrix}.
+        \f]  */
     void rotateStokes(double phi, Direction k);
 
     /** This function adjusts the stokes vector reference axis so it is in the plane of the given
@@ -111,8 +121,36 @@ public:
     double rotateIntoPlane(Direction k, Direction knew);
 
     /** This function transforms the polarization state described by this Stokes vector by applying
-        the Mueller matrix with the specified coefficients (and zero elements elsewhere) to its
-        existing state. */
+        to its existing state a Mueller matrix of the form
+
+        \f[
+        {\bf{M}} \propto
+        \begin{pmatrix}
+        {\rm S}_{11} & {\rm S}_{12} & 0 & 0 \\
+        {\rm S}_{12} & {\rm S}_{22} & 0 & 0 \\
+        0 & 0 & {\rm S}_{33} & {\rm S}_{34} \\
+        0 & 0 & -{\rm S}_{34} &  {\rm S}_{44}
+        \end{pmatrix},
+        \f]
+
+        assuming that \f${\rm S}_{21} = {\rm S}_{12}\f$ and \f${\rm S}_{43} = -{\rm S}_{34}\f$. */
+    void applyMueller(double S11, double S12, double S22, double S33, double S34, double S44);
+
+    /** This function transforms the polarization state described by this Stokes vector by applying
+        to its existing state a Mueller matrix of the form
+
+        \f[
+        {\bf{M}} \propto
+        \begin{pmatrix}
+        {\rm S}_{11} & {\rm S}_{12} & 0 & 0 \\
+        {\rm S}_{12} & {\rm S}_{11} & 0 & 0 \\
+        0 & 0 & {\rm S}_{33} & {\rm S}_{34} \\
+        0 & 0 & -{\rm S}_{34} &  {\rm S}_{33}
+        \end{pmatrix},
+        \f]
+
+        assuming that \f${\rm S}_{21} = {\rm S}_{12}\f$, \f${\rm S}_{43} = -{\rm S}_{34}\f$,
+        \f${\rm S}_{22} = {\rm S}_{11}\f$ and \f${\rm S}_{44} = {\rm S}_{44}\f$. */
     void applyMueller(double S11, double S12, double S33, double S34);
 
 private:


### PR DESCRIPTION
**Description**
With this update, we support polarization for Compton scattering by free electrons represented by the `ElectronMix` class or as part of the `XRayAtomicGasMix` class. As a result, both media types now support polarization across the full wavelength range (i.e. for both Thomson and Compton scattering). 

Important limitation: the XRayAtomicGasMix class supports polarization only in the approximation where the bound electrons are treated as free electrons.

**Motivation**
Polarization at high energies is relevant for simulations of certain X-ray observations.

**Tests**
The existing functional tests still run correctly. However, the new functionality has been not yet been tested extensively.

_Use with care!_
