### PR TITLE
Extrapolated optical properties for AGN dust mixes

### DIFF
--- a/SKIRT/resources/ExpectedResources.txt
+++ b/SKIRT/resources/ExpectedResources.txt
@@ -1,5 +1,5 @@
 Core 6
 BPASS 1
 TODDLERS 1
-ExtraDust 2
+ExtraDust 3
 AtomsMolecules 5


### PR DESCRIPTION
**Description**
This pull request updates the resource files for the optical properties of the dust mixes in the ExtraDust resource pack, i.e. `BegemannPorousAlumina`, `DorschnerOlivine`, and `HofmeisterPericlase`, typically used for AGN models.

The Qabs and Qsca values for each dust species for each grain size were extrapolated to wavelengths from 1e-3 to 1e3
microns following a rough approximation of the behavior of the Qabs and Qsca. Previously the optical properties did not
cover this wavelength range and the outer regions were filled by SKIRT with a constant value.

**Motivation**
Allow simulations to use the more extended wavelength range.

**Context**
These data were prepared and provided by @oura71 .
