### PR TITLE
Fix performance issue in photon life cycle without forced scattering

### DIFF
--- a/SKIRT/core/Configuration.cpp
+++ b/SKIRT/core/Configuration.cpp
@@ -481,6 +481,12 @@ void Configuration::setupSelfAfter()
         log->warning("  Disabling path length stretching to allow Doppler shifts to be properly sampled");
         _pathLengthBias = 0.;
     }
+    // inform user that path length stretching is not implemented for non-forced scattering
+    if (!_forceScattering && _pathLengthBias > 0.)
+    {
+        log->warning("  Disabling path length stretching because it is not implemented without forced scattering");
+        _pathLengthBias = 0.;
+    }
 
     // --- log magnetic field issues ---
 

--- a/SKIRT/core/MonteCarloSimulation.cpp
+++ b/SKIRT/core/MonteCarloSimulation.cpp
@@ -574,6 +574,9 @@ void MonteCarloSimulation::performLifeCycle(size_t firstIndex, size_t numIndices
                             // if the interaction point is outside of the path, terminate the packet
                             if (!simulateNonForcedPropagation(&pp)) break;
 
+                            // if the packet's weight drops to zero, terminate it
+                            if (pp.luminosity() <= 0) break;
+
                             // process the scattering event
                             if (peel) peelOffScattering(&pp, &ppp);
                             mediumSystem()->simulateScattering(random(), &pp);

--- a/SKIRT/core/MonteCarloSimulation.hpp
+++ b/SKIRT/core/MonteCarloSimulation.hpp
@@ -461,9 +461,11 @@ private:
         to register the radiation field (in the current implementation). The details of the
         propagation process depend on whether explicit absorption is enabled or not. Refer to the
         simulateNonForcedPropagation() function. If the selected interaction point turns out to be
-        beyond the model boundary, the packet is terminated. Otherwise, scattering peel-off photon
-        packets are created and launched towards each instrument, if so requested, the actual
-        scattering event is simulated, and the loop repeats itself.
+        beyond the model boundary, the packet is terminated. As an optimization, if the packet's
+        luminosity has fallen to zero, it is terminated as well because it can no longer have any
+        contribution to the simulation results. If the packet has not been terminated, scattering
+        peel-off photon packets are created and launched towards each instrument, if so requested,
+        the actual scattering event is simulated, and the loop repeats itself.
 
         The first two arguments of this function specify the range of photon packet history indices
         to be handled. The \em primary flag is true to launch from primary sources, false for

--- a/SKIRT/core/PhotonPacketOptions.hpp
+++ b/SKIRT/core/PhotonPacketOptions.hpp
@@ -29,8 +29,29 @@
     not support storing the radiation field, which means it cannot be used when the simulation
     includes secondary emission or dynamic state iteration.
 
-    The remaining options serve to further configure the detailed behavior of the forced scattering
-    photon cycle. */
+    The remaining three options serve to further configure the detailed behavior of the forced
+    scattering photon cycle. The first two options determine when the photon life cycle will be
+    terminated, i.e. after the weight of photon packet has decreased to some insignificant fraction
+    of its original weight (luminosity) through interaction with the medium, with a given minimum
+    number of scattering events if so desired.
+
+    The last option configures the path length stretching mechanism. When determining the next
+    interaction location of a photon packet with the medium, this technique samples in part from a
+    distribution representing unphysically long path segments, correcting this deviation through a
+    bias factor on the photon packet's weight. This allows a photon packet to more easily skip
+    through high optical depth regions. The value configured for this option determines the
+    fraction of path lengths sampled from the unphysical distribution. A value of zero disables the
+    mechanism altogether.
+
+    The path length stretching mechanism cannot be used for models where the photon packet
+    wavelength may change during its life cycle, for example during scattering or as a result of
+    bulk motions in the medium. This is so because the unphysically long distances between
+    interactions would no longer correctly sample the effects on the wavelength. Also, path length
+    stretching is currently \em not implemented for photon cycles without forced scattering. In all
+    these cases, the path length stretching mechanism will automatically be disabled during setup.
+    As a result, these simulations will lack the potential optimization brought by the path length
+    technique. In particulatar, penetrating regions of high optical depth may require many
+    scattering events with correspondingly longer running times. */
 class PhotonPacketOptions : public SimulationItem
 {
     ITEM_CONCRETE(PhotonPacketOptions, SimulationItem, "a set of options related to the photon packet lifecycle")
@@ -62,7 +83,7 @@ class PhotonPacketOptions : public SimulationItem
         PROPERTY_DOUBLE(pathLengthBias, "the fraction of path lengths sampled from a stretched distribution")
         ATTRIBUTE_MIN_VALUE(pathLengthBias, "[0")
         ATTRIBUTE_MAX_VALUE(pathLengthBias, "1]")
-        ATTRIBUTE_DEFAULT_VALUE(pathLengthBias, "Lya:0;0.5")
+        ATTRIBUTE_DEFAULT_VALUE(pathLengthBias, "(ForceScattering)&(!Lya):0.5;0")
         ATTRIBUTE_RELEVANT_IF(pathLengthBias, "(ForceScattering)&(!Lya)")
         ATTRIBUTE_DISPLAYED_IF(pathLengthBias, "Level3")
 


### PR DESCRIPTION
**Motivation**
The photon life cycle without forced scattering terminates only after the photon packet escapes from the model. However, in some cases, the luminosity of a photon packet may fall to zero long before it actually escapes from the model. A zero-luminosity packet can no longer make any contributions to the simulation results, so it does not make sense to continue tracking its path through the medium.

**Context**
This issue was reported by @BertVdM. In the provided example (a torus of `XRayAtomicGasMix` gas with a central point source) some photon packets would experience more than 25 million scattering events before escaping from the model, most of which after reaching zero luminosity.

**Description**
With this pull request:
- The photon life cycle without forced scattering terminates any photon packets that reach zero luminosity.
- The documentation of the PhotonPacketOptions class indicates that path length stretching is not implemented for the photon life cycle without forced scattering.
- A warning is issued at runtime if path length stretching is requested for a photon life cycle without forced scattering.

**Tests**
All functional tests produce the same results.
