### PR TITLE
Corrections to the optical prop files of the new composition for AGN dust

### DIFF
--- a/SKIRT/core/BegemannPorousAluminaGrainComposition.hpp
+++ b/SKIRT/core/BegemannPorousAluminaGrainComposition.hpp
@@ -15,7 +15,9 @@
     (1997) for wavelengths >7.8 microns. The optical properties for wavelengths <7.8 microns are
     taken from Laor, A, & Draine, B.T. 1993 ApJ 402,441. The calorimetric properties are those for
     astronomical silicates given by Draine & Li (2007), originally from Draine & Lee (1984). The
-    bulk mass density is set to 4020 kg/m3. */
+    bulk mass density is set to 4020 kg/m3. The grain shape is assumed to be a Continuous Distribution 
+    of Ellipsoids (CDE) and the grain size corresponds to a volume that a spherical grain with 
+    the given radius would have.*/
 class BegemannPorousAluminaGrainComposition : public GrainComposition
 {
     ITEM_CONCRETE(BegemannPorousAluminaGrainComposition, GrainComposition,

--- a/SKIRT/core/BegemannPorousAluminaGrainComposition.hpp
+++ b/SKIRT/core/BegemannPorousAluminaGrainComposition.hpp
@@ -15,9 +15,9 @@
     (1997) for wavelengths >7.8 microns. The optical properties for wavelengths <7.8 microns are
     taken from Laor, A, & Draine, B.T. 1993 ApJ 402,441. The calorimetric properties are those for
     astronomical silicates given by Draine & Li (2007), originally from Draine & Lee (1984). The
-    bulk mass density is set to 4020 kg/m3. The grain shape is assumed to be a Continuous Distribution 
-    of Ellipsoids (CDE) and the grain size corresponds to a volume that a spherical grain with 
-    the given radius would have.*/
+    bulk mass density is set to 4020 kg/m3. The grain shape is assumed to be a Continuous
+    Distribution of Ellipsoids (CDE) and the grain size corresponds to a volume that a spherical
+    grain with the given radius would have. */
 class BegemannPorousAluminaGrainComposition : public GrainComposition
 {
     ITEM_CONCRETE(BegemannPorousAluminaGrainComposition, GrainComposition,

--- a/SKIRT/core/DorschnerOlivineGrainComposition.hpp
+++ b/SKIRT/core/DorschnerOlivineGrainComposition.hpp
@@ -13,7 +13,8 @@
 /** The DorschnerOlivineGrainComposition class represents the optical and calorimetric properties
     of olivine dust grains. The optical properties are taken from Dorschner et al. (1995). The
     calorimetric properties are those for astronomical silicates given by Draine & Li (2007),
-    originally from Draine & Lee (1984). The bulk mass density is set to 3790 kg/m3 */
+    originally from Draine & Lee (1984). The bulk mass density is set to 3790 kg/m3. The grain shape 
+    is assumed to be a sphere (Mie particle). */
 class DorschnerOlivineGrainComposition : public GrainComposition
 {
     ITEM_CONCRETE(DorschnerOlivineGrainComposition, GrainComposition, "a Dorschner olivine dust grain composition")

--- a/SKIRT/core/DorschnerOlivineGrainComposition.hpp
+++ b/SKIRT/core/DorschnerOlivineGrainComposition.hpp
@@ -13,8 +13,8 @@
 /** The DorschnerOlivineGrainComposition class represents the optical and calorimetric properties
     of olivine dust grains. The optical properties are taken from Dorschner et al. (1995). The
     calorimetric properties are those for astronomical silicates given by Draine & Li (2007),
-    originally from Draine & Lee (1984). The bulk mass density is set to 3790 kg/m3. The grain shape 
-    is assumed to be a sphere (Mie particle). */
+    originally from Draine & Lee (1984). The bulk mass density is set to 3790 kg/m3. The grain
+    shape is assumed to be a sphere (Mie particle). */
 class DorschnerOlivineGrainComposition : public GrainComposition
 {
     ITEM_CONCRETE(DorschnerOlivineGrainComposition, GrainComposition, "a Dorschner olivine dust grain composition")

--- a/SKIRT/core/HofmeisterPericlaseGrainComposition.hpp
+++ b/SKIRT/core/HofmeisterPericlaseGrainComposition.hpp
@@ -13,9 +13,9 @@
 /** The HofmeisterPericlaseGrainComposition class represents the optical and calorimetric
     properties of periclase dust grains. The optical properties are taken from Hofmeister et al.
     (2003). The calorimetric properties are those for astronomical silicates given by Draine & Li
-    (2007), originally from Draine & Lee (1984). The bulk mass density is set to 3560 kg/m3.
-    The grain shape is assumed to be a Continuous Distribution of Ellipsoids (CDE) and the grain 
-    size corresponds to a volume that a spherical grain with the given radius would have. */
+    (2007), originally from Draine & Lee (1984). The bulk mass density is set to 3560 kg/m3. The
+    grain shape is assumed to be a Continuous Distribution of Ellipsoids (CDE) and the grain size
+    corresponds to a volume that a spherical grain with the given radius would have. */
 class HofmeisterPericlaseGrainComposition : public GrainComposition
 {
     ITEM_CONCRETE(HofmeisterPericlaseGrainComposition, GrainComposition,

--- a/SKIRT/core/HofmeisterPericlaseGrainComposition.hpp
+++ b/SKIRT/core/HofmeisterPericlaseGrainComposition.hpp
@@ -13,7 +13,9 @@
 /** The HofmeisterPericlaseGrainComposition class represents the optical and calorimetric
     properties of periclase dust grains. The optical properties are taken from Hofmeister et al.
     (2003). The calorimetric properties are those for astronomical silicates given by Draine & Li
-    (2007), originally from Draine & Lee (1984). The bulk mass density is set to 3560 kg/m3 */
+    (2007), originally from Draine & Lee (1984). The bulk mass density is set to 3560 kg/m3.
+    The grain shape is assumed to be a Continuous Distribution of Ellipsoids (CDE) and the grain 
+    size corresponds to a volume that a spherical grain with the given radius would have. */
 class HofmeisterPericlaseGrainComposition : public GrainComposition
 {
     ITEM_CONCRETE(HofmeisterPericlaseGrainComposition, GrainComposition,

--- a/SKIRT/resources/ExpectedResources.txt
+++ b/SKIRT/resources/ExpectedResources.txt
@@ -1,4 +1,4 @@
 Core 6
 BPASS 1
-ExtraDust 1
+ExtraDust 2
 AtomsMolecules 4


### PR DESCRIPTION
**Description**
The files of optical properties of Periclase and Porous Alumina calculated considering spherical grains were replaced by files with optical properties considering grains described by a continuous distribution of elliposids. For the Olivine file, only information was added in the commented section, where it is specified that the grains are spherical.
