### PR TITLE
Minor scattering peel-off code improvement

### DIFF
--- a/SKIRT/core/ComptonPhaseFunction.cpp
+++ b/SKIRT/core/ComptonPhaseFunction.cpp
@@ -198,8 +198,8 @@ void ComptonPhaseFunction::peeloffScattering(double& I, double& Q, double& U, do
         // calculate the value of the phase function
         double value = phaseFunctionValueForCosine(x, costheta);
 
-        // accumulate the weighted sum in the intensity
-        I += value;
+        // store this value as the intensity
+        I = value;
     }
     else
     {
@@ -220,11 +220,11 @@ void ComptonPhaseFunction::peeloffScattering(double& I, double& Q, double& U, do
         // it is given bfkobs because the photon is at this point aimed towards the observer
         svnew.rotateIntoPlane(bfkobs, bfky);
 
-        // acumulate the weighted sum of all Stokes components to support polarization
-        I += value * svnew.stokesI();
-        Q += value * svnew.stokesQ();
-        U += value * svnew.stokesU();
-        V += value * svnew.stokesV();
+        // store the new Stokes vector components
+        I = value * svnew.stokesI();
+        Q = value * svnew.stokesQ();
+        U = value * svnew.stokesU();
+        V = value * svnew.stokesV();
     }
 
     // adjust the wavelength

--- a/SKIRT/core/ComptonPhaseFunction.hpp
+++ b/SKIRT/core/ComptonPhaseFunction.hpp
@@ -162,9 +162,9 @@ public:
     /** This function calculates the contribution of a Compton scattering event to the peel-off
         photon luminosity and polarization state and determines the adjusted wavelength of the
         outgoing photon packet for the given geometry and incoming wavelength and polarization
-        state. The contributions to the Stokes vector components are added to the incoming values
-        of the \em I, \em Q, \em U, \em V arguments, and the adjusted wavelength is stored in the
-        \em lambda argument. */
+        state. The contributions to the Stokes vector components are stored in the \em I, \em Q,
+        \em U, \em V arguments, which are guaranteed to be initialized to zero by the caller. The
+        adjusted wavelength value replaces the incoming value of the \em lambda argument. */
     void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfk, Direction bfkobs,
                            Direction bfky, const StokesVector* sv) const;
 

--- a/SKIRT/core/DipolePhaseFunction.cpp
+++ b/SKIRT/core/DipolePhaseFunction.cpp
@@ -128,8 +128,8 @@ void DipolePhaseFunction::peeloffScattering(double& I, double& Q, double& U, dou
         double costheta = Vec::dot(bfk, bfkobs);
         double value = phaseFunctionValueForCosine(costheta);
 
-        // accumulate the weighted sum in the intensity
-        I += value;
+        // store this value as the intensity
+        I = value;
     }
     else
     {
@@ -151,11 +151,11 @@ void DipolePhaseFunction::peeloffScattering(double& I, double& Q, double& U, dou
         // it is given bfkobs because the photon is at this point aimed towards the observer
         svnew.rotateIntoPlane(bfkobs, bfky);
 
-        // acumulate the weighted sum of all Stokes components to support polarization
-        I += value * svnew.stokesI();
-        Q += value * svnew.stokesQ();
-        U += value * svnew.stokesU();
-        V += value * svnew.stokesV();
+        // store the new Stokes vector components
+        I = value * svnew.stokesI();
+        Q = value * svnew.stokesQ();
+        U = value * svnew.stokesU();
+        V = value * svnew.stokesV();
     }
 }
 

--- a/SKIRT/core/DipolePhaseFunction.hpp
+++ b/SKIRT/core/DipolePhaseFunction.hpp
@@ -115,9 +115,8 @@ private:
 public:
     /** This function calculates the contribution of a dipole scattering event to the peel-off
         photon luminosity and polarization state for the given geometry and polarization state. The
-        contributions to the Stokes vector components are added to the incoming values of the \em
-        I, \em Q, \em U, \em V arguments. See the description of the
-        MaterialMix::peeloffScattering() function for more information. */
+        contributions to the Stokes vector components are stored in the \em I, \em Q, \em U, \em V
+        arguments, which are guaranteed to be initialized to zero by the caller. */
     void peeloffScattering(double& I, double& Q, double& U, double& V, Direction bfk, Direction bfkobs, Direction bfky,
                            const StokesVector* sv) const;
 

--- a/SKIRT/core/DustMix.cpp
+++ b/SKIRT/core/DustMix.cpp
@@ -439,8 +439,8 @@ void DustMix::peeloffScattering(double& I, double& Q, double& U, double& V, doub
             double g = asymmpar(lambda);
             double value = abs(g) > glarge ? meanHG(g, costheta) : valueHG(g, costheta);
 
-            // accumulate the weighted sum in the intensity (no support for polarization in this case)
-            I += value;
+            // store this value as the intensity (no support for polarization in this case)
+            I = value;
             break;
         }
         case DustMix::ScatteringMode::MaterialPhaseFunction:
@@ -449,8 +449,8 @@ void DustMix::peeloffScattering(double& I, double& Q, double& U, double& V, doub
             double costheta = Vec::dot(pp->direction(), bfkobs);
             double value = phaseFunctionValueForCosine(lambda, costheta);
 
-            // accumulate the weighted sum in the intensity (no support for polarization in this case)
-            I += value;
+            // store this value as the intensity (no support for polarization in this case)
+            I = value;
             break;
         }
         case DustMix::ScatteringMode::SphericalPolarization:
@@ -474,11 +474,11 @@ void DustMix::peeloffScattering(double& I, double& Q, double& U, double& V, doub
             // it is given bfkobs because the photon is at this point aimed towards the observer
             sv.rotateIntoPlane(bfkobs, bfky);
 
-            // acumulate the weighted sum of all Stokes components to support polarization
-            I += value * sv.stokesI();
-            Q += value * sv.stokesQ();
-            U += value * sv.stokesU();
-            V += value * sv.stokesV();
+            // store the new Stokes vector components to support polarization
+            I = value * sv.stokesI();
+            Q = value * sv.stokesQ();
+            U = value * sv.stokesU();
+            V = value * sv.stokesV();
             break;
         }
     }

--- a/SKIRT/core/DustMix.hpp
+++ b/SKIRT/core/DustMix.hpp
@@ -257,16 +257,18 @@ public:
 
     /** This function calculates the contribution of the medium component associated with this
         material mix to the peel-off photon luminosity, polarization state, and wavelength shift
-        for the given wavelength, geometry, material state, and photon properties. See the
-        description of the MaterialMix::peeloffScattering() function for more information.
+        for the given wavelength, geometry, material state, and photon properties. The
+        contributions to the Stokes vector components are stored in the \em I, \em Q, \em U, \em V
+        arguments, which are guaranteed to be initialized to zero by the caller. For dust mixes,
+        the wavelength remains unchanged.
 
-        For dust mixes, evaluation of the phase function depends on the scattering mode supported
-        by supported by the dust mix, as defined by each subclass. For the most basic mode, the
-        material mix provides a value for the scattering asymmetry parameter
-        \f$g=\left<\cos\theta\right>\f$. A value of \f$g=0\f$ corresponds to isotropic scattering.
-        Other values \f$-1\le g\le 1\f$ are substituted in the Henyey-Greenstein phase function,
-        \f[ \Phi(\cos\theta) = \frac{1-g^2} {(1+g^2-2g\cos\theta)^{3/2}}. \f] For other scattering
-        modes, the phase function provided by the material mix is invoked instead.
+        Evaluation of the phase function depends on the scattering mode supported by supported by
+        the dust mix, as defined by each subclass. For the most basic mode, the material mix
+        provides a value for the scattering asymmetry parameter \f$g=\left<\cos\theta\right>\f$. A
+        value of \f$g=0\f$ corresponds to isotropic scattering. Other values \f$-1\le g\le 1\f$ are
+        substituted in the Henyey-Greenstein phase function, \f[ \Phi(\cos\theta) = \frac{1-g^2}
+        {(1+g^2-2g\cos\theta)^{3/2}}. \f] For other scattering modes, the phase function provided
+        by the material mix is invoked instead.
 
         In case polarization is supported in the current simulation configuration, the polarization
         state of the peel off photon packet is adjusted as well. The adjusted Stokes vector for a

--- a/SKIRT/core/ElectronMix.hpp
+++ b/SKIRT/core/ElectronMix.hpp
@@ -162,9 +162,14 @@ public:
 
     /** This function calculates the contribution of the medium component associated with this
         electron mix to the peel-off photon luminosity, polarization state, and wavelength shift
-        for the given wavelength, geometry, material state, and photon properties. If \em
-        includePolarization has been set to true, the function supports polarization; otherwise it
-        does not. */
+        for the given wavelength, geometry, material state, and photon properties. The
+        contributions to the Stokes vector components are stored in the \em I, \em Q, \em U, \em V
+        arguments, which are guaranteed to be initialized to zero by the caller. If there is
+        wavelength shift, the new wavelength value replaces the incoming value of the \em lambda
+        argument.
+
+        If \em includePolarization has been set to true, the function supports polarization;
+        otherwise it does not. */
     void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
                            const MaterialState* state, const PhotonPacket* pp) const override;
 

--- a/SKIRT/core/FragmentDustMixDecorator.hpp
+++ b/SKIRT/core/FragmentDustMixDecorator.hpp
@@ -181,7 +181,9 @@ public:
         material mix to the peel-off photon luminosity, polarization state, and wavelength shift
         for the given wavelength, geometry, material state, and photon properties. The relative
         weight of each fragment's contribution is adjusted by the relative scattering opacity of
-        the fragment. */
+        the fragment. The contributions to the Stokes vector components are stored in the \em I,
+        \em Q, \em U, \em V arguments, which are guaranteed to be initialized to zero by the
+        caller. For dust mixes, the wavelength remains unchanged. */
     void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
                            const MaterialState* state, const PhotonPacket* pp) const override;
 

--- a/SKIRT/core/LyaNeutralHydrogenGasMix.hpp
+++ b/SKIRT/core/LyaNeutralHydrogenGasMix.hpp
@@ -138,8 +138,10 @@ public:
 
     /** This function calculates the contribution of the medium component associated with this
         material mix to the peel-off photon luminosity, polarization state, and wavelength shift,
-        for the given wavelength, geometry, material state, and photon properties. See the
-        description of the MaterialMix::peeloffScattering() function for more information.
+        for the given wavelength, geometry, material state, and photon properties. The
+        contributions to the Stokes vector components are stored in the \em I, \em Q, \em U, \em V
+        arguments, which are guaranteed to be initialized to zero by the caller, and the adjusted
+        wavelength is stored in the \em lambda argument.
 
         For the Lyman-alpha material mix, the function implements resonant scattering without or
         with support for polarization depending on the user-configured \em includePolarization

--- a/SKIRT/core/MaterialMix.hpp
+++ b/SKIRT/core/MaterialMix.hpp
@@ -443,9 +443,10 @@ public:
     /** This function calculates the contribution of the medium component associated with this
         material mix to the peel-off photon luminosity, polarization state, and wavelength shift
         for the given wavelength, geometry, material state, and photon properties. The
-        contributions to the Stokes vector components are added to the incoming values of the \em
-        I, \em Q, \em U, \em V arguments. If there is wavelength shift, the new wavelength value
-        replaces the incoming value of the \em lambda argument.
+        contributions to the Stokes vector components are stored in the \em I, \em Q, \em U, \em V
+        arguments, which are guaranteed to be initialized to zero by the caller. If there is a
+        wavelength shift, the new wavelength value replaces the incoming value of the \em lambda
+        argument.
 
         Since we force the peel-off photon packet to be scattered from the direction \f${\bf{k}}\f$
         into the direction \f${\bf{k}}_{\text{obs}}\f$, the corresponding biasing factor is given

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -755,7 +755,12 @@ void MediumSystem::peelOffScattering(const ShortArray& wv, double lambda, Direct
 
     // pass the result to the peel-off photon packet
     ppp->launchScatteringPeelOff(pp, bfkobs, _state.bulkVelocity(m), lambda, I);
-    if (_config->hasPolarization()) ppp->setPolarized(I, Q, U, V, pp->normal());
+    if (_config->hasPolarization())
+    {
+        // the Stokes vector has already been rotated towards the observer frame,
+        // so the reference direction is no longer used and can be left unspecified
+        ppp->setPolarized(I, Q, U, V);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -774,7 +779,12 @@ void MediumSystem::peelOffScattering(int h, double w, double lambda, Direction b
 
     // pass the result to the peel-off photon packet
     ppp->launchScatteringPeelOff(pp, bfkobs, _state.bulkVelocity(m), lambda, I * w);
-    if (_config->hasPolarization()) ppp->setPolarized(I, Q, U, V, pp->normal());
+    if (_config->hasPolarization())
+    {
+        // the Stokes vector has already been rotated towards the observer frame,
+        // so the reference direction is no longer used and can be left unspecified
+        ppp->setPolarized(I, Q, U, V);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/TrivialGasMix.cpp
+++ b/SKIRT/core/TrivialGasMix.cpp
@@ -99,8 +99,8 @@ void TrivialGasMix::peeloffScattering(double& I, double& /*Q*/, double& /*U*/, d
     double t = 1. + g * g - 2. * g * costheta;
     double value = (1. - g) * (1. + g) / sqrt(t * t * t);
 
-    // accumulate the weighted sum in the intensity
-    I += value;
+    // store this value as the intensity
+    I = value;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -1069,8 +1069,8 @@ void XRayAtomicGasMix::peeloffScattering(double& I, double& Q, double& U, double
     // fluorescence
     else
     {
-        // unpolarized isotropic emission, so the bias weight is trivially 1 and QUV remain unchanged
-        I += 1.;
+        // unpolarized isotropic emission; the bias weight is trivially 1 and there is no contribution to Q, U, V
+        I = 1.;
 
         // update the photon packet wavelength to the wavelength of this fluorescence transition
         lambda = _lambdafluov[scatinfo->species - 2 * numAtoms];

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -349,15 +349,20 @@ private:
 
 public:
     /** This function calculates the contribution of the medium component associated with this
-        material mix to the peel-off photon luminosity and wavelength shift for the given
-        wavelength and observer direction. It first calls the private setScatteringInfoIfNeeded()
-        function to establish a random scattering channel and atom velocity for this event.
+        material mix to the peel-off photon luminosity, polarization state, and wavelength shift
+        for the given wavelength, geometry, material state, and photon properties. The
+        contributions to the Stokes vector components are stored in the \em I, \em Q, \em U, \em V
+        arguments, which are guaranteed to be initialized to zero by the caller. If there is
+        wavelength shift, the new wavelength value replaces the incoming value of the \em lambda
+        argument.
 
-        In case the selected channel is bound electron scattering, the peel-off bias weight and
-        wavelength shift are determined by the Compton phase function and the selected atom
-        velocity. For fluorescence, the peel-off bias weight is trivially one because emission is
-        isotropic, and the outgoing wavelength is determined by Doppler-shifting the rest
-        wavelength of the selected fluorescence transition for the selected atom velocity. */
+        The function first calls the private setScatteringInfoIfNeeded() function to establish a
+        random scattering channel and atom velocity for this event. In case the selected channel is
+        bound electron scattering, the peel-off bias weight and wavelength shift are determined by
+        the Compton phase function and the selected atom velocity. For fluorescence, the peel-off
+        bias weight is trivially one because emission is isotropic and unpolarized, and the
+        outgoing wavelength is determined by Doppler-shifting the rest wavelength of the selected
+        fluorescence transition for the selected atom velocity. */
     void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
                            const MaterialState* state, const PhotonPacket* pp) const override;
 

--- a/SKIRT/utils/StokesVector.cpp
+++ b/SKIRT/utils/StokesVector.cpp
@@ -16,12 +16,29 @@ StokesVector::StokesVector(double I, double Q, double U, double V, Direction n)
 
 void StokesVector::setPolarized(double I, double Q, double U, double V, Direction n)
 {
-    if (I != 0.0)
+    if (I != 0.0 && !n.isNull())
     {
         _Q = Q / I;
         _U = U / I;
         _V = V / I;
         _normal = n;
+        _polarized = true;
+    }
+    else
+    {
+        setUnpolarized();
+    }
+}
+
+//////////////////////////////////////////////////////////////////////
+
+void StokesVector::setPolarized(double I, double Q, double U, double V)
+{
+    if (I != 0.0)
+    {
+        _Q = Q / I;
+        _U = U / I;
+        _V = V / I;
         _polarized = true;
     }
     else

--- a/SKIRT/utils/StokesVector.cpp
+++ b/SKIRT/utils/StokesVector.cpp
@@ -163,7 +163,7 @@ void StokesVector::applyMueller(double S11, double S12, double S22, double S33, 
     double Q = S12 + S22 * _Q;
     double U = S33 * _U + S34 * _V;
     double V = -S34 * _U + S44 * _V;
-    setPolarized(I, Q, U, V, _normal);
+    setPolarized(I, Q, U, V);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/StokesVector.hpp
+++ b/SKIRT/utils/StokesVector.hpp
@@ -46,10 +46,18 @@ public:
         _normal.set(0, 0, 0);
     }
 
-    /** This function sets the Stokes vector to the specified parameter values, after normalizing
-        them through division by \f$I\f$. If \f$I=0\f$, the Stokes vector is set to an unpolarized
-        state. */
+    /** This function sets the Stokes vector to the specified vector components and the specified
+        normal to the reference direction. The \f$Q, U, V\f$ components are normalized through
+        division by \f$I\f$. If \f$I=0\f$ or \f$n\f$ is the null vector, the Stokes vector is set
+        to an unpolarized state. */
     void setPolarized(double I, double Q, double U, double V, Direction n);
+
+    /** This function sets the Stokes vector to the specified vector components, leaving the
+        (normal to) the reference direction unspecified. This function can be used in case the
+        reference direction is determined by an external convention and no further transformations
+        will be performed on the Stokes vector. The \f$Q, U, V\f$ components are normalized through
+        division by \f$I\f$. If \f$I=0\f$, the Stokes vector is set to an unpolarized state. */
+    void setPolarized(double I, double Q, double U, double V);
 
     /** This function copies the specified Stokes vector into the receiver. */
     void setPolarized(const StokesVector& polarization);

--- a/SKIRT/utils/StokesVector.hpp
+++ b/SKIRT/utils/StokesVector.hpp
@@ -52,11 +52,12 @@ public:
         to an unpolarized state. */
     void setPolarized(double I, double Q, double U, double V, Direction n);
 
-    /** This function sets the Stokes vector to the specified vector components, leaving the
-        (normal to) the reference direction unspecified. This function can be used in case the
-        reference direction is determined by an external convention and no further transformations
-        will be performed on the Stokes vector. The \f$Q, U, V\f$ components are normalized through
-        division by \f$I\f$. If \f$I=0\f$, the Stokes vector is set to an unpolarized state. */
+    /** This function sets the Stokes vector to the specified vector components leaving the normal
+        to the reference direction unchanged. This function can be used when the reference
+        direction should not be updated, or in case it is determined by an external convention and
+        no further transformations will be performed on the Stokes vector. The \f$Q, U, V\f$
+        components are normalized through division by \f$I\f$. If \f$I=0\f$, the Stokes vector is
+        set to an unpolarized state. */
     void setPolarized(double I, double Q, double U, double V);
 
     /** This function copies the specified Stokes vector into the receiver. */


### PR DESCRIPTION
**Description**
This update slightly improves the code and documentation for the scattering peel-off implementation in the various material mixes. The functionality has not changed (at least, that is the intention).

**Motivation**
It should now be more obvious to the reader that the Stokes vector components other than the intensity do not need to be updated for a "scattering" process that always emits isotopic and unpolarized radiation. 
