### PR TITLE
Add Nested Density Tree Policy

### DIFF
--- a/SKIRT/core/DensityTreePolicy.cpp
+++ b/SKIRT/core/DensityTreePolicy.cpp
@@ -85,8 +85,12 @@ void DensityTreePolicy::setupSelfBefore()
 
 ////////////////////////////////////////////////////////////////////
 
-bool DensityTreePolicy::needsSubdivide(TreeNode* node, int /*level*/)
+bool DensityTreePolicy::needsSubdivide(TreeNode* node)
 {
+    // handle minimum and maximum level
+    if (node->level() < minLevel()) return true;
+    if (node->level() >= maxLevel()) return false;
+
     // results for the sampled mass or number densities, if applicable
     double rho = 0.;          // dust mass density
     double rhomin = DBL_MAX;  // smallest sample for dust mass density
@@ -181,28 +185,13 @@ vector<TreeNode*> DensityTreePolicy::constructTree(TreeNode* root)
     // initialize the tree node list with the root node as the first item
     vector<TreeNode*> nodev{root};
 
-    // recursively subdivide the root node until the minimum level has been reached
+    // initialize iteration variables to level 0
     int level = 0;    // current level
     size_t lbeg = 0;  // node index range for the current level;
     size_t lend = 1;  // at level 0, the node list contains just the root node
-    while (level != minLevel())
-    {
-        log->info("Subdividing level " + std::to_string(level) + ": " + std::to_string(lend - lbeg) + " nodes");
-        log->infoSetElapsed(lend - lbeg);
-        for (size_t l = lbeg; l != lend; ++l)
-        {
-            nodev[l]->subdivide(nodev);
-            if ((l + 1) % logDivideChunkSize == 0)
-                log->infoIfElapsed("Subdividing level " + std::to_string(level) + ": ", logDivideChunkSize);
-        }
-        // update iteration variables to the next level
-        level++;
-        lbeg = lend;
-        lend = nodev.size();
-    }
 
-    // recursively subdivide the nodes beyond the minimum level until all nodes satisfy the configured criteria
-    while (level != maxLevel() && lend != lbeg)
+    // recursively subdivide nodes until all nodes satisfy the configured criteria
+    while (lend != lbeg)
     {
         size_t numEvalNodes = lend - lbeg;
         log->info("Subdividing level " + std::to_string(level) + ": " + std::to_string(numEvalNodes) + " nodes");
@@ -217,7 +206,7 @@ vector<TreeNode*> DensityTreePolicy::constructTree(TreeNode* root)
                 size_t currentChunkSize = min(logEvalChunkSize, numIndices);
                 for (size_t l = firstIndex; l != firstIndex + currentChunkSize; ++l)
                 {
-                    if (needsSubdivide(nodev[lbeg + l], level)) divide[l] = 1.;
+                    if (needsSubdivide(nodev[lbeg + l])) divide[l] = 1.;
                 }
                 log->infoIfElapsed("Evaluation for level " + std::to_string(level) + ": ", currentChunkSize);
                 firstIndex += currentChunkSize;
@@ -240,6 +229,7 @@ vector<TreeNode*> DensityTreePolicy::constructTree(TreeNode* root)
                     log->infoIfElapsed("Subdivision for level " + std::to_string(level) + ": ", logDivideChunkSize);
             }
         }
+
         // update iteration variables to the next level
         level++;
         lbeg = lend;

--- a/SKIRT/core/DensityTreePolicy.cpp
+++ b/SKIRT/core/DensityTreePolicy.cpp
@@ -85,7 +85,7 @@ void DensityTreePolicy::setupSelfBefore()
 
 ////////////////////////////////////////////////////////////////////
 
-bool DensityTreePolicy::needsSubdivide(TreeNode* node, int level)
+bool DensityTreePolicy::needsSubdivide(TreeNode* node, int /*level*/)
 {
     // results for the sampled mass or number densities, if applicable
     double rho = 0.;          // dust mass density

--- a/SKIRT/core/DensityTreePolicy.cpp
+++ b/SKIRT/core/DensityTreePolicy.cpp
@@ -20,6 +20,8 @@
 
 void DensityTreePolicy::setupSelfBefore()
 {
+    TreePolicy::setupSelfBefore();
+
     // get the random generator and the number of samples (not a big effort, so we do this even if we don't need it)
     _random = find<Random>();
     _numSamples = find<Configuration>()->numDensitySamples();
@@ -83,7 +85,7 @@ void DensityTreePolicy::setupSelfBefore()
 
 ////////////////////////////////////////////////////////////////////
 
-bool DensityTreePolicy::needsSubdivide(TreeNode* node)
+bool DensityTreePolicy::needsSubdivide(TreeNode* node, int level)
 {
     // results for the sampled mass or number densities, if applicable
     double rho = 0.;          // dust mass density
@@ -215,7 +217,7 @@ vector<TreeNode*> DensityTreePolicy::constructTree(TreeNode* root)
                 size_t currentChunkSize = min(logEvalChunkSize, numIndices);
                 for (size_t l = firstIndex; l != firstIndex + currentChunkSize; ++l)
                 {
-                    if (needsSubdivide(nodev[lbeg + l])) divide[l] = 1.;
+                    if (needsSubdivide(nodev[lbeg + l], level)) divide[l] = 1.;
                 }
                 log->infoIfElapsed("Evaluation for level " + std::to_string(level) + ": ", currentChunkSize);
                 firstIndex += currentChunkSize;

--- a/SKIRT/core/DensityTreePolicy.hpp
+++ b/SKIRT/core/DensityTreePolicy.hpp
@@ -123,14 +123,13 @@ protected:
         evaluate the configured criteria. */
     void setupSelfBefore() override;
 
-private:
+public:
     /** This function returns true if the given node needs to be subdivided according to the
         criteria configured for this policy, and false otherwise. The minimum and maximum level are
         not checked, because this function is never called for nodes that don't conform to the
         level criteria. */
-    bool needsSubdivide(TreeNode* node);
+    virtual bool needsSubdivide(TreeNode* node, int level);
 
-public:
     /** This function constructs the hierarchical tree and all (interconnected) nodes forming the
         tree as described for the corresponding pure virtual function in the base class. The
         implementation for this class loops over the tree subdivision levels (up to the maximum
@@ -177,7 +176,7 @@ private:
     bool _hasElectronFraction{false};
     bool _hasGasFraction{false};
 
-    // cashed values for each material type (valid if corresponding flag is enabled)
+    // cached values for each material type (valid if corresponding flag is enabled)
     double _dustMass{0.};
     double _dustKappa{0.};
     double _electronNumber{0.};

--- a/SKIRT/core/DensityTreePolicy.hpp
+++ b/SKIRT/core/DensityTreePolicy.hpp
@@ -125,23 +125,21 @@ protected:
 
 public:
     /** This function returns true if the given node needs to be subdivided according to the
-        criteria configured for this policy, and false otherwise. The minimum and maximum level are
-        not checked, because this function is never called for nodes that don't conform to the
-        level criteria. */
-    virtual bool needsSubdivide(TreeNode* node, int level);
+        criteria configured for this policy, including minimum and maximum level, and false
+        otherwise. */
+    virtual bool needsSubdivide(TreeNode* node);
 
     /** This function constructs the hierarchical tree and all (interconnected) nodes forming the
         tree as described for the corresponding pure virtual function in the base class. The
-        implementation for this class loops over the tree subdivision levels (up to the maximum
-        level configured in the TreePolicy base class). For each level, the function alternates
-        between evaluating all of the nodes (i.e. determining which nodes need subdivision) and
-        actually subdividing the nodes that need it.
+        implementation for this class loops over the tree subdivision levels. For each level, the
+        function alternates between evaluating all of the nodes (i.e. determining which nodes need
+        subdivision) and actually subdividing the nodes that need it.
 
         These operations are split over two phases because the first one can be parallelized (the
         only output is a Boolean flag), while the second one cannot (the tree structure is updated
         in various ways). Parallelizing the first operation is often meaningful, because
-        determining whether a node needs subdivision can be resource-intensive (for example, it may
-        require sampling densities in the source distribution). */
+        determining whether a node needs subdivision can be resource-intensive. For example, it may
+        require sampling densities in the source distribution. */
     vector<TreeNode*> constructTree(TreeNode* root) override;
 
     //======================== Other Functions =======================

--- a/SKIRT/core/NestedDensityTreePolicy.cpp
+++ b/SKIRT/core/NestedDensityTreePolicy.cpp
@@ -1,0 +1,52 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "NestedDensityTreePolicy.hpp"
+#include "FatalError.hpp"
+#include "MediumSystem.hpp"
+#include "TreeNode.hpp"
+#include "TreeSpatialGrid.hpp"
+
+void NestedDensityTreePolicy::setupSelfBefore()
+{
+    DensityTreePolicy::setupSelfBefore();
+
+    _inner = Box(_minXInner, _minYInner, _minZInner, _maxXInner, _maxYInner, _maxZInner);
+
+    auto ms = find<MediumSystem>(false);
+    auto grid = ms->find<TreeSpatialGrid>(false);
+    Box _outer = grid->boundingBox();
+
+    if (!_outer.contains(_inner)) throw FATALERROR("The nested density tree is not contained in the outer region");
+
+    _outerMinLevel = _minLevel;
+    _outerMaxLevel = _maxLevel;
+}
+
+void NestedDensityTreePolicy::setupSelfAfter()
+{
+    DensityTreePolicy::setupSelfAfter();
+
+    _minLevel = min(_minLevel, _nestedTree->_minLevel);
+    _maxLevel = max(_maxLevel, _nestedTree->_maxLevel);
+}
+
+bool NestedDensityTreePolicy::needsSubdivide(TreeNode* node, int level)
+{
+    if (_inner.intersects(node->extent()))
+    {
+        if (level < _nestedTree->_minLevel) return true;
+        if (level >= _nestedTree->_maxLevel) return false;
+
+        return _nestedTree->needsSubdivide(node, level);
+    }
+    else
+    {
+        if (level < _outerMinLevel) return true;
+        if (level >= _outerMaxLevel) return false;
+
+        return DensityTreePolicy::needsSubdivide(node, level);
+    }
+}

--- a/SKIRT/core/NestedDensityTreePolicy.cpp
+++ b/SKIRT/core/NestedDensityTreePolicy.cpp
@@ -4,6 +4,7 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "NestedDensityTreePolicy.hpp"
+#include "FatalError.hpp"
 #include "Log.hpp"
 #include "SpatialGrid.hpp"
 #include "TreeNode.hpp"
@@ -14,8 +15,15 @@ void NestedDensityTreePolicy::setupSelfBefore()
 {
     DensityTreePolicy::setupSelfBefore();
 
+    // verify that the inner box is not empty
+    if (_innerMaxX <= _innerMinX) throw FATALERROR("The extent of the inner box should be positive in the X direction");
+    if (_innerMaxY <= _innerMinY) throw FATALERROR("The extent of the inner box should be positive in the Y direction");
+    if (_innerMaxZ <= _innerMinZ) throw FATALERROR("The extent of the inner box should be positive in the Z direction");
+
+    // copy the coordinates to a Box instance for ease of use
     _inner = Box(_innerMinX, _innerMinY, _innerMinZ, _innerMaxX, _innerMaxY, _innerMaxZ);
 
+    // verify that the inner box is inside the spatial grid
     auto grid = find<SpatialGrid>(false);
     if (!grid->boundingBox().contains(_inner))
         find<Log>()->warning("The nested density tree policy region is not fully inside the spatial grid domain");

--- a/SKIRT/core/NestedDensityTreePolicy.cpp
+++ b/SKIRT/core/NestedDensityTreePolicy.cpp
@@ -5,7 +5,6 @@
 
 #include "NestedDensityTreePolicy.hpp"
 #include "Log.hpp"
-#include "MediumSystem.hpp"
 #include "SpatialGrid.hpp"
 #include "TreeNode.hpp"
 
@@ -15,10 +14,10 @@ void NestedDensityTreePolicy::setupSelfBefore()
 {
     DensityTreePolicy::setupSelfBefore();
 
-    _inner = Box(_minXInner, _minYInner, _minZInner, _maxXInner, _maxYInner, _maxZInner);
+    _inner = Box(_innerMinX, _innerMinY, _innerMinZ, _innerMaxX, _innerMaxY, _innerMaxZ);
 
-    auto ms = find<MediumSystem>(false);
-    if (!ms->grid()->boundingBox().contains(_inner))
+    auto grid = find<SpatialGrid>(false);
+    if (!grid->boundingBox().contains(_inner))
         find<Log>()->warning("The nested density tree policy region is not fully inside the spatial grid domain");
 }
 
@@ -27,7 +26,7 @@ void NestedDensityTreePolicy::setupSelfBefore()
 bool NestedDensityTreePolicy::needsSubdivide(TreeNode* node)
 {
     if (_inner.intersects(node->extent()))
-        return _nestedTree->needsSubdivide(node);
+        return _innerPolicy->needsSubdivide(node);
     else
         return DensityTreePolicy::needsSubdivide(node);
 }

--- a/SKIRT/core/NestedDensityTreePolicy.hpp
+++ b/SKIRT/core/NestedDensityTreePolicy.hpp
@@ -1,0 +1,84 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef NESTEDDENSITYTREEPOLICY_HPP
+#define NESTEDDENSITYTREEPOLICY_HPP
+
+#include "Box.hpp"
+#include "DensityTreePolicy.hpp"
+
+/** NestedDensityTreePolicy is a tree policy that allows for nesting DensityTreePolicies, enabling
+    users to define a region containing another (nested) density tree. 
+
+    This class inherits from DensityTreePolicy and uses all the inherited properties to classify the
+    outer region. Additionally, it introduces an additional property called nestedTree, which is
+    also a DensityTreePolicy. The nestedTree property decides the properties of the inner region.
+
+    If a TreeNode intersects with the inner 'nested' region the node will be subdivided based on the
+    properties of the nestedTree. This means that even TreeNodes almost fully outside the inner
+    region can be subdivided if they have a non-zero intersection with the inner region. */
+class NestedDensityTreePolicy : public DensityTreePolicy
+{
+    ITEM_CONCRETE(NestedDensityTreePolicy, DensityTreePolicy,
+                  "a tree grid construction policy using a nested density tree policy")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(NestedDensityTreePolicy, "Level2")
+
+        PROPERTY_DOUBLE(minXInner, "the start point of the inner box in the X direction")
+        ATTRIBUTE_QUANTITY(minXInner, "length")
+
+        PROPERTY_DOUBLE(maxXInner, "the end point of the inner box in the X direction")
+        ATTRIBUTE_QUANTITY(maxXInner, "length")
+
+        PROPERTY_DOUBLE(minYInner, "the start point of the inner box in the Y direction")
+        ATTRIBUTE_QUANTITY(minYInner, "length")
+
+        PROPERTY_DOUBLE(maxYInner, "the end point of the inner box in the Y direction")
+        ATTRIBUTE_QUANTITY(maxYInner, "length")
+
+        PROPERTY_DOUBLE(minZInner, "the start point of the inner box in the Z direction")
+        ATTRIBUTE_QUANTITY(minZInner, "length")
+
+        PROPERTY_DOUBLE(maxZInner, "the end point of the inner box in the Z direction")
+        ATTRIBUTE_QUANTITY(maxZInner, "length")
+
+        PROPERTY_ITEM(nestedTree, DensityTreePolicy, "the nested density tree inside the inner region")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function checks whether the inner region is inside the outer region. It also copies the
+     * minLevel and maxLevel as these determine the refinement of the outer region. */
+    void setupSelfBefore() override;
+
+    /** This function calculates the minLevel and maxLevel values used in the inherited function
+        constructTree. The minLevel is the minimum value among all the minLevel of all the child
+        nestedTrees. The maxLevel is the maximum value among all the maxLevel of all the child
+        nestedTrees. */
+    void setupSelfAfter() override;
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function determines whether a given node needs to be subdivided for a given level. If
+        the node intersects with the inner region, the level must lie between the minLevel and
+        maxLevel of the inner region. If the node is not within the inner region, it will use the
+        baseMinLevel and baseMaxLevel as bounds. If the node is within all the refinement bounds
+        then it will use the needsSubdidive function of the corresponding DensityTreePolicy. */
+    bool needsSubdivide(TreeNode* node, int level) override;
+
+    //======================== Data Members ========================
+
+private:
+    // the inner region box
+    Box _inner;
+
+    // the refinement bounds for the outer region
+    int _outerMinLevel;
+    int _outerMaxLevel;
+};
+
+#endif

--- a/SKIRT/core/NestedDensityTreePolicy.hpp
+++ b/SKIRT/core/NestedDensityTreePolicy.hpp
@@ -9,41 +9,57 @@
 #include "Box.hpp"
 #include "DensityTreePolicy.hpp"
 
-/** NestedDensityTreePolicy is a tree policy that allows for nesting DensityTreePolicies, enabling
-    users to define a region containing another (nested) density tree.
+/** NestedDensityTreePolicy is a DensityTreePolicy policy that allows defining separate subdivision
+    criteria in a given subregion of the spatial grid. This can be used, for example, to specify
+    a higher resolution in a given region of interest.
 
-    This class inherits from DensityTreePolicy and uses all the inherited properties to classify the
-    outer region. Additionally, it introduces an additional property called nestedTree, which is
-    also a DensityTreePolicy. The nestedTree property decides the properties of the inner region.
+    The class inherits from DensityTreePolicy and uses all the inherited properties to classify the
+    outer region. Additional \em innerMin/innerMax coordinate properties define the bounding box of
+    the inner region. Finally, the additional property \em innerPolicy, which is also expected to
+    be a DensityTreePolicy instance, specifies the subdivision criteria for the inner region.
 
-    If a TreeNode intersects with the inner 'nested' region the node will be subdivided based on the
-    properties of the nestedTree. This means that even TreeNodes almost fully outside the inner
-    region can be subdivided if they have a non-zero intersection with the inner region. */
+    If a TreeNode intersects with the inner region the node will be subdivided based on the
+    criteria defined by the \em innerPolicy. This means that even TreeNodes that are almost fully
+    outside the inner region can be subdivided by those criteria if they have a non-zero
+    intersection with the inner region.
+
+    It is not meaningful to specify an inner region that extends outside of the spatial grid
+    bounding box, because none of the tree nodes will intersect those outside areas. Therefore, a
+    warning is issued if the inner region is not fully inside the spatial grid domain.
+
+    <b>Recursive nesting</b>
+
+    By default, the inner policy is a regular DensityTreePolicy instance. However, because
+    NestedDensityTreePolicy inherits DensityTreePolicy, it is also possible to again select a
+    NestedDensityTreePolicy instance as the inner policy, leading to recursive nesting. While this
+    is not a recommended use case, it would allow specifying recursively inreasing resolution in
+    nested, successively smaller regions of the spatial domain. */
 class NestedDensityTreePolicy : public DensityTreePolicy
 {
     ITEM_CONCRETE(NestedDensityTreePolicy, DensityTreePolicy,
                   "a tree grid construction policy using a nested density tree policy")
         ATTRIBUTE_TYPE_DISPLAYED_IF(NestedDensityTreePolicy, "Level2")
 
-        PROPERTY_DOUBLE(minXInner, "the start point of the inner box in the X direction")
-        ATTRIBUTE_QUANTITY(minXInner, "length")
+        PROPERTY_DOUBLE(innerMinX, "the start point of the inner box in the X direction")
+        ATTRIBUTE_QUANTITY(innerMinX, "length")
 
-        PROPERTY_DOUBLE(maxXInner, "the end point of the inner box in the X direction")
-        ATTRIBUTE_QUANTITY(maxXInner, "length")
+        PROPERTY_DOUBLE(innerMaxX, "the end point of the inner box in the X direction")
+        ATTRIBUTE_QUANTITY(innerMaxX, "length")
 
-        PROPERTY_DOUBLE(minYInner, "the start point of the inner box in the Y direction")
-        ATTRIBUTE_QUANTITY(minYInner, "length")
+        PROPERTY_DOUBLE(innerMinY, "the start point of the inner box in the Y direction")
+        ATTRIBUTE_QUANTITY(innerMinY, "length")
 
-        PROPERTY_DOUBLE(maxYInner, "the end point of the inner box in the Y direction")
-        ATTRIBUTE_QUANTITY(maxYInner, "length")
+        PROPERTY_DOUBLE(innerMaxY, "the end point of the inner box in the Y direction")
+        ATTRIBUTE_QUANTITY(innerMaxY, "length")
 
-        PROPERTY_DOUBLE(minZInner, "the start point of the inner box in the Z direction")
-        ATTRIBUTE_QUANTITY(minZInner, "length")
+        PROPERTY_DOUBLE(innerMinZ, "the start point of the inner box in the Z direction")
+        ATTRIBUTE_QUANTITY(innerMinZ, "length")
 
-        PROPERTY_DOUBLE(maxZInner, "the end point of the inner box in the Z direction")
-        ATTRIBUTE_QUANTITY(maxZInner, "length")
+        PROPERTY_DOUBLE(innerMaxZ, "the end point of the inner box in the Z direction")
+        ATTRIBUTE_QUANTITY(innerMaxZ, "length")
 
-        PROPERTY_ITEM(nestedTree, DensityTreePolicy, "the nested density tree inside the inner region")
+        PROPERTY_ITEM(innerPolicy, DensityTreePolicy, "the density tree policy for the inner region")
+        ATTRIBUTE_DEFAULT_VALUE(innerPolicy, "DensityTreePolicy")
 
     ITEM_END()
 

--- a/SKIRT/core/NestedDensityTreePolicy.hpp
+++ b/SKIRT/core/NestedDensityTreePolicy.hpp
@@ -10,8 +10,8 @@
 #include "DensityTreePolicy.hpp"
 
 /** NestedDensityTreePolicy is a DensityTreePolicy policy that allows defining separate subdivision
-    criteria in a given subregion of the spatial grid. This can be used, for example, to specify
-    a higher resolution in a given region of interest.
+    criteria in a given subregion of the spatial grid. This can be used, for example, to specify a
+    higher resolution in a given region of interest.
 
     The class inherits from DensityTreePolicy and uses all the inherited properties to classify the
     outer region. Additional \em innerMin/innerMax coordinate properties define the bounding box of
@@ -32,7 +32,7 @@
     By default, the inner policy is a regular DensityTreePolicy instance. However, because
     NestedDensityTreePolicy inherits DensityTreePolicy, it is also possible to again select a
     NestedDensityTreePolicy instance as the inner policy, leading to recursive nesting. While this
-    is not a recommended use case, it would allow specifying recursively inreasing resolution in
+    is not a recommended use case, it would allow specifying recursively increasing resolution in
     nested, successively smaller regions of the spatial domain. */
 class NestedDensityTreePolicy : public DensityTreePolicy
 {

--- a/SKIRT/core/NestedDensityTreePolicy.hpp
+++ b/SKIRT/core/NestedDensityTreePolicy.hpp
@@ -10,7 +10,7 @@
 #include "DensityTreePolicy.hpp"
 
 /** NestedDensityTreePolicy is a tree policy that allows for nesting DensityTreePolicies, enabling
-    users to define a region containing another (nested) density tree. 
+    users to define a region containing another (nested) density tree.
 
     This class inherits from DensityTreePolicy and uses all the inherited properties to classify the
     outer region. Additionally, it introduces an additional property called nestedTree, which is
@@ -50,35 +50,23 @@ class NestedDensityTreePolicy : public DensityTreePolicy
     //============= Construction - Setup - Destruction =============
 
 protected:
-    /** This function checks whether the inner region is inside the outer region. It also copies the
-     * minLevel and maxLevel as these determine the refinement of the outer region. */
+    /** This function checks whether the inner region is inside the outer region. */
     void setupSelfBefore() override;
-
-    /** This function calculates the minLevel and maxLevel values used in the inherited function
-        constructTree. The minLevel is the minimum value among all the minLevel of all the child
-        nestedTrees. The maxLevel is the maximum value among all the maxLevel of all the child
-        nestedTrees. */
-    void setupSelfAfter() override;
 
     //======================== Other Functions =======================
 
 public:
-    /** This function determines whether a given node needs to be subdivided for a given level. If
-        the node intersects with the inner region, the level must lie between the minLevel and
-        maxLevel of the inner region. If the node is not within the inner region, it will use the
-        baseMinLevel and baseMaxLevel as bounds. If the node is within all the refinement bounds
-        then it will use the needsSubdidive function of the corresponding DensityTreePolicy. */
-    bool needsSubdivide(TreeNode* node, int level) override;
+    /** This function determines whether the given node needs to be subdivided. Depending on
+        whether the node intersects with the inner region or not, the request is passed to the
+        needsSubdivide() function of the nested policy or to the needsSubdivide() function of our
+        base class. */
+    bool needsSubdivide(TreeNode* node) override;
 
     //======================== Data Members ========================
 
 private:
     // the inner region box
     Box _inner;
-
-    // the refinement bounds for the outer region
-    int _outerMinLevel;
-    int _outerMaxLevel;
 };
 
 #endif

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -374,6 +374,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
 
     // wavelength distributions
     ItemRegistry::add<WavelengthDistribution>();
+    ItemRegistry::add<DefaultWavelengthDistribution>();
     ItemRegistry::add<RangeWavelengthDistribution>();
     ItemRegistry::add<LinWavelengthDistribution>();
     ItemRegistry::add<LogWavelengthDistribution>();

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -172,6 +172,7 @@
 #include "MollweideProjection.hpp"
 #include "MonteCarloSimulation.hpp"
 #include "MultiGaussianExpansionGeometry.hpp"
+#include "NestedDensityTreePolicy.hpp"
 #include "NestedLogWavelengthGrid.hpp"
 #include "NetzerAngularDistribution.hpp"
 #include "NoPolarizationProfile.hpp"
@@ -373,7 +374,6 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
 
     // wavelength distributions
     ItemRegistry::add<WavelengthDistribution>();
-    ItemRegistry::add<DefaultWavelengthDistribution>();
     ItemRegistry::add<RangeWavelengthDistribution>();
     ItemRegistry::add<LinWavelengthDistribution>();
     ItemRegistry::add<LogWavelengthDistribution>();
@@ -484,6 +484,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     // spatial grid policies
     ItemRegistry::add<TreePolicy>();
     ItemRegistry::add<DensityTreePolicy>();
+    ItemRegistry::add<NestedDensityTreePolicy>();
     ItemRegistry::add<SiteListTreePolicy>();
 
     // one-dimensional meshes for spatial grids

--- a/SKIRT/core/TreePolicy.hpp
+++ b/SKIRT/core/TreePolicy.hpp
@@ -8,7 +8,6 @@
 
 #include "SimulationItem.hpp"
 class TreeNode;
-class NestedDensityTreePolicy;
 
 //////////////////////////////////////////////////////////////////////
 
@@ -59,9 +58,6 @@ public:
         neighbors with the largest overlapping border area are listed first, increasing (on
         average) the probability of locating the correct neighbor early in the list. */
     virtual vector<TreeNode*> constructTree(TreeNode* root) = 0;
-
-    /** The NestedDensityTreePolicy needs access to the minLevel and maxLevel. */
-    friend NestedDensityTreePolicy;
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/TreePolicy.hpp
+++ b/SKIRT/core/TreePolicy.hpp
@@ -60,9 +60,7 @@ public:
         average) the probability of locating the correct neighbor early in the list. */
     virtual vector<TreeNode*> constructTree(TreeNode* root) = 0;
 
-    /**
-     * The NestedDensityTreePolicy needs access to the minLevel and maxLevel.
-     */
+    /** The NestedDensityTreePolicy needs access to the minLevel and maxLevel. */
     friend NestedDensityTreePolicy;
 };
 

--- a/SKIRT/core/TreePolicy.hpp
+++ b/SKIRT/core/TreePolicy.hpp
@@ -8,6 +8,7 @@
 
 #include "SimulationItem.hpp"
 class TreeNode;
+class NestedDensityTreePolicy;
 
 //////////////////////////////////////////////////////////////////////
 
@@ -58,6 +59,11 @@ public:
         neighbors with the largest overlapping border area are listed first, increasing (on
         average) the probability of locating the correct neighbor early in the list. */
     virtual vector<TreeNode*> constructTree(TreeNode* root) = 0;
+
+    /**
+     * The NestedDensityTreePolicy needs access to the minLevel and maxLevel.
+     */
+    friend NestedDensityTreePolicy;
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/Box.hpp
+++ b/SKIRT/utils/Box.hpp
@@ -111,9 +111,8 @@ public:
     /** This function returns true if the given box is inside this box, false otherwise. */
     inline bool contains(const Box& box) const
     {
-        return xmin() <= box.xmin() && xmax() >= box.xmax() &&
-               ymin() <= box.ymin() && ymax() >= box.ymax() &&
-               zmin() <= box.zmin() && zmax() >= box.zmax();
+        return xmin() <= box.xmin() && xmax() >= box.xmax() && ymin() <= box.ymin() && ymax() >= box.ymax()
+               && zmin() <= box.zmin() && zmax() >= box.zmax();
     }
 
     /** This function returns the volume \f$(x_\text{max}-x_\text{min}) \times
@@ -167,8 +166,8 @@ public:
         k = std::max(0, std::min(nz - 1, static_cast<int>(nz * (r.z() - _zmin) / (_zmax - _zmin))));
     }
 
-    /** This function returns true if the given box and this box have a non-zero intersection, false
-     * otherwise. */
+    /** This function returns true if the given box and this box have a non-zero intersection,
+        false otherwise. */
     inline bool intersects(const Box& box) const
     {
         if (xmax() < box.xmin() || box.xmax() < xmin()) return false;

--- a/SKIRT/utils/Box.hpp
+++ b/SKIRT/utils/Box.hpp
@@ -108,6 +108,14 @@ public:
         return x >= _xmin && x <= _xmax && y >= _ymin && y <= _ymax && z >= _zmin && z <= _zmax;
     }
 
+    /** This function returns true if the given box is inside this box, false otherwise. */
+    inline bool contains(const Box& box) const
+    {
+        return xmin() <= box.xmin() && xmax() >= box.xmax() &&
+               ymin() <= box.ymin() && ymax() >= box.ymax() &&
+               zmin() <= box.zmin() && zmax() >= box.zmax();
+    }
+
     /** This function returns the volume \f$(x_\text{max}-x_\text{min}) \times
         (y_\text{max}-y_\text{min}) \times (z_\text{max}-z_\text{min})\f$ of the box. */
     inline double volume() const { return (_xmax - _xmin) * (_ymax - _ymin) * (_zmax - _zmin); }
@@ -157,6 +165,16 @@ public:
         i = std::max(0, std::min(nx - 1, static_cast<int>(nx * (r.x() - _xmin) / (_xmax - _xmin))));
         j = std::max(0, std::min(ny - 1, static_cast<int>(ny * (r.y() - _ymin) / (_ymax - _ymin))));
         k = std::max(0, std::min(nz - 1, static_cast<int>(nz * (r.z() - _zmin) / (_zmax - _zmin))));
+    }
+
+    /** This function returns true if the given box and this box have a non-zero intersection, false
+     * otherwise. */
+    inline bool intersects(const Box& box) const
+    {
+        if (xmax() < box.xmin() || box.xmax() < xmin()) return false;
+        if (ymax() < box.ymin() || box.ymax() < ymin()) return false;
+        if (zmax() < box.zmin() || box.zmax() < zmin()) return false;
+        return true;
     }
 
     /** This function intersects the receiving axis-aligned bounding box with a ray (half-line)


### PR DESCRIPTION
**Description**
- slight changes to `DensityTreePolicy` & `TreePolicy` to conform with the new `NestedDensityTreePolicy`
- added extra `contains` & `intersects` to Box

**Motivation**
Allows for using nested OctTree / BinTree for greater refinement in user chosen regions

**Tests**
Tested for both OctTree and BinTree with different refinement levels and DensityTree properties such as `maxDustFraction`
