### PR TITLE
Honor wavelength output style in ski files

### DIFF
--- a/SKIRT/core/DensityTreePolicy.hpp
+++ b/SKIRT/core/DensityTreePolicy.hpp
@@ -100,7 +100,7 @@ class DensityTreePolicy : public TreePolicy, public MaterialWavelengthRangeInter
         ATTRIBUTE_MIN_VALUE(maxDustDensityDispersion, "[0")
         ATTRIBUTE_MAX_VALUE(maxDustDensityDispersion, "1]")
         ATTRIBUTE_DEFAULT_VALUE(maxDustDensityDispersion, "0")
-        ATTRIBUTE_DISPLAYED_IF(maxDustDensityDispersion, "Level2")
+        ATTRIBUTE_DISPLAYED_IF(maxDustDensityDispersion, "DustMix&Level2")
 
         PROPERTY_DOUBLE(maxElectronFraction, "the maximum fraction of electrons contained in each cell")
         ATTRIBUTE_MIN_VALUE(maxElectronFraction, "[0")
@@ -112,7 +112,7 @@ class DensityTreePolicy : public TreePolicy, public MaterialWavelengthRangeInter
         ATTRIBUTE_MIN_VALUE(maxGasFraction, "[0")
         ATTRIBUTE_MAX_VALUE(maxGasFraction, "1e-2]")
         ATTRIBUTE_DEFAULT_VALUE(maxGasFraction, "1e-6")
-        ATTRIBUTE_DISPLAYED_IF(maxGasFraction, "GasMix&Level2")
+        ATTRIBUTE_DISPLAYED_IF(maxGasFraction, "GasMix")
 
     ITEM_END()
 

--- a/SKIRT/core/ListLineSED.hpp
+++ b/SKIRT/core/ListLineSED.hpp
@@ -15,9 +15,9 @@
     file (i.e. without referring to an input file). It is intended for use in cases where there are
     just a few wavelength/luminosity pairs, but nothing keeps the user from specifying a long list.
 
-    The wavelengths are by default given in micron and may be listed be in any order. The
-    corresponding luminosity values are by default given in solar luminosity units, but the scaling
-    of the values is arbitrary because the %SED will be normalized after being loaded.
+    The wavelengths are by default given in micron and may be listed in any order. The
+    corresponding luminosity values are given in luminosity units, but the scaling of the values is
+    arbitrary because the %SED will be normalized after being loaded.
 
     Because the specific luminosity of the spectrum is undefined, there are important restrictions
     on the use of this %SED. See the description of the LineSED class for more information. */

--- a/SKIRT/core/ListSED.hpp
+++ b/SKIRT/core/ListSED.hpp
@@ -33,6 +33,7 @@ class ListSED : public TabulatedSED
     ENUM_END()
 
     ITEM_CONCRETE(ListSED, TabulatedSED, "a spectral energy distribution specified inside the configuration file")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(ListSED, "Level2")
 
         PROPERTY_DOUBLE_LIST(wavelengths, "the wavelengths at which to specify the specific luminosity")
         ATTRIBUTE_QUANTITY(wavelengths, "wavelength")

--- a/SKIRT/core/SkirtUnitDef.cpp
+++ b/SKIRT/core/SkirtUnitDef.cpp
@@ -263,6 +263,17 @@ SkirtUnitDef::SkirtUnitDef()
     addUnit("bolluminosity", "erg/s", 1e-7);
     addUnit("bolluminosity", "Lsun", Lsun);
 
+    // wavelength-style bolometric luminosity
+    addUnit("wavelengthbolluminosity", "W", 1.);
+    addUnit("wavelengthbolluminosity", "Lsun", Lsun);
+
+    // frequency-style bolometric luminosity
+    addUnit("frequencybolluminosity", "W", 1.);
+
+    // energy-style bolometric luminosity
+    addUnit("energybolluminosity", "W", 1.);
+    addUnit("energybolluminosity", "erg/s", 1e-7);
+
     // bolometric luminosity volume density
     addUnit("bolluminosityvolumedensity", "W/m3", 1.);
     addUnit("bolluminosityvolumedensity", "erg/s/cm3", 0.1);
@@ -532,6 +543,9 @@ SkirtUnitDef::SkirtUnitDef()
     addDefaultUnit("SIUnits", "magneticfield", "T");
     addDefaultUnit("SIUnits", "pressure", "Pa");
     addDefaultUnit("SIUnits", "bolluminosity", "W");
+    addDefaultUnit("SIUnits", "wavelengthbolluminosity", "W");
+    addDefaultUnit("SIUnits", "frequencybolluminosity", "W");
+    addDefaultUnit("SIUnits", "energybolluminosity", "W");
     addDefaultUnit("SIUnits", "bolluminosityvolumedensity", "W/m3");
     addDefaultUnit("SIUnits", "bolluminositysurfacedensity", "W/m2");
     addDefaultUnit("SIUnits", "neutralmonluminosity", "W");
@@ -588,6 +602,9 @@ SkirtUnitDef::SkirtUnitDef()
     addDefaultUnit("StellarUnits", "magneticfield", "uG");
     addDefaultUnit("StellarUnits", "pressure", "K/m3");
     addDefaultUnit("StellarUnits", "bolluminosity", "Lsun");
+    addDefaultUnit("StellarUnits", "wavelengthbolluminosity", "Lsun");
+    addDefaultUnit("StellarUnits", "frequencybolluminosity", "W");
+    addDefaultUnit("StellarUnits", "energybolluminosity", "erg/s");
     addDefaultUnit("StellarUnits", "bolluminosityvolumedensity", "Lsun/AU3");
     addDefaultUnit("StellarUnits", "bolluminositysurfacedensity", "Lsun/AU2");
     addDefaultUnit("StellarUnits", "neutralmonluminosity", "Lsun");
@@ -644,6 +661,9 @@ SkirtUnitDef::SkirtUnitDef()
     addDefaultUnit("ExtragalacticUnits", "magneticfield", "uG");
     addDefaultUnit("ExtragalacticUnits", "pressure", "K/m3");
     addDefaultUnit("ExtragalacticUnits", "bolluminosity", "Lsun");
+    addDefaultUnit("ExtragalacticUnits", "wavelengthbolluminosity", "Lsun");
+    addDefaultUnit("ExtragalacticUnits", "frequencybolluminosity", "W");
+    addDefaultUnit("ExtragalacticUnits", "energybolluminosity", "erg/s");
     addDefaultUnit("ExtragalacticUnits", "bolluminosityvolumedensity", "Lsun/pc3");
     addDefaultUnit("ExtragalacticUnits", "bolluminositysurfacedensity", "Lsun/pc2");
     addDefaultUnit("ExtragalacticUnits", "neutralmonluminosity", "Lsun");

--- a/SKIRT/core/SpecialtyWavelengthProbe.hpp
+++ b/SKIRT/core/SpecialtyWavelengthProbe.hpp
@@ -27,7 +27,6 @@ class SpecialtyWavelengthProbe : public SpecialtyWhenProbe, public MaterialWavel
         ATTRIBUTE_MIN_VALUE(wavelength, "1 pm")
         ATTRIBUTE_MAX_VALUE(wavelength, "1 m")
         ATTRIBUTE_DEFAULT_VALUE(wavelength, "0.55 micron")
-        ATTRIBUTE_DISPLAYED_IF(wavelength, "Level2")
 
     ITEM_END()
 

--- a/SKIRT/core/TabulatedSED.hpp
+++ b/SKIRT/core/TabulatedSED.hpp
@@ -20,7 +20,6 @@
 class TabulatedSED : public ContSED
 {
     ITEM_ABSTRACT(TabulatedSED, ContSED, "a spectral energy distribution tabulated by the user")
-        ATTRIBUTE_TYPE_DISPLAYED_IF(TabulatedSED, "Level2")
     ITEM_END()
 
     //============= Construction - Setup - Destruction =============

--- a/SMILE/schema/AbstractDoublePropertyHandler.cpp
+++ b/SMILE/schema/AbstractDoublePropertyHandler.cpp
@@ -166,8 +166,11 @@ string AbstractDoublePropertyHandler::toString(double value) const
     if (!qty.empty())
     {
         string system = unitSystem();
-        value = schema()->out(qty, system, value);  // overwrite incoming value
-        unit = " " + schema()->unit(qty, system);   // include separating space
+        string style = StringUtils::toLower(unitStyle());
+
+        unit = schema()->unit(qty, system, style);  // get output unit string
+        value = schema()->out(qty, unit, value);    // convert and overwrite incoming value
+        unit = " " + unit;                          // include separating space
     }
 
     return StringUtils::toString(value) + unit;
@@ -262,6 +265,51 @@ string AbstractDoublePropertyHandler::unitSystem() const
         ancestor = ancestor->parent();
     }
     throw FATALERROR("No item of type " + baseType + " found in hierarchy");
+}
+
+////////////////////////////////////////////////////////////////////
+
+string AbstractDoublePropertyHandler::unitStyle() const
+{
+    // define a function to find the item representing the unit system, so we can return from multiple points
+    auto getUnitSystemItem = [this]() -> Item* {
+        // get the base type; or if there is only one unit system, its name
+        string baseType = schema()->unitSystemBase();
+
+        // loop over all ancestors
+        Item* ancestor = target();
+        while (ancestor)
+        {
+            // test the ancestor
+            if (schema()->inherits(ancestor->type(), baseType)) return ancestor;
+
+            // test its children
+            for (auto child : ancestor->children())
+            {
+                if (schema()->inherits(child->type(), baseType)) return child;
+            }
+
+            // next ancestor
+            ancestor = ancestor->parent();
+        }
+        // no unit system found
+        return nullptr;
+    };
+
+    // actually get the item representing the unit system, if any
+    Item* unitSystemItem = getUnitSystemItem();
+    if (unitSystemItem)
+    {
+        // loop over the properties of the unit system item's type
+        for (const string& property : schema()->properties(unitSystemItem->type()))
+        {
+            // return the value of the first enumeration property, if any
+            auto handler = schema()->createPropertyHandler(unitSystemItem, property, nameManager());
+            auto enumHandler = dynamic_cast<EnumPropertyHandler*>(handler.get());
+            if (enumHandler) return enumHandler->value();
+        }
+    }
+    return string();
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SMILE/schema/AbstractDoublePropertyHandler.hpp
+++ b/SMILE/schema/AbstractDoublePropertyHandler.hpp
@@ -101,6 +101,7 @@ public:
         represent a dimensionless quantity. */
     string quantity() const;
 
+private:
     /** Returns the name of the unit system associated with the dataset in which the handled
         property resides. If the schema definition does not provide a unit system, the function
         throws an error. If the schema definition provides a single unit system, the function
@@ -109,6 +110,16 @@ public:
         that inherits the common unit system base type, and returns the actual type of that item.
         If no such data item can be found, the function throws an error. */
     string unitSystem() const;
+
+    /** Returns the name of the unit style associated with the dataset in which the handled
+        property resides. If the schema definition does not provide a unit system, the function
+        throws an error. If the schema definition provides one or more unit systems, the function
+        searches the hierarchy of the target dataset for a SMILE data item that inherits the common
+        unit system base type (or is of the sole unit system type). If such a data item is found,
+        the function returns the value of this item's first enumeration property (in schema
+        definition order). If no such data item is found, or the item does not have an enumeration
+        property, the function returns the empty string. */
+    string unitStyle() const;
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SMILE/schema/SchemaDef.cpp
+++ b/SMILE/schema/SchemaDef.cpp
@@ -815,9 +815,9 @@ double SchemaDef::out(string qty, string unit, double value) const
 
 ////////////////////////////////////////////////////////////////////
 
-string SchemaDef::unit(string qty, string unitSystem) const
+string SchemaDef::unit(string qty, string unitSystem, string unitStyle) const
 {
-    return _unitDef.unit(qty, unitSystem);
+    return _unitDef.unit(qty, unitSystem, unitStyle);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SMILE/schema/SchemaDef.hpp
+++ b/SMILE/schema/SchemaDef.hpp
@@ -239,11 +239,15 @@ public:
     double out(string qty, string unit, double value) const;
 
     /** This function returns the name of the default unit listed in the schema definition for the
-        specified physical quantity in the specified unit system. The physical quantity and unit
-        system names are case sensitive and should not contain any spaces. If the specified
-        combination of physical quantity and unit system is not provided in the schema definition,
-        the function throws an exception. */
-    string unit(string qty, string unitSystem) const;
+        specified physical quantity in the specified unit system. If the specified unit style is
+        nonempty, the function first prefixes the quantity name with the unit style string and
+        attempts to locate the default value for this embellished quantity name. If this fails, the
+        function tries again with the regular quantity name.
+
+        The physical quantity, unit system, and unit style name are case sensitive and should not
+        contain any spaces. If the specified combination of physical quantity (embellished or not)
+        and unit system is not present in the unit definition, the function throws an exception. */
+    string unit(string qty, string unitSystem, string unitStyle) const;
 
     /** This function returns true if two or more unit systems are provided in the schema
         definition. Otherwise it returns false. */

--- a/SMILE/schema/UnitDef.cpp
+++ b/SMILE/schema/UnitDef.cpp
@@ -102,10 +102,14 @@ double UnitDef::out(string qty, string unit, double value) const
 
 ////////////////////////////////////////////////////////////////////
 
-string UnitDef::unit(string qty, string unitSystem) const
+string UnitDef::unit(string qty, string unitSystem, string unitStyle) const
 {
-    if (_unitSystems.count(unitSystem) && _unitSystems.at(unitSystem).count(qty))
-        return _unitSystems.at(unitSystem).at(qty);
+    if (_unitSystems.count(unitSystem))
+    {
+        if (!unitStyle.empty() && _unitSystems.at(unitSystem).count(unitStyle + qty))
+            return _unitSystems.at(unitSystem).at(unitStyle + qty);
+        if (_unitSystems.at(unitSystem).count(qty)) return _unitSystems.at(unitSystem).at(qty);
+    }
 
     throw FATALERROR("Unknow quantity " + qty + " and/or unit system " + unitSystem);
 }

--- a/SMILE/schema/UnitDef.hpp
+++ b/SMILE/schema/UnitDef.hpp
@@ -133,10 +133,13 @@ public:
     double out(string qty, string unit, double value) const;
 
     /** This function returns the name of the default unit listed in the schema definition for the
-        specified physical quantity in the specified unit system. If the specified combination of
-        physical quantity and unit system is not present in the unit definition, the function
-        throws an exception. */
-    string unit(string qty, string unitSystem) const;
+        specified physical quantity in the specified unit system. If the unit style is specified
+        and nonempty, the function first prefixes the quantity name with the unit style string and
+        attempts to locate the default value for this embellished quantity name. If this fails, the
+        function tries again with the regular quantity name. If the specified combination of
+        physical quantity (embellished or not) and unit system is not present in the unit
+        definition, the function throws an exception. */
+    string unit(string qty, string unitSystem, string unitStyle = string()) const;
 
     // ================== Data members ==================
 


### PR DESCRIPTION
**Description and Motivation**
With this update, wavelengths are written to `.ski` files and `_parameters.xml` files in units that depend on the selected `wavelengthOutputStyle`. For example, with the `Energy` style, spectral values are expressed in `keV`.
For simulations at X-ray wavelengths, keV is a much more natural unit for expressing spectral values than micron.

Also, a few configuration options were moved from user experience level 2 to level 1 to allow performing the upcoming X-ray tutorial in experience level 1.

**Limitations**
SKIRT converts all values to internal units and does not retain information about the units that were used to enter a value during the Q&A session or in `MakeUp`. This implementation choice has the following consequences for ski files configured with the `Energy` style:
- All spectral values in the output ski file are expressed in keV regardless of how they were entered. For example, 80 eV will be converted to 0.08 keV.
- The default value for a spectral quantity in an option that is unused (and thus irrelevant) for a particular configuration is likely given internally  as some "rounded" value when expressed in micron, yielding a random-looking value in keV. This is not a problem since the value is not used, but it doesn't look very nice.
- Default values for spectral quantities offered during Q&A or in `MakeUp` have the same issue.

**Tests**
All function tests run without change except that those with `wavelengthOutputStyle` set to `frequency` or `energy` output a slightly different `_parameters.xml` file.

**Context**
These changes were suggested by @BertVdM.
