### PR TITLE
Add convergence criterion to NonLTELineGasMix using global level populations

### DIFF
--- a/SKIRT/core/Configuration.hpp
+++ b/SKIRT/core/Configuration.hpp
@@ -314,6 +314,11 @@ public:
         otherwise. */
     bool hasSecondaryDynamicState() const { return _hasSecondaryDynamicState; }
 
+    /** Returns true if the simulation has primary or merged iterations and includes one or more
+        recipes or media that perform primary or secondary dynamic medium state (DMS) updates, and
+        false otherwise. */
+    bool hasDynamicState() const { return _hasPrimaryDynamicState || _hasSecondaryDynamicState; }
+
     // ----> photon cycle
 
     /** Returns true if the extinction cross section (the sum of the absorption and scattering

--- a/SKIRT/core/MaterialMix.cpp
+++ b/SKIRT/core/MaterialMix.cpp
@@ -117,7 +117,9 @@ UpdateStatus MaterialMix::updateSpecificState(MaterialState* /*state*/, const Ar
 
 ////////////////////////////////////////////////////////////////////
 
-bool MaterialMix::isSpecificStateConverged(int /*numCells*/, int /*numUpdated*/, int /*numNotConverged*/) const
+bool MaterialMix::isSpecificStateConverged(int /*numCells*/, int /*numUpdated*/, int /*numNotConverged*/,
+                                           MaterialState* /*currentAggregate*/,
+                                           MaterialState* /*previousAggregate*/) const
 {
     return true;
 }

--- a/SKIRT/core/MaterialMix.hpp
+++ b/SKIRT/core/MaterialMix.hpp
@@ -384,11 +384,14 @@ public:
         updateSpecificState() has been called for all spatial cells. The \em numCells, \em
         numUpdated and \em numNotConverged arguments specify respectively the number of spatial
         cells in the simulation, the number of cells updated during this update cycle, and the
-        number of updated cells that have not yet converged. Based on this information and any
-        relevant user configuration options, the function returns true if the medium state is
-        considered to be converged and false if not. The default implementation in this base class
-        always returns true. */
-    virtual bool isSpecificStateConverged(int numCells, int numUpdated, int numNotConverged) const;
+        number of updated cells that have not yet converged. The \em currentAggregate and \em
+        previousAggregate arguments provide the current and previous aggregate material states for
+        this material mix (for more information, see the section on aggregation in the MediumState
+        class header). Based on this information and any relevant user configuration options, the
+        function returns true if the medium state is considered to be converged and false if not.
+        The default implementation in this base class always returns true. */
+    virtual bool isSpecificStateConverged(int numCells, int numUpdated, int numNotConverged,
+                                          MaterialState* currentAggregate, MaterialState* previousAggregate) const;
 
     //======== Low-level material properties =======
 

--- a/SKIRT/core/MediumState.cpp
+++ b/SKIRT/core/MediumState.cpp
@@ -9,10 +9,11 @@
 
 //////////////////////////////////////////////////////////////////////
 
-void MediumState::initConfiguration(int numCells, int numMedia)
+void MediumState::initConfiguration(int numCells, int numMedia, int numAggregateCells)
 {
     _numCells = numCells;
     _numMedia = numMedia;
+    _numAggregateCells = numAggregateCells;
 
     _off_dens.resize(_numMedia);
     _off_meta.resize(_numMedia);
@@ -54,11 +55,16 @@ void MediumState::initSpecificStateVariables(const vector<StateVariable>& variab
     {
         switch (variable.identifier())
         {
-            case StateVariable::Identifier::NumberDensity: _off_dens[_nextComponent] = _nextOffset++; break;
+            case StateVariable::Identifier::NumberDensity:
+                if (_numAggregateCells) _densityOffsets.push_back(_nextOffset);
+                _off_dens[_nextComponent] = _nextOffset++;
+                break;
             case StateVariable::Identifier::Metallicity: _off_meta[_nextComponent] = _nextOffset++; break;
             case StateVariable::Identifier::Temperature: _off_temp[_nextComponent] = _nextOffset++; break;
             case StateVariable::Identifier::Custom:
                 if (variable.customIndex() == 0) _off_cust[_nextComponent] = _nextOffset;
+                if (_numAggregateCells && variable.quantity() == "numbervolumedensity")
+                    _densityOffsets.push_back(_nextOffset);
                 _nextOffset++;
                 break;
             case StateVariable::Identifier::Volume:
@@ -77,7 +83,7 @@ size_t MediumState::initAllocate()
     if (_nextComponent != _numMedia) throw FATALERROR("Failed to request state variables for all medium components");
     _numVars = _nextOffset;
 
-    size_t numAlloc = static_cast<size_t>(_numVars) * static_cast<size_t>(_numCells);
+    size_t numAlloc = static_cast<size_t>(_numVars) * static_cast<size_t>(_numCells + _numAggregateCells);
     _data.resize(numAlloc);
     return numAlloc;
 }
@@ -145,6 +151,35 @@ std::pair<int, int> MediumState::synchronize(const vector<UpdateStatus>& cellFla
         }
     }
     return std::make_pair(numUpdated, numNotConverged);
+}
+
+//////////////////////////////////////////////////////////////////////
+
+void MediumState::aggregate()
+{
+    // if aggregation is requested
+    if (_numAggregateCells)
+    {
+        // shift the previous aggregate states to make room
+        for (int m = _numCells + _numAggregateCells - 1; m != _numCells; --m)
+        {
+            for (int i = 0; i != _numVars; ++i) _data[_numVars * m + i] = _data[_numVars * (m - 1) + i];
+        }
+
+        // clear the variables in the current aggregate state
+        for (int i = 0; i != _numVars; ++i) _data[_numVars * _numCells + i] = 0.;
+
+        // calculate the current aggregate state
+        for (int m = 0; m != _numCells; ++m)
+        {
+            // cell volume
+            double volume = _data[_numVars * m + _off_volu];
+            _data[_numVars * _numCells + _off_volu] += volume;
+
+            // variables of type number volume density
+            for (int i : _densityOffsets) _data[_numVars * _numCells + i] += _data[_numVars * m + i] * volume;
+        }
+    }
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/MediumState.cpp
+++ b/SKIRT/core/MediumState.cpp
@@ -155,17 +155,11 @@ std::pair<int, int> MediumState::synchronize(const vector<UpdateStatus>& cellFla
 
 //////////////////////////////////////////////////////////////////////
 
-void MediumState::aggregate()
+void MediumState::calculateAggregate()
 {
     // if aggregation is requested
     if (_numAggregateCells)
     {
-        // shift the previous aggregate states to make room
-        for (int m = _numCells + _numAggregateCells - 1; m != _numCells; --m)
-        {
-            for (int i = 0; i != _numVars; ++i) _data[_numVars * m + i] = _data[_numVars * (m - 1) + i];
-        }
-
         // clear the variables in the current aggregate state
         for (int i = 0; i != _numVars; ++i) _data[_numVars * _numCells + i] = 0.;
 
@@ -178,6 +172,21 @@ void MediumState::aggregate()
 
             // variables of type number volume density
             for (int i : _densityOffsets) _data[_numVars * _numCells + i] += _data[_numVars * m + i] * volume;
+        }
+    }
+}
+
+//////////////////////////////////////////////////////////////////////
+
+void MediumState::pushAggregate()
+{
+    // if aggregation is requested
+    if (_numAggregateCells)
+    {
+        // shift the previous aggregate states to make room
+        for (int m = _numCells + _numAggregateCells - 1; m != _numCells; --m)
+        {
+            for (int i = 0; i != _numVars; ++i) _data[_numVars * m + i] = _data[_numVars * (m - 1) + i];
         }
     }
 }

--- a/SKIRT/core/MediumState.hpp
+++ b/SKIRT/core/MediumState.hpp
@@ -83,11 +83,12 @@
     recent) aggregate state has cell index \f$m=M\f$, the previous aggregate state has cell index
     \f$m=M+1\f$, the one before that has cell index \f$m=M+2\f$, and so forth.
 
-    The aggregate() function should be called at the end of construction, i.e. after
-    initCommunicate(), and at the end of each step in the iterative process, after synchronize().
-    It first shifts the existing aggregate states to the next higher cell index, dropping the least
-    recent aggregate state and making room for a new one. It then recalculates the current
-    aggregate state by accumulating information over all cells.
+    The calculateAggregate() function should be called at the end of construction, i.e. after
+    initCommunicate(), and at the end of each dynamic medium state update cycle, i.e. after
+    synchronize(). It recalculates the current aggregate state by accumulating information over all
+    spatial cells. The pushAggregate() function should be called at the end of each step in the
+    iterative process. It shifts the existing aggregate states to the next higher cell index,
+    dropping the least recent aggregate state and making room for a new one.
 
     The current implementation performs the following aggregation. The cell volume is summed over
     all cells, providing the total volume of the spatial domain: \f$V_\mathrm{tot} = \sum V_m\f$.
@@ -158,6 +159,7 @@ public:
 
     //============= Synchronization and Aggregation =============
 
+public:
     /** This function synchronizes the state variables between processes after each process has
         possibly updated some of their values. The provided vector indicates the cells for which
         the calling process has made some changes. The vector must be of length \em numCells as
@@ -173,10 +175,15 @@ public:
         undefined. */
     std::pair<int, int> synchronize(const vector<UpdateStatus>& cellFlags);
 
+    /** If aggregation has been requested when initializing the configuration, this function
+        calculates the current aggregate state. For more information, see the description of
+        aggregation in the class header. */
+    void calculateAggregate();
+
     /** If aggregation has been requested when initializing the configuration, this function shifts
-        the previously stored aggregate states to make room, and calculates the current aggregate
-        state. For more information, see the description of aggregation in the class header. */
-    void aggregate();
+        the previously stored aggregate states to make room for a new current aggregate state. For
+        more information, see the description of aggregation in the class header. */
+    void pushAggregate();
 
     //============= Setting =============
 

--- a/SKIRT/core/MediumState.hpp
+++ b/SKIRT/core/MediumState.hpp
@@ -46,26 +46,67 @@
      - the initCommonStateVariables() function specifies the set of common state variables.
      - the initSpecificStateVariables() function must be called once for each medium component, in
        order of component index, specifying the set of specific state variables for that component.
-     - the initAllocate() function finalizes construction and actually allocates storage.
-     - the initCommunicate() function communicates the state variable values between processes.
+     - the initAllocate() function finalizes construction and actually allocates storage;
+       it initializes all variables to a value of zero.
+     - the setXXX() functions set any nonzero initial variable values required to reflect the input
+       model; this may happen in parallel.
+     - the initCommunicate() function communicates the initialized state variable values between
+       processes.
 
     The initCommonStateVariables() and initSpecificStateVariables() functions each receive a list
-    of StateVariable objects to identify the required state variables (only the identifier is used,
-    the other information is ignored). All required state variables must be listed, including those
-    that should always present. Variables of type Custom must be listed last. Multiple variables of
-    type Custom can be requested by supplying indices in the range \f$ 0 \le k < K\f$, where K is
-    the total number of custom variables. Each of these indices must occur in the list exactly once
-    in increasing order.
+    of StateVariable objects to identify the required state variables. All required state variables
+    must be listed, including those that should always present. Variables of type Custom must be
+    listed last. Multiple variables of type Custom can be requested by supplying indices in the
+    range \f$ 0 \le k < K\f$, where K is the total number of custom variables. Each of these
+    indices must occur in the list exactly once in increasing order.
+
+    <b>Synchronization</b>
+
+    A simulation may update the values of medium state variables, often as part of an iterative
+    process to calculate a self-consistent state. These updates may happen in parallel over cells.
+    After a set of updates, usually at the end of each step in the iterative process, the
+    synchronize() function should be called to broadcast the updates between processes.
+
+    <b>Aggregation</b>
+
+    When a simulation employs an iterative process to calculate a self-consistent medium state, it
+    needs a criterion to determine whether the state has sufficiently converged. Such criterion is
+    often based on aggregate information calculated over all cells in the spatial grid for the
+    current iteration and for one or more previous iterations. This class can calculate and store
+    such aggregate information in the form of "fake" cells that are added at the end of the array
+    of regular cells. The number of stored aggregated states, including current and previous ones,
+    must be specified as the last argument of the initConfiguration() function. If this number is
+    zero, no aggregation is performed.
+
+    Information from the aggregate states can be retrieved using the same functions as those for
+    regular cells. Assuming a number of regular spatial cells \f$M\f$, the current (i.e. most
+    recent) aggregate state has cell index \f$m=M\f$, the previous aggregate state has cell index
+    \f$m=M+1\f$, the one before that has cell index \f$m=M+2\f$, and so forth.
+
+    The aggregate() function should be called at the end of each step in the iterative process,
+    after the synchronize() function has been called. It first shifts the existing aggregate states
+    to the next higher cell index, dropping the least recent aggregate state and making room for a
+    new one. It then recalculates the current aggregate state by accumulating information over all
+    cells.
+
+    The current implementation performs the following aggregation. The cell volume is summed over
+    all cells, providing the total volume of the spatial domain: \f$V_\mathrm{tot} = \sum V_m\f$.
+    All variables with quantity type "numbervolumedensity" are summed after multiplication with the
+    cell volume, providing a total number: \f$N_\mathrm{tot} = \sum n_m V_m\f$. Any other variables
+    are not aggregated; i.e. the aggregated values are zero. The aggregated values can be retrieved
+    through the volume(), numberDensity() and custom() functions using the fake cell index
+    corresponding to the desired current or previous state.
 
     <b>Storage</b>
 
     To simplify the storage mechanism, state variables of type \c Vec are split into their three
     components, so that all state variables can considered to be of type \c double. Memory is
     allocated only for state variables that are actually needed. Given the number of spatial cells
-    \f$M\f$, the number of medium components \f$H\f$, the number of common state variables \f$C\f$,
-    and the number of specific state variables \f$S_h\f$ for each medium component \f$h\f$, the
-    number of state variables per spatial cell is \f$K = C+\sum_h S_h\f$ and the grand total number
-    of state variables is \f$N = M (C+\sum_h S_h)\f$.
+    \f$M\f$ (possibly increased by the requested number of aggregate cells), the number of medium
+    components \f$H\f$, the number of common state variables \f$C\f$, and the number of specific
+    state variables \f$S_h\f$ for each medium component \f$h\f$, the number of state variables per
+    spatial cell is \f$K = C+\sum_h S_h\f$ and the grand total number of state variables is \f$N =
+    M (C+\sum_h S_h)\f$.
 
     The MediumState class allocates a single one-dimensional data array of this size \f$N\f$ and
     provides a mapping to locate a particular state variable in this array. This is accomplished by
@@ -75,9 +116,8 @@
 
     Given the offset \f$O_x\f$ for a particular state variable \f$x\f$, a spatial cell index
     \f$m\f$ and a medium component index \f$h\f$, the index of the variable in the data array can
-    be calculated as \f$i=K \times m + O_x\f$ (storing contiguously per cell) or \f$i=M \times O_x
-    + m\f$ (storing contiguously per variable). We can evaluate the performance of these and
-    possibly other mapping schemes.
+    be calculated as \f$i=K \times m + O_x\f$. This implies that variables are stored contiguously
+    per cell.
 
     <b>Access to undefined variables</b>
 
@@ -92,8 +132,10 @@ class MediumState
     //============= Construction =============
 
 public:
-    /** This function initializes the number of spatial cells and number of medium components. */
-    void initConfiguration(int numCells, int numMedia);
+    /** This function initializes the number of spatial cells and number of medium components. If
+        the specified number of aggregate cells is nonzero, the configuration is also prepared to
+        store that number of aggregate states, as described in the class header. */
+    void initConfiguration(int numCells, int numMedia, int numAggregateCells);
 
     /** This function initializes the set of required common state variables. */
     void initCommonStateVariables(const vector<StateVariable>& variables);
@@ -114,7 +156,7 @@ public:
         assumes that the uninitialized variables have a zero value). */
     void initCommunicate();
 
-    //============= Synchronization =============
+    //============= Synchronization and Aggregation =============
 
     /** This function synchronizes the state variables between processes after each process has
         possibly updated some of their values. The provided vector indicates the cells for which
@@ -130,6 +172,11 @@ public:
         more processes updated the state of the same cell, the result of the synchronization is
         undefined. */
     std::pair<int, int> synchronize(const vector<UpdateStatus>& cellFlags);
+
+    /** If aggregation has been requested when initializing the configuration, this function shifts
+        the previously stored aggregate states to make room, and calculates the current aggregate
+        state. For more information, see the description of aggregation in the class header. */
+    void aggregate();
 
     //============= Setting =============
 
@@ -214,10 +261,13 @@ private:
     // data array containing the medium state variables
     Array _data;
 
-    // configuration and offsets used for mapping to indices in the data array
+    // overall configuration
     int _numCells{0};
     int _numMedia{0};
+    int _numAggregateCells{0};
     int _numVars{0};
+
+    // offsets used for mapping common and specific variables (for each medium component) to indices in the data array
     int _off_volu{0};
     int _off_velo{0};
     int _off_mfld{0};
@@ -225,6 +275,9 @@ private:
     vector<int> _off_meta;
     vector<int> _off_temp;
     vector<int> _off_cust;
+
+    // offsets used to aggregate all standard and custom specific variables of quantity type "numbervolumedensity"
+    vector<int> _densityOffsets;
 
     // indices indicating the next item to be initialized; used only during initialization
     int _nextOffset{0};

--- a/SKIRT/core/MediumState.hpp
+++ b/SKIRT/core/MediumState.hpp
@@ -83,11 +83,11 @@
     recent) aggregate state has cell index \f$m=M\f$, the previous aggregate state has cell index
     \f$m=M+1\f$, the one before that has cell index \f$m=M+2\f$, and so forth.
 
-    The aggregate() function should be called at the end of each step in the iterative process,
-    after the synchronize() function has been called. It first shifts the existing aggregate states
-    to the next higher cell index, dropping the least recent aggregate state and making room for a
-    new one. It then recalculates the current aggregate state by accumulating information over all
-    cells.
+    The aggregate() function should be called at the end of construction, i.e. after
+    initCommunicate(), and at the end of each step in the iterative process, after synchronize().
+    It first shifts the existing aggregate states to the next higher cell index, dropping the least
+    recent aggregate state and making room for a new one. It then recalculates the current
+    aggregate state by accumulating information over all cells.
 
     The current implementation performs the following aggregation. The cell volume is summed over
     all cells, providing the total volume of the spatial domain: \f$V_\mathrm{tot} = \sum V_m\f$.

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -1547,6 +1547,10 @@ bool MediumSystem::updateDynamicStateRecipes()
     _state.calculateAggregate();
 
     // tell all recipes to end the update cycle and collect convergence info
+    // !! we should pass aggregate medium state information to the recipes
+    // !! .. which requires calling endUpdate() for each medium component
+    // !! .. which implies an inconvenient redesign of the DynamicRecipe classes
+    // !! .. and since the info is currently not used, we postpone this until a later time
     bool converged = true;
     for (auto recipe : recipes) converged &= recipe->endUpdate(_numCells, numUpdated, numNotConverged);
     return converged;

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -393,7 +393,7 @@ void MediumSystem::setupSelfAfter()
     _state.initCommunicate();
 
     // calculate the initial aggregate state, if needed
-    _state.aggregate();
+    _state.calculateAggregate();
 
     log->info("Done calculating cell densities");
 }
@@ -1544,7 +1544,7 @@ bool MediumSystem::updateDynamicStateRecipes()
               + StringUtils::toString(100. * numNotConverged / _numCells, 'f', 2) + " %)");
 
     // calculate the new current aggregate state
-    _state.aggregate();
+    _state.calculateAggregate();
 
     // tell all recipes to end the update cycle and collect convergence info
     bool converged = true;
@@ -1596,7 +1596,7 @@ bool MediumSystem::updateDynamicStateMedia(bool primary)
                   + StringUtils::toString(100. * numNotConverged / _numCells, 'f', 2) + " %)");
 
     // calculate the new current aggregate state
-    _state.aggregate();
+    _state.calculateAggregate();
 
     // collect convergence info from the material mixes
     bool converged = true;
@@ -1607,6 +1607,13 @@ bool MediumSystem::updateDynamicStateMedia(bool primary)
         converged &= mix(0, h)->isSpecificStateConverged(_numCells, numUpdated, numNotConverged, &current, &previous);
     }
     return converged;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void MediumSystem::beginDynamicMediumStateIteration()
+{
+    _state.pushAggregate();
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -1598,7 +1598,11 @@ bool MediumSystem::updateDynamicStateMedia(bool primary)
     // collect convergence info from the material mixes
     bool converged = true;
     for (int h : (primary ? _pdms_hv : _sdms_hv))
-        converged &= mix(0, h)->isSpecificStateConverged(_numCells, numUpdated, numNotConverged);
+    {
+        MaterialState current(_state, _numCells, h);
+        MaterialState previous(_state, _numCells + 1, h);
+        converged &= mix(0, h)->isSpecificStateConverged(_numCells, numUpdated, numNotConverged, &current, &previous);
+    }
     return converged;
 }
 

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -392,6 +392,9 @@ void MediumSystem::setupSelfAfter()
     // communicate the calculated states across multiple processes, if needed
     _state.initCommunicate();
 
+    // calculate the initial aggregate state, if needed
+    _state.aggregate();
+
     log->info("Done calculating cell densities");
 }
 

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -198,7 +198,7 @@ void MediumSystem::setupSelfAfter()
     // ----- allocate memory for the medium state -----
 
     // basic configuration
-    _state.initConfiguration(_numCells, _numMedia);
+    _state.initConfiguration(_numCells, _numMedia, _config->hasDynamicState() ? 2 : 0);
 
     // common state variables
     vector<StateVariable> variables;
@@ -1540,6 +1540,9 @@ bool MediumSystem::updateDynamicStateRecipes()
     log->info("  Not converged: " + std::to_string(numNotConverged) + " out of " + std::to_string(_numCells) + " ("
               + StringUtils::toString(100. * numNotConverged / _numCells, 'f', 2) + " %)");
 
+    // calculate the new current aggregate state
+    _state.aggregate();
+
     // tell all recipes to end the update cycle and collect convergence info
     bool converged = true;
     for (auto recipe : recipes) converged &= recipe->endUpdate(_numCells, numUpdated, numNotConverged);
@@ -1589,7 +1592,10 @@ bool MediumSystem::updateDynamicStateMedia(bool primary)
         log->info("  Not converged: " + std::to_string(numNotConverged) + " out of " + std::to_string(_numCells) + " ("
                   + StringUtils::toString(100. * numNotConverged / _numCells, 'f', 2) + " %)");
 
-    // collect convergence info
+    // calculate the new current aggregate state
+    _state.aggregate();
+
+    // collect convergence info from the material mixes
     bool converged = true;
     for (int h : (primary ? _pdms_hv : _sdms_hv))
         converged &= mix(0, h)->isSpecificStateConverged(_numCells, numUpdated, numNotConverged);

--- a/SKIRT/core/MediumSystem.hpp
+++ b/SKIRT/core/MediumSystem.hpp
@@ -805,6 +805,10 @@ private:
     bool updateDynamicStateMedia(bool primary);
 
 public:
+    /** This function shifts the current aggregate medium state to the previous aggregate medium
+        state. It should be called at the start of each iteration step. */
+    void beginDynamicMediumStateIteration();
+
     /** This function updates the primary dynamic medium state (PDMS) for all spatial cells and
         medium components based on the currently established radiation field. It invokes any
         dynamic medium state recipes (instances of a DynamicStateRecipe subclass) configured for

--- a/SKIRT/core/MonteCarloSimulation.cpp
+++ b/SKIRT/core/MonteCarloSimulation.cpp
@@ -291,6 +291,8 @@ void MonteCarloSimulation::runPrimaryEmissionIterations()
             string segment = "primary emission iteration " + std::to_string(iter);
             TimeLogger logger(log(), segment);
 
+            mediumSystem()->beginDynamicMediumStateIteration();
+
             // clear the radiation field
             mediumSystem()->clearRadiationField(true);
 
@@ -347,6 +349,8 @@ void MonteCarloSimulation::runSecondaryEmissionIterations()
         {
             string segment = "secondary emission iteration " + std::to_string(iter);
             TimeLogger logger(log(), segment);
+
+            mediumSystem()->beginDynamicMediumStateIteration();
 
             // clear the secondary radiation field
             mediumSystem()->clearRadiationField(false);
@@ -423,6 +427,8 @@ void MonteCarloSimulation::runMergedEmissionIterations()
             string segment1 = "merged primary emission iteration " + std::to_string(iter);
             string segment2 = "merged secondary emission iteration " + std::to_string(iter);
             TimeLogger logger(log(), segment);
+
+            mediumSystem()->beginDynamicMediumStateIteration();
 
             // clear the radiation field
             mediumSystem()->clearRadiationField(true);

--- a/SKIRT/core/NonLTELineGasMix.hpp
+++ b/SKIRT/core/NonLTELineGasMix.hpp
@@ -146,6 +146,32 @@
     artificially combine the effect of both thermal motion and turbulence into an effective
     temperature, \f[ T_\mathrm{eff} = T_\mathrm{kin} + \frac{m v_\mathrm{turb}^2}{2k}. \f]
 
+    <b>Numerical convergence</b>
+
+    As mentioned above, a simulation including this material mix performs iterations to
+    self-consistently calculate the radiation field and the medium state (i.e. the energy level
+    populations that drive the line emission). This class offers three user-configurable properties
+    that specify the convergence criteria for this iterative process.
+
+    The first two properties configure a criterion based on statistics per spatial cell. The \em
+    maxChangeInLevelPopulations property specifies the maximum relative change between consecutive
+    iterations in the level populations for a given spatial cell for that cell to be considered
+    converged. The \em maxFractionNotConvergedCells property then specifies the maximum fraction of
+    cells (relative to the total number of cells in the simulation) that may be left not converged
+    for the whole spatial domain to be considered converged.
+
+    The third property configures a global criterion. The \em maxChangeInGlobalLevelPopulations
+    property specifies the maximum relative change between consecutive iterations in the global
+    level populations, accumulated over the complete spatial domain, for the spatial domain to be
+    considered converged. In other words, convergence has been reached if \f[ \epsilon =
+    \underset{i}{\mathrm{max}} \left| \frac{N_i^{(k)} - N_i^{(k-1)}} {N_i^{(k-1)}} \right| \le
+    \epsilon_\mathrm{max}\f] where \f$N_i^{(k)}\f$ denotes the total population across the spatial
+    domain for energy level \f$i\f$ at iteration \f$k\f$ and \f$\epsilon_\mathrm{max}\f$ is the
+    user-configured value of the \em maxChangeInGlobalLevelPopulations property.
+
+    Both criteria must be satisfied simultaneously. Howver, the user can effectively disable a
+    criterion by specifying very liberal maximum values.
+
     <b>Level populations</b>
 
     We denote the populations for the \f$N\f$ supported energy levels as \f$n_i\f$, with indices
@@ -425,7 +451,8 @@ public:
 
     /** This function returns true if the state of the medium component corresponding to this
         material mix can be considered to be converged based on the given spatial cell statistics
-        and aggregate material states, and false otherwise. */
+        and aggregate material states, and false otherwise. For more information on the convergence
+        criteria, see the corresponding section in the class header. */
     bool isSpecificStateConverged(int numCells, int numUpdated, int numNotConverged, MaterialState* currentAggregate,
                                   MaterialState* previousAggregate) const override;
 

--- a/SKIRT/core/NonLTELineGasMix.hpp
+++ b/SKIRT/core/NonLTELineGasMix.hpp
@@ -318,11 +318,18 @@ class NonLTELineGasMix : public EmittingGasMix
         ATTRIBUTE_DISPLAYED_IF(maxChangeInLevelPopulations, "Level2")
 
         PROPERTY_DOUBLE(maxFractionNotConvergedCells,
-                        "the maximum fraction of spatial cells that have not convergenced")
+                        "the maximum fraction of not-converged cells for all cells to be considered converged")
         ATTRIBUTE_MIN_VALUE(maxFractionNotConvergedCells, "[0")
         ATTRIBUTE_MAX_VALUE(maxFractionNotConvergedCells, "1]")
-        ATTRIBUTE_DEFAULT_VALUE(maxFractionNotConvergedCells, "0.001")
+        ATTRIBUTE_DEFAULT_VALUE(maxFractionNotConvergedCells, "0.01")
         ATTRIBUTE_DISPLAYED_IF(maxFractionNotConvergedCells, "Level2")
+
+        PROPERTY_DOUBLE(maxChangeInGlobalLevelPopulations,
+                        "the maximum relative change for the global level populations to be considered converged")
+        ATTRIBUTE_MIN_VALUE(maxChangeInGlobalLevelPopulations, "[0")
+        ATTRIBUTE_MAX_VALUE(maxChangeInGlobalLevelPopulations, "1]")
+        ATTRIBUTE_DEFAULT_VALUE(maxChangeInGlobalLevelPopulations, "0.05")
+        ATTRIBUTE_DISPLAYED_IF(maxChangeInGlobalLevelPopulations, "Level2")
 
         PROPERTY_DOUBLE(lowestOpticalDepth, "Lower limit of (negative) optical depth along a cell diagonal")
         ATTRIBUTE_MIN_VALUE(lowestOpticalDepth, "[-10")
@@ -417,12 +424,10 @@ public:
     UpdateStatus updateSpecificState(MaterialState* state, const Array& Jv) const override;
 
     /** This function returns true if the state of the medium component corresponding to this
-        material mix can be considered to be converged based on the given spatial cell statistics,
-        and false otherwise. The \em numCells, \em numUpdated and \em numNotConverged arguments
-        specify respectively the number of spatial cells in the simulation, the number of cells
-        updated during the latest update cycle, and the number of updated cells that have not yet
-        converged. */
-    bool isSpecificStateConverged(int numCells, int numUpdated, int numNotConverged) const override;
+        material mix can be considered to be converged based on the given spatial cell statistics
+        and aggregate material states, and false otherwise. */
+    bool isSpecificStateConverged(int numCells, int numUpdated, int numNotConverged, MaterialState* currentAggregate,
+                                  MaterialState* previousAggregate) const override;
 
     //======== Low-level material properties =======
 


### PR DESCRIPTION
**Description**

The `NonLTELineGasMix` class now offers an additional convergence criterion based on the global level populations.  Specifically, the _maxChangeInGlobalLevelPopulations_ property specifies the maximum relative change between consecutive iterations in the total level populations accumulated over the complete spatial domain. The new criterion complements or, if so desired, replaces the existing criterion based on statistics per spatial cell. Both criteria must be satisfied simultaneously; however, the user can effectively disable a criterion by specifying very liberal maximum values.

**Motivation**
For complex models, the Monte Carlo noise inherent to the SKIRT simulation mechanism can cause the level populations in individual cells to fluctuate quite significantly between iterations. This makes it hard to configure a proper convergence criterion using cell-based properties. Accumulating the level populations across the spatial domain mostly averages out the random fluctuations, allowing a much more stable convergence criterion.

**Context**
The aggregate information for the current and previous medium state (needed for this feature) is calculated and stored by framework classes (`MediumSystem` and `MediumState`) so that future material mixes or dynamic state recipes can benefit from this as well.

**Tests**
A functional test was added. All other tests still work unchanged.
