### PR TITLE
Add TODDLERS star-forming region SED template library

### DIFF
--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -247,6 +247,8 @@
 #include "TemperatureProbe.hpp"
 #include "TemperatureWavelengthCellLibrary.hpp"
 #include "ThemisDustMix.hpp"
+#include "ToddlersSED.hpp"
+#include "ToddlersSEDFamily.hpp"
 #include "TorusGeometry.hpp"
 #include "TreePolicy.hpp"
 #include "TreeSpatialGrid.hpp"
@@ -339,6 +341,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<FSPSSED>();
     ItemRegistry::add<BpassSED>();
     ItemRegistry::add<MappingsSED>();
+    ItemRegistry::add<ToddlersSED>();
     ItemRegistry::add<TabulatedSED>();
     ItemRegistry::add<FileSED>();
     ItemRegistry::add<ListSED>();
@@ -362,6 +365,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<FileSSPSEDFamily>();
     ItemRegistry::add<FileIndexedSEDFamily>();
     ItemRegistry::add<MappingsSEDFamily>();
+    ItemRegistry::add<ToddlersSEDFamily>();
     ItemRegistry::add<LyaGaussianSEDFamily>();
     ItemRegistry::add<LyaDoublePeakedSEDFamily>();
     ItemRegistry::add<LyaSEDFamilyDecorator>();

--- a/SKIRT/core/ToddlersSED.cpp
+++ b/SKIRT/core/ToddlersSED.cpp
@@ -1,0 +1,24 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "ToddlersSED.hpp"
+#include "NR.hpp"
+#include "ToddlersSEDFamily.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+const SEDFamily* ToddlersSED::getFamilyAndParameters(Array& parameters)
+{
+    // set the parameters using arbitrary scaling
+    NR::assign(parameters, _age, _metallicity, _SFE, _cloudNumDensity, 1.);
+
+    // construct the library of SED models
+    return new ToddlersSEDFamily(
+        this,
+        _pahfraction == PAHFraction::High ? ToddlersSEDFamily::PAHFraction::High : ToddlersSEDFamily::PAHFraction::Low,
+        _resolution == Resolution::Low ? ToddlersSEDFamily::Resolution::Low : ToddlersSEDFamily::Resolution::High);
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ToddlersSED.hpp
+++ b/SKIRT/core/ToddlersSED.hpp
@@ -11,17 +11,14 @@
 ////////////////////////////////////////////////////////////////////
 
 /** A ToddlersSED class instance represents a single star-forming region SED taken from the
-    Toddlers template library, parameterized on age, metallicity, star formation efficiency, and
-    cloud number density. See the ToddlersSEDFamily class for more information.
-
-    TODDLERS = Time evolution of Dust Diagnostics and Line Emission from Regions containing young
-    Stars. */
+    TODDLERS template library, parameterized on age, metallicity, star formation efficiency, and
+    cloud number density. See the ToddlersSEDFamily class for more information. */
 class ToddlersSED : public FamilySED
 {
     /** The enumeration type indicating the maximum PAH-to-dust fraction. */
     ENUM_DEF(PAHFraction, High, Low)
-        ENUM_VAL(PAHFraction, High, "High PAH fraction (4.6%)")
-        ENUM_VAL(PAHFraction, Low, "Low PAH fraction (1%)")
+        ENUM_VAL(PAHFraction, High, "High PAH-to-dust fraction (4.6%)")
+        ENUM_VAL(PAHFraction, Low, "Low PAH-to-dust fraction (1%)")
     ENUM_END()
 
     /** The enumeration type indicating the wavelength resolution. */

--- a/SKIRT/core/ToddlersSED.hpp
+++ b/SKIRT/core/ToddlersSED.hpp
@@ -1,0 +1,76 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef TODDLERSSED_HPP
+#define TODDLERSSED_HPP
+
+#include "FamilySED.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** A ToddlersSED class instance represents a single star-forming region SED taken from the
+    Toddlers template library, parameterized on age, metallicity, star formation efficiency, and
+    cloud number density. See the ToddlersSEDFamily class for more information.
+
+    TODDLERS = Time evolution of Dust Diagnostics and Line Emission from Regions containing young
+    Stars. */
+class ToddlersSED : public FamilySED
+{
+    /** The enumeration type indicating the maximum PAH-to-dust fraction. */
+    ENUM_DEF(PAHFraction, High, Low)
+        ENUM_VAL(PAHFraction, High, "High PAH fraction (4.6%)")
+        ENUM_VAL(PAHFraction, Low, "Low PAH fraction (1%)")
+    ENUM_END()
+
+    /** The enumeration type indicating the wavelength resolution. */
+    ENUM_DEF(Resolution, Low, High)
+        ENUM_VAL(Resolution, Low, "Low wavelength resolution (continuum and lines at R=300)")
+        ENUM_VAL(Resolution, High, "High wavelength resolution (continuum at R=300 and lines at R=1e5)")
+    ENUM_END()
+
+    ITEM_CONCRETE(ToddlersSED, FamilySED, "a Toddlers SED for emission from star-forming regions")
+
+        PROPERTY_ENUM(pahfraction, PAHFraction, "the maximum PAH-to-dust fraction")
+        ATTRIBUTE_DEFAULT_VALUE(pahfraction, "High")
+
+        PROPERTY_ENUM(resolution, Resolution, "the wavelength resolution")
+        ATTRIBUTE_DEFAULT_VALUE(resolution, "Low")
+
+        PROPERTY_DOUBLE(age, "system age")
+        ATTRIBUTE_QUANTITY(age, "time")
+        ATTRIBUTE_MIN_VALUE(age, "[0.1 Myr")
+        ATTRIBUTE_MAX_VALUE(age, "30 Myr]")
+        ATTRIBUTE_DEFAULT_VALUE(age, "2.5 Myr")
+
+        PROPERTY_DOUBLE(metallicity, "system metallicity")
+        ATTRIBUTE_MIN_VALUE(metallicity, "[0.001")
+        ATTRIBUTE_MAX_VALUE(metallicity, "0.04]")
+        ATTRIBUTE_DEFAULT_VALUE(metallicity, "0.02")
+
+        PROPERTY_DOUBLE(SFE, "star formation efficiency ")
+        ATTRIBUTE_MIN_VALUE(SFE, "[.01")
+        ATTRIBUTE_MAX_VALUE(SFE, ".15]")
+        ATTRIBUTE_DEFAULT_VALUE(SFE, ".025")
+
+        PROPERTY_DOUBLE(cloudNumDensity, "natal cloud number density")
+        ATTRIBUTE_QUANTITY(cloudNumDensity, "numbervolumedensity")
+        ATTRIBUTE_MIN_VALUE(cloudNumDensity, "[10 /cm3")
+        ATTRIBUTE_MAX_VALUE(cloudNumDensity, "2560 /cm3]")
+        ATTRIBUTE_DEFAULT_VALUE(cloudNumDensity, "320 /cm3")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function returns a newly created SEDFamily object (which is already hooked into the
+        simulation item hierachy so it will be automatically deleted) and stores the parameters for
+        the specific %SED configured by the user in the specified array. */
+    const SEDFamily* getFamilyAndParameters(Array& parameters) override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/ToddlersSEDFamily.cpp
+++ b/SKIRT/core/ToddlersSEDFamily.cpp
@@ -39,7 +39,7 @@ vector<SnapshotParameter> ToddlersSEDFamily::parameterInfo() const
         SnapshotParameter::metallicity(),
         SnapshotParameter::custom("Star formation efficiency"),
         SnapshotParameter::custom("Cloud number density", "numbervolumedensity", "1/cm3"),
-        SnapshotParameter::custom("Stellar mass", "mass", "Msun"),
+        SnapshotParameter::custom("Mass", "mass", "Msun"),
     };
 }
 

--- a/SKIRT/core/ToddlersSEDFamily.cpp
+++ b/SKIRT/core/ToddlersSEDFamily.cpp
@@ -1,0 +1,81 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "ToddlersSEDFamily.hpp"
+#include "Constants.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+ToddlersSEDFamily::ToddlersSEDFamily(SimulationItem* parent, PAHFraction pahfraction, Resolution resolution)
+{
+    parent->addChild(this);
+    _pahfraction = pahfraction;
+    _resolution = resolution;
+    setup();
+}
+
+////////////////////////////////////////////////////////////////////
+
+void ToddlersSEDFamily::setupSelfBefore()
+{
+    SEDFamily::setupSelfBefore();
+
+    string name = "ToddlersSEDFamily_";
+    name += _pahfraction == PAHFraction::High ? "high" : "low";
+    name += "PAHfrac_";
+    name += _resolution == Resolution::Low ? "lr" : "hr";
+
+    _table.open(this, name, "lambda(m),t(Myr),Z(1),SFE(1),n_cl(1/cm3)", "Llambda(W/m)", false);
+}
+
+////////////////////////////////////////////////////////////////////
+
+vector<SnapshotParameter> ToddlersSEDFamily::parameterInfo() const
+{
+    return {
+        SnapshotParameter::age(),
+        SnapshotParameter::metallicity(),
+        SnapshotParameter::custom("Star formation efficiency"),
+        SnapshotParameter::custom("Cloud number density", "numbervolumedensity", "1/cm3"),
+        SnapshotParameter::custom("Stellar mass", "mass", "Msun"),
+    };
+}
+
+////////////////////////////////////////////////////////////////////
+
+Range ToddlersSEDFamily::intrinsicWavelengthRange() const
+{
+    return _table.axisRange<0>();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double ToddlersSEDFamily::specificLuminosity(double wavelength, const Array& parameters) const
+
+{
+    double age = parameters[0] / (1e6 * Constants::year());
+    double Z = parameters[1];
+    double SFE = parameters[2];
+    double n_cl = parameters[3] / 1e6;
+    double M = parameters[4] / Constants::Msun();
+
+    return M * _table(wavelength, age, Z, SFE, n_cl);
+}
+
+////////////////////////////////////////////////////////////////////
+
+double ToddlersSEDFamily::cdf(Array& lambdav, Array& pv, Array& Pv, const Range& wavelengthRange,
+                              const Array& parameters) const
+
+{
+    double age = parameters[0] / (1e6 * Constants::year());
+    double Z = parameters[1];
+    double SFE = parameters[2];
+    double n_cl = parameters[3] / 1e6;
+    double M = parameters[4] / Constants::Msun();
+
+    return M * _table.cdf(lambdav, pv, Pv, wavelengthRange, age, Z, SFE, n_cl);
+}
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ToddlersSEDFamily.hpp
+++ b/SKIRT/core/ToddlersSEDFamily.hpp
@@ -11,39 +11,42 @@
 
 //////////////////////////////////////////////////////////////////////
 
-/** An instance of the ToddlersSEDFamily class represents the family of TODDLERS star-forming
-    regions UV--mm SEDs parameterized on age, metallicity, star formation efficiency, and cloud
-    number density.
+/** An instance of the ToddlersSEDFamily class represents the TODDLERS (Time evolution of Dust
+    Diagnostics and Line Emission from Regions containing young Stars) family of star-forming
+    region SEDs parameterized on age, metallicity, star formation efficiency, and cloud number
+    density. This %SED template library is described in detail by Kapoor et al. in the manuscript
+    submitted to MNRAS on May 26, 2023. The spectra were generated using the Cloudy master branch
+    commit with SHA 69c3fa5871da3262341910e37c6ed2e5fb76dd3c.
 
-    TODDLERS = Time evolution of Dust Diagnostics and Line Emission from Regions containing young
-    Stars.
+    The SEDs in the TODDLERS library are tabulated over a wavelength range from \f$0.01\f$ to
+    \f$3000~\mu\mathrm{m}\f$ and include both continuum and line emission. The low-resolution
+    version of the library uses the default Cloudy output resolution of \f$R=300\f$ to represent
+    both the line and continuum components, resulting in 3787 wavelength points. The
+    high-resolution version represents each line using a high-resolution Gaussian line profile with
+    \f$R= 2\lambda/\Delta\lambda = 1e5\f$, where \f$\Delta\lambda\f$ is width of the \f$4 \sigma\f$
+    truncated Gaussian. The line profiles are added to the default \f$R=300\f$ resolution
+    continuum, resulting in a total of 9756 wavelength points.
 
-    The time resolved SED library is scaled by the particle mass. The scaling assumes a cloud mass
-    function obeying a power law with slope -1.8, i.e., dN/dM ∝ M^{-1.8} running from cloud mass
-    of 1e5 - 1e6.75 Msun. The SEDs span 90 ages from 0.1-30 Myr, 5 metallicity values from
-    0.001-0.04, 7 star formation efficiencies from 1-15%, and 9 cloud number densities ranging from
-    10-2560 cm^{-3}. The PAH fraction is a maximal value scaled by the neutral Hydrogen abundance
-    in a shell, two maximum q_PAH values are available: High(Default) = 4.6%, Low = 1%.
+    The TODDLERS parameter space spans 90 ages from 0.1-30 Myr, 5 metallicity values from
+    0.001-0.04, 7 star formation efficiencies from 1-15%, and 9 cloud number densities from 10-2560
+    \f$\mathrm{cm}^{-3}\f$. The PAH-to-dust fraction is a maximum value scaled by the neutral
+    hydrogen abundance in a shell. Two maximum PAH fractions are available: High = 4.6%, Low = 1%.
+    Finally, the SEDs are scaled by the mass of the imported star-forming region particle. The
+    scaling assumes a cloud mass function obeying a power law with slope -1.8, i.e., \f$dN/dM
+    \propto M^{-1.8}\f$ running from a cloud mass of \f$10^5\f$ to
+    \f$10^{6.75}~\mathrm{M}_\odot\f$.
 
-    Additionally, this class allows the use of low and high resolution spectra to represent the
-    total SED. The model spectra have 3787/9756 wavelengths in the low/high resolution SEDs. The
-    low resolution set uses the default Cloudy output resolution of R=300 to represent both the
-    line and continuum components. The high resolution SEDs contain the set of lines discussed in
-    Kapoor et al 2023 with high resolution Gaussian line profiles (\f$R= 2\lambda/\Delta\lambda =
-    1e5\f$, \f$\Delta\lambda\f$ = width of the \f$4 \sigma\f$ truncated Gaussian) added to the
-    default Cloudy resolution continuum spectra. The SEDs are tabulated over a wavelength range
-    from 100 Angstrom to 3000 micron.
-
-    The data was generated using the Cloudy master branch SHA:
-    69c3fa5871da3262341910e37c6ed2e5fb76dd3c
-
-    For more details refer to Kapoor et al 2023. */
+    When imported from a text column file, the parameters for this %SED family must appear in the
+    following order in the specified default units (unless these units are overridden by column
+    header info): \f[ t\,(\mathrm{yr}) \quad Z\,(\mathrm{dimensionless}) \quad
+    \mathrm{SFE}\,(\mathrm{dimensionless}) \quad n_\mathrm{cloud} (\mathrm{cm}^{-3}) \quad
+    M\,(\mathrm{M}_\odot) \f] */
 class ToddlersSEDFamily : public SEDFamily
 {
     /** The enumeration type indicating the maximum PAH-to-dust fraction. */
     ENUM_DEF(PAHFraction, High, Low)
-        ENUM_VAL(PAHFraction, High, "High PAH fraction (4.6%)")
-        ENUM_VAL(PAHFraction, Low, "Low PAH fraction (1%)")
+        ENUM_VAL(PAHFraction, High, "High PAH-to-dust fraction (4.6%)")
+        ENUM_VAL(PAHFraction, Low, "Low PAH-to-dust fraction (1%)")
     ENUM_END()
 
     /** The enumeration type indicating the wavelength resolution. */

--- a/SKIRT/core/ToddlersSEDFamily.hpp
+++ b/SKIRT/core/ToddlersSEDFamily.hpp
@@ -1,0 +1,112 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef TODDLERSSEDFAMILY_HPP
+#define TODDLERSSEDFAMILY_HPP
+
+#include "SEDFamily.hpp"
+#include "StoredTable.hpp"
+
+//////////////////////////////////////////////////////////////////////
+
+/** An instance of the ToddlersSEDFamily class represents the family of TODDLERS star-forming
+    regions UV--mm SEDs parameterized on age, metallicity, star formation efficiency, and cloud
+    number density.
+
+    TODDLERS = Time evolution of Dust Diagnostics and Line Emission from Regions containing young
+    Stars.
+
+    The time resolved SED library is scaled by the particle mass. The scaling assumes a cloud mass
+    function obeying a power law with slope -1.8, i.e., dN/dM ∝ M^{-1.8} running from cloud mass
+    of 1e5 - 1e6.75 Msun. The SEDs span 90 ages from 0.1-30 Myr, 5 metallicity values from
+    0.001-0.04, 7 star formation efficiencies from 1-15%, and 9 cloud number densities ranging from
+    10-2560 cm^{-3}. The PAH fraction is a maximal value scaled by the neutral Hydrogen abundance
+    in a shell, two maximum q_PAH values are available: High(Default) = 4.6%, Low = 1%.
+
+    Additionally, this class allows the use of low and high resolution spectra to represent the
+    total SED. The model spectra have 3787/9756 wavelengths in the low/high resolution SEDs. The
+    low resolution set uses the default Cloudy output resolution of R=300 to represent both the
+    line and continuum components. The high resolution SEDs contain the set of lines discussed in
+    Kapoor et al 2023 with high resolution Gaussian line profiles (\f$R= 2\lambda/\Delta\lambda =
+    1e5\f$, \f$\Delta\lambda\f$ = width of the \f$4 \sigma\f$ truncated Gaussian) added to the
+    default Cloudy resolution continuum spectra. The SEDs are tabulated over a wavelength range
+    from 100 Angstrom to 3000 micron.
+
+    The data was generated using the Cloudy master branch SHA:
+    69c3fa5871da3262341910e37c6ed2e5fb76dd3c
+
+    For more details refer to Kapoor et al 2023. */
+class ToddlersSEDFamily : public SEDFamily
+{
+    /** The enumeration type indicating the maximum PAH-to-dust fraction. */
+    ENUM_DEF(PAHFraction, High, Low)
+        ENUM_VAL(PAHFraction, High, "High PAH fraction (4.6%)")
+        ENUM_VAL(PAHFraction, Low, "Low PAH fraction (1%)")
+    ENUM_END()
+
+    /** The enumeration type indicating the wavelength resolution. */
+    ENUM_DEF(Resolution, Low, High)
+        ENUM_VAL(Resolution, Low, "Low wavelength resolution (continuum and lines at R=300)")
+        ENUM_VAL(Resolution, High, "High wavelength resolution (continuum at R=300 and lines at R=1e5)")
+    ENUM_END()
+
+    ITEM_CONCRETE(ToddlersSEDFamily, SEDFamily, "a Toddlers SED family for emission from star-forming regions")
+
+        PROPERTY_ENUM(pahfraction, PAHFraction, "the maximum PAH-to-dust fraction")
+        ATTRIBUTE_DEFAULT_VALUE(pahfraction, "High")
+
+        PROPERTY_ENUM(resolution, Resolution, "the wavelength resolution")
+        ATTRIBUTE_DEFAULT_VALUE(resolution, "Low")
+
+    ITEM_END()
+
+public:
+    /** This constructor can be invoked programmatically by classes that use a hard-coded SED
+        family (as opposed to selected through the ski file). Before the constructor returns, the
+        newly created object is hooked up as a child to the specified parent in the simulation
+        hierarchy (so it will automatically be deleted), and its setup() function has been called.
+        */
+    explicit ToddlersSEDFamily(SimulationItem* parent, PAHFraction pahfraction, Resolution resolution);
+
+protected:
+    /** This function opens the appropriate resource file (in SKIRT stored table format). */
+    void setupSelfBefore() override;
+
+    //====================== Other functions =====================
+
+public:
+    /** This function returns the number and type of parameters used by this particular %SED family
+        as a list of SnapshotParameter objects. Each of these objects specifies unit information
+        and a human-readable description for the parameter. */
+    vector<SnapshotParameter> parameterInfo() const override;
+
+    /** This function returns the intrinsic wavelength range of the %SED family. It retrieves this
+        range from the underlying stored table. */
+    Range intrinsicWavelengthRange() const override;
+
+    /** This function returns the specific luminosity \f$L_\lambda\f$ (i.e. radiative power per
+        unit of wavelength) for the %SED with the specified parameters at the specified wavelength,
+        or zero if the wavelength is outside of the %SED's intrinsic wavelength range. The number
+        and type of parameters must match the information returned by the parameterInfo() function;
+        if not the behavior is undefined. */
+    double specificLuminosity(double wavelength, const Array& parameters) const override;
+
+    /** This function constructs both the normalized probability density function (pdf) and the
+        corresponding normalized cumulative distribution function (cdf) for the %SED with the
+        specified parameters over the specified wavelength range. The function returns the
+        normalization factor. The number and type of parameters must match the information returned
+        by the parameterInfo() function; if not the behavior is undefined. */
+    double cdf(Array& lambdav, Array& pv, Array& Pv, const Range& wavelengthRange,
+               const Array& parameters) const override;
+
+    //====================== Data members =====================
+
+private:
+    StoredTable<5> _table;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/resources/ExpectedResources.txt
+++ b/SKIRT/resources/ExpectedResources.txt
@@ -1,4 +1,5 @@
 Core 6
 BPASS 1
+TODDLERS 1
 ExtraDust 2
 AtomsMolecules 4


### PR DESCRIPTION
**Description**
This update adds the TODDLERS family of star-forming region SEDs parameterized on age, metallicity, star formation efficiency, and cloud number density. This SED template library has been developed by @anandutsavkapoor and is described in detail by Kapoor et al. in the manuscript submitted to MNRAS on May 26, 2023.

The `ToddlersSEDFamily` class requires the data contained in the TODDLERS resource pack, which can be installed through the `./downloadResources.sh` procedure.

**Motivation**
When compared to the previous treatment of star-forming regions in SKIRT, TODDLERS shows a better agreement with low-redshift observational data in the IR wavelength range, while offering a more comprehensive line-emission support. This paves the way for a variety of applications using simulated galaxies at low and high redshift.

**Tests**
The new classes have been minimally tested. Further testing is required before production use.
