### PR TITLE
Adds possibility to oversampling to ParallelProjectionForm

### DIFF
--- a/SKIRT/core/ParallelProjectionForm.cpp
+++ b/SKIRT/core/ParallelProjectionForm.cpp
@@ -68,9 +68,9 @@ void ParallelProjectionForm::writeQuantity(const ProbeFormBridge* bridge) const
         {
             for (int i = 0; i != Nxp; ++i)
             {
-                for (int is = 0; is != Nsampling; ++is)
+                for (int is = 0; is < Nsampling; ++is)
                 {
-                    for (int js = 0; js != Nsampling; ++js)
+                    for (int js = 0; js < Nsampling; ++js)
                     {
                         // transform pixel indices to observer coordinates
                         double xp = xpmin + (i + (is + 1.0) / (Nsampling + 1.0)) * xpsiz;

--- a/SKIRT/core/ParallelProjectionForm.cpp
+++ b/SKIRT/core/ParallelProjectionForm.cpp
@@ -28,6 +28,9 @@ void ParallelProjectionForm::writeQuantity(const ProbeFormBridge* bridge) const
     double ypmin = centerY() - 0.5 * fieldOfViewY();
     double ypsiz = fieldOfViewY() / numPixelsY();
 
+    // get the oversampling rate
+    int Nsampling = numSampling();
+    
     // calculate sines and cosines for the transformation from observer to model coordinates
     double costheta = cos(inclination());
     double sintheta = sin(inclination());
@@ -55,8 +58,9 @@ void ParallelProjectionForm::writeQuantity(const ProbeFormBridge* bridge) const
     log->infoSetElapsed(Nyp);
     auto parallel = bridge->probe()->find<ParallelFactory>()->parallelDistributed();
     parallel->call(Nyp, [&vvv, bridge, xpmin, xpsiz, ypmin, ypsiz, kx, ky, kz, zp, costheta, sintheta, cosphi, sinphi,
-                         cosomega, sinomega, Nxp, Nv, log](size_t firstIndex, size_t numIndices) {
+                         cosomega, sinomega, Nxp, Nv, log, Nsampling](size_t firstIndex, size_t numIndices) {
         Array values(Nv);
+        int Nsampling2 = Nsampling * Nsampling;
         string progress = bridge->probe()->typeAndName() + " calculated projected pixels: ";
 
         // loop over pixels
@@ -64,32 +68,38 @@ void ParallelProjectionForm::writeQuantity(const ProbeFormBridge* bridge) const
         {
             for (int i = 0; i != Nxp; ++i)
             {
-                // transform pixel indices to observer coordinates
-                double xp = xpmin + (i + 0.5) * xpsiz;
-                double yp = ypmin + (j + 0.5) * ypsiz;
-
-                // transform observer coordinates to model coordinates (inverse transform of frame instrument)
-                double xpp = sinomega * xp - cosomega * yp;
-                double ypp = cosomega * xp + sinomega * yp;
-                double zpp = zp;
-                double x = cosphi * costheta * xpp - sinphi * ypp + cosphi * sintheta * zpp;
-                double y = sinphi * costheta * xpp + cosphi * ypp + sinphi * sintheta * zpp;
-                double z = -sintheta * xpp + costheta * zpp;
-
-                // get the quantity value aggregated along a path leaving the pixel through the model
-                bridge->valuesAlongPath(Position(x, y, z), kz, values);
-
-                // store the result
-                if (bridge->isVector())
+                for (int is = 0; is != Nsampling; ++is)
                 {
-                    Vec v(values[0], values[1], values[2]);
-                    vvv(0, j, i) = Vec::dot(v, kx);
-                    vvv(1, j, i) = Vec::dot(v, ky);
-                    vvv(2, j, i) = Vec::dot(v, kz);
-                }
-                else
-                {
-                    for (int p = 0; p != Nv; ++p) vvv(p, j, i) = values[p];
+                    for (int js = 0; js != Nsampling; ++js)
+                    {
+                        // transform pixel indices to observer coordinates
+                        double xp = xpmin + (i + (is + 1.0) / (Nsampling + 1.0)) * xpsiz;
+                        double yp = ypmin + (j + (js + 1.0) / (Nsampling + 1.0)) * ypsiz;
+
+                        // transform observer coordinates to model coordinates (inverse transform of frame instrument)
+                        double xpp = sinomega * xp - cosomega * yp;
+                        double ypp = cosomega * xp + sinomega * yp;
+                        double zpp = zp;
+                        double x = cosphi * costheta * xpp - sinphi * ypp + cosphi * sintheta * zpp;
+                        double y = sinphi * costheta * xpp + cosphi * ypp + sinphi * sintheta * zpp;
+                        double z = -sintheta * xpp + costheta * zpp;
+                        
+                        // get the quantity value aggregated along a path leaving the pixel through the model
+                        bridge->valuesAlongPath(Position(x, y, z), kz, values);
+                        
+                        // add the result to the sum and store it
+                        if (bridge->isVector())
+                        {
+                            Vec v(values[0], values[1], values[2]);
+                            vvv(0, j, i) += Vec::dot(v, kx) / Nsampling2;
+                            vvv(1, j, i) += Vec::dot(v, ky) / Nsampling2;
+                            vvv(2, j, i) += Vec::dot(v, kz) / Nsampling2;
+                        }
+                        else
+                        {
+                            for (int p = 0; p != Nv; ++p) vvv(p, j, i) += values[p] / Nsampling2;
+                        }
+                    }
                 }
             }
             log->infoIfElapsed(progress, 1);

--- a/SKIRT/core/ParallelProjectionForm.cpp
+++ b/SKIRT/core/ParallelProjectionForm.cpp
@@ -30,7 +30,7 @@ void ParallelProjectionForm::writeQuantity(const ProbeFormBridge* bridge) const
 
     // get the oversampling rate
     int Nsampling = numSampling();
-    
+
     // calculate sines and cosines for the transformation from observer to model coordinates
     double costheta = cos(inclination());
     double sintheta = sin(inclination());
@@ -83,10 +83,10 @@ void ParallelProjectionForm::writeQuantity(const ProbeFormBridge* bridge) const
                         double x = cosphi * costheta * xpp - sinphi * ypp + cosphi * sintheta * zpp;
                         double y = sinphi * costheta * xpp + cosphi * ypp + sinphi * sintheta * zpp;
                         double z = -sintheta * xpp + costheta * zpp;
-                        
+
                         // get the quantity value aggregated along a path leaving the pixel through the model
                         bridge->valuesAlongPath(Position(x, y, z), kz, values);
-                        
+
                         // add the result to the sum and store it
                         if (bridge->isVector())
                         {

--- a/SKIRT/core/ParallelProjectionForm.hpp
+++ b/SKIRT/core/ParallelProjectionForm.hpp
@@ -21,16 +21,17 @@
 
     The FITS file contains a number of image frames corresponding to the number of components in a
     value of the quantity being probed (i.e. 1 for scalar quantities, 3 for vector quantities, and
-    N for compound quantities). In case of a vector quantity, the three image frames represent
-    the velocity vector components in the frame of the projection, i.e. the two components
-    projected on the x and y axes of the projection plane and the component perpendicular to it,
-    where positive values indicate vectors pointing away from the viewer.
- 
-    For each pixel of the output array, the class subdivides the pixel into \f$ N \times N\f$ regularly
-    positioned subpixels, where \f$N\f$ is the user-supplied oversampling rate. For each of these
-    \f$N^2\f$ rays, a ray is sent through the model, calculating the projection by accumulating information
-    along that ray. At the end, the algorithm averages the result of these \f$N^2\f$ calclulations. Higher
-    oversampling rates correspond to higher accuracy, but also increased compuational cost. */
+    N for compound quantities). In case of a vector quantity, the three image frames represent the
+    velocity vector components in the frame of the projection, i.e. the two components projected on
+    the x and y axes of the projection plane and the component perpendicular to it, where positive
+    values indicate vectors pointing away from the viewer.
+
+    For each pixel of the output array, the class subdivides the pixel into \f$ N \times N\f$
+    regularly positioned subpixels, where \f$N\f$ is the user-supplied oversampling rate. For each
+    of these \f$N^2\f$ subpixels, a ray is sent through the model, calculating the projection by
+    accumulating information along that ray. At the end, the algorithm averages the result of these
+    \f$N^2\f$ calclulations. Higher oversampling rates correspond to higher accuracy, but also
+    increased compuational cost. */
 class ParallelProjectionForm : public GenericForm
 {
     ITEM_CONCRETE(ParallelProjectionForm, GenericForm, "parallel projection on a distant plane")

--- a/SKIRT/core/ParallelProjectionForm.hpp
+++ b/SKIRT/core/ParallelProjectionForm.hpp
@@ -25,11 +25,12 @@
     the velocity vector components in the frame of the projection, i.e. the two components
     projected on the x and y axes of the projection plane and the component perpendicular to it,
     where positive values indicate vectors pointing away from the viewer.
-
-    This class sends a ray through the model for each output pixel center, calculating the
-    projection by accumulating information along that ray. Consequently, it ignores small features
-    in the model that project on the pixel but do not overlap the pixel center. To improve
-    accuracy, decrease the pixel size by increasing the number of pixels along each axis. */
+ 
+    For each pixel of the output array, the class subdivides the pixel into \f$ N \times N\f$ regularly
+    positioned subpixels, where \f$N\f$ is the user-supplied oversampling rate. For each of these
+    \f$N^2\f$ rays, a ray is sent through the model, calculating the projection by accumulating information
+    along that ray. At the end, the algorithm averages the result of these \f$N^2\f$ calclulations. Higher
+    oversampling rates correspond to higher accuracy, but also increased compuational cost. */
 class ParallelProjectionForm : public GenericForm
 {
     ITEM_CONCRETE(ParallelProjectionForm, GenericForm, "parallel projection on a distant plane")
@@ -83,6 +84,11 @@ class ParallelProjectionForm : public GenericForm
         ATTRIBUTE_QUANTITY(centerY, "length")
         ATTRIBUTE_DEFAULT_VALUE(centerY, "0")
         ATTRIBUTE_DISPLAYED_IF(centerY, "Level2")
+
+        PROPERTY_INT(numSampling, "the oversampling rate in each direction")
+        ATTRIBUTE_MIN_VALUE(numSampling, "1")
+        ATTRIBUTE_MAX_VALUE(numSampling, "9")
+        ATTRIBUTE_DEFAULT_VALUE(numSampling, "1")
 
     ITEM_END()
 


### PR DESCRIPTION
**Description**
This pull request adds the possibility to oversampling to the ParallelProjectionForm. 

**Motivation**
The parallel projection for the probes was based on a simple algorithm that just integrated the quantity to be projected along a single line from the centre of each pixel of the array in the projection plane. This is not ideal if the pixels are relatively large compared to the size of the particles (in the case of smoothed particles). The new version allows for oversampling: instead of integrating along a single line, each pixel is now subdivided into N x N subpixels, and the result is the average of the integrations along all these lines. The oversampling rate N is a parameter that can be chosen by the user.

**Tests**
Tests were done with a simple model (a single SPH particle, no medium) and with a pixel size that is relatively large compared to the particle smoothing length. In the ideal world, an image with many photon packets and a parallel ImportedSourceLuminosityProbe should give the same result. With N=1 the agreement is not perfect, as N is increased the agreement increases.