### PR TITLE
Add separate SpinFlip emission/absorption classes

### DIFF
--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -370,10 +370,10 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<FileIndexedSEDFamily>();
     ItemRegistry::add<MappingsSEDFamily>();
     ItemRegistry::add<ToddlersSEDFamily>();
+    ItemRegistry::add<SpinFlipSEDFamily>();
     ItemRegistry::add<LyaGaussianSEDFamily>();
     ItemRegistry::add<LyaDoublePeakedSEDFamily>();
     ItemRegistry::add<LyaSEDFamilyDecorator>();
-    ItemRegistry::add<SpinFlipSEDFamily>();
 
     // wavelength distributions
     ItemRegistry::add<WavelengthDistribution>();
@@ -560,11 +560,11 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
 
     ItemRegistry::add<ElectronMix>();
     ItemRegistry::add<SpinFlipAbsorptionMix>();
-    ItemRegistry::add<LyaNeutralHydrogenGasMix>();
+    ItemRegistry::add<SpinFlipHydrogenGasMix>();
     ItemRegistry::add<XRayAtomicGasMix>();
     ItemRegistry::add<EmittingGasMix>();
-    ItemRegistry::add<SpinFlipHydrogenGasMix>();
     ItemRegistry::add<NonLTELineGasMix>();
+    ItemRegistry::add<LyaNeutralHydrogenGasMix>();
     ItemRegistry::add<TrivialGasMix>();
 
     // material mix families

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -237,7 +237,9 @@
 #include "SpheroidalGeometryDecorator.hpp"
 #include "SpheroidalGraphiteGrainComposition.hpp"
 #include "SpheroidalSilicateGrainComposition.hpp"
+#include "SpinFlipAbsorptionMix.hpp"
 #include "SpinFlipHydrogenGasMix.hpp"
+#include "SpinFlipSEDFamily.hpp"
 #include "SpiralStructureGeometryDecorator.hpp"
 #include "Starburst99SED.hpp"
 #include "Starburst99SEDFamily.hpp"
@@ -371,6 +373,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<LyaGaussianSEDFamily>();
     ItemRegistry::add<LyaDoublePeakedSEDFamily>();
     ItemRegistry::add<LyaSEDFamilyDecorator>();
+    ItemRegistry::add<SpinFlipSEDFamily>();
 
     // wavelength distributions
     ItemRegistry::add<WavelengthDistribution>();
@@ -556,6 +559,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<FragmentDustMixDecorator>();
 
     ItemRegistry::add<ElectronMix>();
+    ItemRegistry::add<SpinFlipAbsorptionMix>();
     ItemRegistry::add<LyaNeutralHydrogenGasMix>();
     ItemRegistry::add<XRayAtomicGasMix>();
     ItemRegistry::add<EmittingGasMix>();

--- a/SKIRT/core/SpinFlipAbsorptionMix.cpp
+++ b/SKIRT/core/SpinFlipAbsorptionMix.cpp
@@ -1,0 +1,165 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "SpinFlipAbsorptionMix.hpp"
+#include "Configuration.hpp"
+#include "Constants.hpp"
+#include "DisjointWavelengthGrid.hpp"
+#include "FatalError.hpp"
+#include "MaterialState.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // special wavelengths
+    constexpr double lambdaSF = 21.10611405413e-2;  // 21 cm
+
+    // wavelength range outside of which we consider absorption to be zero (range of plus-min 9 dispersion elements using a velocity dispersion of 1000 km/s)
+    constexpr Range absorptionRange(0.2047, 0.2174);
+
+    // Einstein coefficient of the 21cm spin-flip transition
+    constexpr double ASF = 2.8843e-15;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void SpinFlipAbsorptionMix::setupSelfBefore()
+{
+    MaterialMix::setupSelfBefore();
+}
+
+MaterialMix::MaterialType SpinFlipAbsorptionMix::materialType() const
+{
+    return MaterialType::Gas;
+}
+
+////////////////////////////////////////////////////////////////////
+
+bool SpinFlipAbsorptionMix::hasExtraSpecificState() const
+{
+    return true;
+}
+
+
+////////////////////////////////////////////////////////////////////
+
+vector<StateVariable> SpinFlipAbsorptionMix::specificStateVariableInfo() const
+{
+    return vector<StateVariable>{StateVariable::numberDensity(),
+                                 StateVariable::temperature()};
+}
+
+////////////////////////////////////////////////////////////////////
+
+void SpinFlipAbsorptionMix::initializeSpecificState(MaterialState* state, double /*metallicity*/, double temperature,
+                                          const Array& /*params*/) const
+{
+    // leave the properties at zero if the cell does not contain any material for this component
+    if (state->numberDensity() > 0.)
+    {
+        // if no value was imported, use default value
+        // make sure the temperature is at least the local universe CMB temperature
+        state->setTemperature(max(Constants::Tcmb(), temperature >= 0. ? temperature : defaultTemperature()));
+    }
+}
+
+
+////////////////////////////////////////////////////////////////////
+
+double SpinFlipAbsorptionMix::mass() const
+{
+    return Constants::Mproton();
+}
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // returns the absorption cross section per neutral hydrogen atom for the given wavelength and gas temperature
+    double crossSection(double lambda, double T)
+    {
+        constexpr double front = 3. * M_SQRT2 * M_2_SQRTPI / M_PI / 128. * ASF * Constants::h() * Constants::c()
+                                 * lambdaSF * lambdaSF / Constants::k();
+        double Tspin = 6000. * (1 - exp(-0.0002 * T));
+        double sigma = sqrt(Constants::k() / Constants::Mproton() * T);
+        double u = Constants::c() * (lambda - lambdaSF) / lambda;
+        double x = u / sigma;
+        double expon = exp(-0.5 * x * x);
+        return front / Tspin / sigma * expon;
+    }
+}
+
+////////////////////////////////////////////////////////////////////
+
+double SpinFlipAbsorptionMix::sectionAbs(double lambda) const
+{
+    return absorptionRange.contains(lambda) ? crossSection(lambda, defaultTemperature()) : 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double SpinFlipAbsorptionMix::sectionSca(double /*lambda*/) const
+{
+    return 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double SpinFlipAbsorptionMix::sectionExt(double lambda) const
+{
+    return sectionAbs(lambda);
+}
+
+////////////////////////////////////////////////////////////////////
+
+double SpinFlipAbsorptionMix::opacityAbs(double lambda, const MaterialState* state, const PhotonPacket* /*pp*/) const
+{
+    if (absorptionRange.contains(lambda))
+    {
+        double number = state->numberDensity();
+        if (number > 0.) return crossSection(lambda, state->temperature()) * number;
+    }
+    return 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double SpinFlipAbsorptionMix::opacitySca(double /*lambda*/, const MaterialState* /*state*/,
+                                          const PhotonPacket* /*pp*/) const
+{
+    return 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double SpinFlipAbsorptionMix::opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const
+{
+    return opacityAbs(lambda, state, pp);
+}
+
+////////////////////////////////////////////////////////////////////
+
+void SpinFlipAbsorptionMix::peeloffScattering(double& /*I*/, double& /*Q*/, double& /*U*/, double& /*V*/,
+                                               double& /*lambda*/, Direction /*bfkobs*/, Direction /*bfky*/,
+                                               const MaterialState* /*state*/, const PhotonPacket* /*pp*/) const
+{}
+
+////////////////////////////////////////////////////////////////////
+
+void SpinFlipAbsorptionMix::performScattering(double /*lambda*/, const MaterialState* /*state*/,
+                                               PhotonPacket* /*pp*/) const
+{}
+
+////////////////////////////////////////////////////////////////////
+
+
+
+double SpinFlipAbsorptionMix::indicativeTemperature(const MaterialState* state, const Array& /*Jv*/) const
+{
+    return state->temperature();
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SpinFlipAbsorptionMix.cpp
+++ b/SKIRT/core/SpinFlipAbsorptionMix.cpp
@@ -17,7 +17,8 @@ namespace
     // special wavelengths
     constexpr double lambdaSF = 21.10611405413e-2;  // 21 cm
 
-    // wavelength range outside of which we consider absorption to be zero (range of plus-min 9 dispersion elements using a velocity dispersion of 1000 km/s)
+    // wavelength range outside of which we consider absorption to be zero
+    // (range of plus-min 9 dispersion elements using a velocity dispersion of 1000 km/s)
     constexpr Range absorptionRange(0.2047, 0.2174);
 
     // Einstein coefficient of the 21cm spin-flip transition
@@ -25,11 +26,6 @@ namespace
 }
 
 ////////////////////////////////////////////////////////////////////
-
-void SpinFlipAbsorptionMix::setupSelfBefore()
-{
-    MaterialMix::setupSelfBefore();
-}
 
 MaterialMix::MaterialType SpinFlipAbsorptionMix::materialType() const
 {
@@ -43,19 +39,17 @@ bool SpinFlipAbsorptionMix::hasExtraSpecificState() const
     return true;
 }
 
-
 ////////////////////////////////////////////////////////////////////
 
 vector<StateVariable> SpinFlipAbsorptionMix::specificStateVariableInfo() const
 {
-    return vector<StateVariable>{StateVariable::numberDensity(),
-                                 StateVariable::temperature()};
+    return vector<StateVariable>{StateVariable::numberDensity(), StateVariable::temperature()};
 }
 
 ////////////////////////////////////////////////////////////////////
 
 void SpinFlipAbsorptionMix::initializeSpecificState(MaterialState* state, double /*metallicity*/, double temperature,
-                                          const Array& /*params*/) const
+                                                    const Array& /*params*/) const
 {
     // leave the properties at zero if the cell does not contain any material for this component
     if (state->numberDensity() > 0.)
@@ -65,7 +59,6 @@ void SpinFlipAbsorptionMix::initializeSpecificState(MaterialState* state, double
         state->setTemperature(max(Constants::Tcmb(), temperature >= 0. ? temperature : defaultTemperature()));
     }
 }
-
 
 ////////////////////////////////////////////////////////////////////
 
@@ -128,7 +121,7 @@ double SpinFlipAbsorptionMix::opacityAbs(double lambda, const MaterialState* sta
 ////////////////////////////////////////////////////////////////////
 
 double SpinFlipAbsorptionMix::opacitySca(double /*lambda*/, const MaterialState* /*state*/,
-                                          const PhotonPacket* /*pp*/) const
+                                         const PhotonPacket* /*pp*/) const
 {
     return 0.;
 }
@@ -143,19 +136,17 @@ double SpinFlipAbsorptionMix::opacityExt(double lambda, const MaterialState* sta
 ////////////////////////////////////////////////////////////////////
 
 void SpinFlipAbsorptionMix::peeloffScattering(double& /*I*/, double& /*Q*/, double& /*U*/, double& /*V*/,
-                                               double& /*lambda*/, Direction /*bfkobs*/, Direction /*bfky*/,
-                                               const MaterialState* /*state*/, const PhotonPacket* /*pp*/) const
+                                              double& /*lambda*/, Direction /*bfkobs*/, Direction /*bfky*/,
+                                              const MaterialState* /*state*/, const PhotonPacket* /*pp*/) const
 {}
 
 ////////////////////////////////////////////////////////////////////
 
 void SpinFlipAbsorptionMix::performScattering(double /*lambda*/, const MaterialState* /*state*/,
-                                               PhotonPacket* /*pp*/) const
+                                              PhotonPacket* /*pp*/) const
 {}
 
 ////////////////////////////////////////////////////////////////////
-
-
 
 double SpinFlipAbsorptionMix::indicativeTemperature(const MaterialState* state, const Array& /*Jv*/) const
 {

--- a/SKIRT/core/SpinFlipAbsorptionMix.hpp
+++ b/SKIRT/core/SpinFlipAbsorptionMix.hpp
@@ -3,35 +3,36 @@
 ////       © Astronomical Observatory, Ghent University         ////
 ///////////////////////////////////////////////////////////////// */
 
-#ifndef SPINFLIPHABSORPTIONMIX_HPP
-#define SPINFLIPHABSORPTIONMIX_HPP
+#ifndef SPINFLIPABSORPTIONMIX_HPP
+#define SPINFLIPABSORPTIONMIX_HPP
 
 #include "MaterialMix.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
 /** The SpinFlipAbsorptionMix class describes the material properties related to the 21 cm
-    spin-flip transition in neutral atomic hydrogen, including only absorption (i.e. omitting 
-    emission processes). The 21 cm opacity in a given cell are determined from gas properties defined 
-    in the input model (gas temperature).
+    spin-flip transition in neutral atomic hydrogen, including only absorption (i.e. omitting
+    emission processes). The 21 cm opacity in a given cell is determined from gas properties
+    defined in the input model (gas temperature).
 
     <b>Configuring the simulation</b>
 
-    Simulations of 21 cm the spin-flip transition usually include 21 cm emission (see SpinFlipSEDFamily
-    class) in addition to a medium component configured with the spin flip material mix (this class).
-    Hence, the simulation mode should be set to "ExtinctionOnly".    
+    Simulations of 21 cm the spin-flip transition usually include 21 cm emission (see
+    SpinFlipSEDFamily class) in addition to a medium component configured with the spin flip
+    material mix (this class). Hence, the simulation mode should be set to "ExtinctionOnly".
 
-    As the opacity of the 21 cm line depends on the gas temperature, this information will be read 
-    from an input file by associating the spin flip material mix with a subclass of ImportedMedium. 
-    For that medium component, the ski file attribute\em importTemperature <b>must</b> be set to 'true',
-    and \em importVariableMixParams must be left at 'false'. For example, if bulk velocities are also 
-    imported for this medium component (i.e. \em importVelocity is 'true'), the column order would be \f[ ...,
-    T, v_\mathrm{x}, v_\mathrm{y}, v_\mathrm{z}\f]
+    As the opacity of the 21 cm line depends on the gas temperature as well as the neutral atomic
+    hydrogen density \f$n_\mathrm{HI}\f$, this information is read from an input file by
+    associating the SpinFlipAbsorptionMix with a subclass of ImportedMedium. For that medium
+    component, the ski file attribute \em importTemperature <b>must</b> be set to 'true', and \em
+    importMetallicity and \em importVariableMixParams must be left at 'false'. For example, if bulk
+    velocities are also imported for this medium component (i.e. \em importVelocity is 'true'), the
+    column order would be \f[ ..., T, v_\mathrm{x}, v_\mathrm{y}, v_\mathrm{z} \f]
 
-    For basic testing purposes, the spin flip material mix can also be associated with a geometric
+    For basic testing purposes, the SpinFlipAbsorptionMix can also be associated with a geometric
     medium component. The geometry then defines the spatial density distribution (i.e.
-    \f$n_\mathrm{HI}\f$), and the spin flip material mix offers configuration properties to specify
-    fixed default values for the other properties that will be used across the spatial domain.
+    \f$n_\mathrm{HI}\f$), and this class offers a configuration property to specify a fixed default
+    temperature value that will be used across the spatial domain.
 
     <b>Absorption</b>
 
@@ -60,8 +61,7 @@
     */
 class SpinFlipAbsorptionMix : public MaterialMix
 {
-    ITEM_CONCRETE(SpinFlipAbsorptionMix, MaterialMix,
-                  "A gas mix supporting the spin-flip 21 cm hydrogen absorption")
+    ITEM_CONCRETE(SpinFlipAbsorptionMix, MaterialMix, "A gas mix supporting the spin-flip 21 cm hydrogen absorption")
 
         PROPERTY_DOUBLE(defaultTemperature, "the default temperature of the gas")
         ATTRIBUTE_QUANTITY(defaultTemperature, "temperature")
@@ -72,19 +72,13 @@ class SpinFlipAbsorptionMix : public MaterialMix
 
     ITEM_END()
 
-    //============= Construction - Setup - Destruction =============
-
-protected:
-    /** This function initializes the DipolePhaseFunction instance held by this class. */
-    void setupSelfBefore() override;
-
     //======== Capabilities =======
 
 public:
     /** This function returns the fundamental material type represented by this material mix, which
-        is MaterialType::Electrons. */
+        is MaterialType::Gas. */
     MaterialType materialType() const override;
-    
+
     /** This function returns true, indicating that the cross sections returned by this material
         mix depend on the values of specific state variables other than the number density. */
     bool hasExtraSpecificState() const override;
@@ -94,20 +88,16 @@ public:
 public:
     /** This function returns a list of StateVariable objects describing the specific state
         variables used by the receiving material mix. For this class, the function returns a list
-        containing descriptors for the properties defined in the input model (number density,
-        metallicity, temperature, and neutral hydrogen fraction) and for a variable to hold the
-        atomic hydrogen fraction derived from the radiation field when the dynamic medium state is
-        updated. */
+        containing descriptors for the properties defined in the input model, namely number density
+        and temperature. */
     vector<StateVariable> specificStateVariableInfo() const override;
 
     /** This function initializes the specific state variables requested by this material mix
         through the specificStateVariableInfo() function except for the number density. For this
-        class, the function initializes the temperature, metallicity and neutral hydrogen fraction
-        to the specified imported values, or if not available, to the user-configured default
-        values. The atomic hydrogen fraction is set to zero. */
-        void initializeSpecificState(MaterialState* state, double metallicity, double temperature,
+        class, the function initializes the temperature to the specified imported value, or if not
+        available, to the user-configured default value. */
+    void initializeSpecificState(MaterialState* state, double metallicity, double temperature,
                                  const Array& params) const override;
-
 
     //======== Low-level material properties =======
 

--- a/SKIRT/core/SpinFlipAbsorptionMix.hpp
+++ b/SKIRT/core/SpinFlipAbsorptionMix.hpp
@@ -1,0 +1,168 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef SPINFLIPHABSORPTIONMIX_HPP
+#define SPINFLIPHABSORPTIONMIX_HPP
+
+#include "MaterialMix.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** The SpinFlipAbsorptionMix class describes the material properties related to the 21 cm
+    spin-flip transition in neutral atomic hydrogen, including only absorption (i.e. omitting 
+    emission processes). The 21 cm opacity in a given cell are determined from gas properties defined 
+    in the input model (gas temperature).
+
+    <b>Configuring the simulation</b>
+
+    Simulations of 21 cm the spin-flip transition usually include 21 cm emission (see SpinFlipSEDFamily
+    class) in addition to a medium component configured with the spin flip material mix (this class).
+    Hence, the simulation mode should be set to "ExtinctionOnly".    
+
+    As the opacity of the 21 cm line depends on the gas temperature, this information will be read 
+    from an input file by associating the spin flip material mix with a subclass of ImportedMedium. 
+    For that medium component, the ski file attribute\em importTemperature <b>must</b> be set to 'true',
+    and \em importVariableMixParams must be left at 'false'. For example, if bulk velocities are also 
+    imported for this medium component (i.e. \em importVelocity is 'true'), the column order would be \f[ ...,
+    T, v_\mathrm{x}, v_\mathrm{y}, v_\mathrm{z}\f]
+
+    For basic testing purposes, the spin flip material mix can also be associated with a geometric
+    medium component. The geometry then defines the spatial density distribution (i.e.
+    \f$n_\mathrm{HI}\f$), and the spin flip material mix offers configuration properties to specify
+    fixed default values for the other properties that will be used across the spatial domain.
+
+    <b>Absorption</b>
+
+    Following Draine 2011 Chapter 8, and substituting wavelengths for frequencies, the
+    monochromatic absorption cross section per neutral hydrogen atom \f$\varsigma(\lambda)\f$ at
+    frequency \f$\lambda\f$ can be written as \f[\varsigma^\text{abs}(\lambda) =
+    \frac{3}{32\pi}\,A_\mathrm{SF}\,\frac{hc \,\lambda_\mathrm{SF}} {k_\mathrm{B}T_\mathrm{s}}
+    \times \frac{\lambda_\mathrm{SF}} {\sqrt{2\pi}\,\sigma} \,\exp\left(-\frac{u^2(\lambda)}
+    {2\sigma^2}\right) \f] where \f$T_\mathrm{s}\f$ is the spin temperature of the hydrogen gas
+    (see below), \f$\sigma=\sqrt{k_B T/m_\mathrm{p}}\f$ is the velocity dispersion corresponding to
+    the thermal motion of the atoms, and \f$u(\lambda)=c(\lambda-\lambda_\mathrm{SF})/\lambda\f$ is
+    the frequency deviation from the line center in velocity units.
+
+    According to Kim, Ostriker and Kim 2014 (ApJ 786:64), the spin temperature \f$T_\mathrm{s}\f$
+    is essentially equal to the kinetic gas temperature \f$T\f$ for low gas temperatures
+    \f$T<1000~\mathrm{K}\f$. For higher gas temperatures, it also depends on other gas properties,
+    with an upper bound that never exceeds a fixed maximum value, i.e. \f$T_\mathrm{s,upper}
+    \lesssim 5000~\mathrm{K}\f$ (see their Figure 2).
+
+    To avoid the need for defining additional gas properties in the input model, we here use an
+    approximate upper bound for the spin temperature given by \f[ T_\mathrm{s}= 6000~\mathrm{K}
+    \times \left( 1-\mathrm{e}^{-T/5000~\mathrm{K} } \right).\f] Because the absorption cross
+    section is inversely proportional to the spin temperature, this yields an approximate lower
+    bound for the cross section.
+
+    */
+class SpinFlipAbsorptionMix : public MaterialMix
+{
+    ITEM_CONCRETE(SpinFlipAbsorptionMix, MaterialMix,
+                  "A gas mix supporting the spin-flip 21 cm hydrogen absorption")
+
+        PROPERTY_DOUBLE(defaultTemperature, "the default temperature of the gas")
+        ATTRIBUTE_QUANTITY(defaultTemperature, "temperature")
+        ATTRIBUTE_MIN_VALUE(defaultTemperature, "[3")  // gas temperature must be above local Universe T_CMB
+        ATTRIBUTE_MAX_VALUE(defaultTemperature, "1e9]")
+        ATTRIBUTE_DEFAULT_VALUE(defaultTemperature, "1e4")
+        ATTRIBUTE_DISPLAYED_IF(defaultTemperature, "Level2")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function initializes the DipolePhaseFunction instance held by this class. */
+    void setupSelfBefore() override;
+
+    //======== Capabilities =======
+
+public:
+    /** This function returns the fundamental material type represented by this material mix, which
+        is MaterialType::Electrons. */
+    MaterialType materialType() const override;
+    
+    /** This function returns true, indicating that the cross sections returned by this material
+        mix depend on the values of specific state variables other than the number density. */
+    bool hasExtraSpecificState() const override;
+
+    //======== Medium state setup =======
+
+public:
+    /** This function returns a list of StateVariable objects describing the specific state
+        variables used by the receiving material mix. For this class, the function returns a list
+        containing descriptors for the properties defined in the input model (number density,
+        metallicity, temperature, and neutral hydrogen fraction) and for a variable to hold the
+        atomic hydrogen fraction derived from the radiation field when the dynamic medium state is
+        updated. */
+    vector<StateVariable> specificStateVariableInfo() const override;
+
+    /** This function initializes the specific state variables requested by this material mix
+        through the specificStateVariableInfo() function except for the number density. For this
+        class, the function initializes the temperature, metallicity and neutral hydrogen fraction
+        to the specified imported values, or if not available, to the user-configured default
+        values. The atomic hydrogen fraction is set to zero. */
+        void initializeSpecificState(MaterialState* state, double metallicity, double temperature,
+                                 const Array& params) const override;
+
+
+    //======== Low-level material properties =======
+
+public:
+    /** This function returns the mass of a neutral hydrogen atom. */
+    double mass() const override;
+
+    /** This function returns the 21 cm absorption cross section per neutral hydrogen atom at the
+        given wavelength and using the default gas properties configured for this material mix. */
+    double sectionAbs(double lambda) const override;
+
+    /** This function returns the 21 scattering cross section per neutral hydrogen atom, which is
+        trivially zero for all wavelengths. */
+    double sectionSca(double lambda) const override;
+
+    /** This function returns the total 21 cm extinction cross section per neutral hydrogen atom at
+        the given wavelength and using the default gas properties configured for this material mix.
+        The extinction cross section is identical to the absorption cross section because the
+        scattering cross section is zero. */
+    double sectionExt(double lambda) const override;
+
+    //======== High-level photon life cycle =======
+
+    /** This function returns the 21 cm absorption opacity \f$k^\text{abs}= n_mathrm{HI}
+        \varsigma^\text{abs}\f$ for the given wavelength and material state. The photon packet
+        properties are not used. */
+    double opacityAbs(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function returns the 21 cm scattering opacity \f$k^\text{sca}\f$ which is trivially
+        zero at all wavelengths. */
+    double opacitySca(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function returns the 21 cm extinction opacity \f$k^\text{ext}=k^\text{abs}\f$ for the
+        given wavelength and material state, which equals the absorption opacity because the
+        scattering opacity is zero. The photon packet properties are not used. */
+    double opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function does nothing because the 21 cm line does not scatter. */
+    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+                           const MaterialState* state, const PhotonPacket* pp) const override;
+
+    /** This function does nothing because the 21 cm line does not scatter. */
+    void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const override;
+
+    //======== Temperature =======
+
+    /** This function returns an indicative temperature of the material mix when it would be
+        embedded in a given radiation field. The implementation in this class ignores the radiation
+        field and returns the temperature stored in the specific state for the relevant spatial
+        cell and medium component. Because the hydrogen temperature is not calculated
+        self-consistently in our treatment, this value corresponds to the temperature defined by
+        the input model at the start of the simulation. */
+    double indicativeTemperature(const MaterialState* state, const Array& Jv) const override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SpinFlipSEDFamily.cpp
+++ b/SKIRT/core/SpinFlipSEDFamily.cpp
@@ -49,7 +49,7 @@ double SpinFlipSEDFamily::specificLuminosity(double wavelength, const Array& par
 ////////////////////////////////////////////////////////////////////
 
 double SpinFlipSEDFamily::cdf(Array& lambdav, Array& pv, Array& Pv, const Range& wavelengthRange,
-                                 const Array& parameters) const
+                              const Array& parameters) const
 {
     double L = parameters[0];
     double s = parameters[1];

--- a/SKIRT/core/SpinFlipSEDFamily.cpp
+++ b/SKIRT/core/SpinFlipSEDFamily.cpp
@@ -1,0 +1,72 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "SpinFlipSEDFamily.hpp"
+#include "Constants.hpp"
+#include "NR.hpp"
+
+//////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // number of wavelength points in tabulated result per dispersion unit
+    const int numWavelengthsPerDispersionUnit = 100;
+
+    // Gaussian centered on 0 with dispersion of 1, evaluated at x
+    double unitGaussian(double x) { return (0.5 * M_SQRT1_2 * M_2_SQRTPI) * exp(-0.5 * x * x); }
+
+    constexpr double lambdaSF = 21.10611405413e-2;  // 21 cm
+}
+
+////////////////////////////////////////////////////////////////////
+
+vector<SnapshotParameter> SpinFlipSEDFamily::parameterInfo() const
+{
+    return {SnapshotParameter::custom("line luminosity", "bolluminosity", "W"),
+            SnapshotParameter::custom("dispersion", "velocity", "km/s")};
+}
+
+////////////////////////////////////////////////////////////////////
+
+Range SpinFlipSEDFamily::intrinsicWavelengthRange() const
+{
+    return Range(0.2047, 0.2174);
+}
+
+////////////////////////////////////////////////////////////////////
+
+double SpinFlipSEDFamily::specificLuminosity(double wavelength, const Array& parameters) const
+{
+    double L = parameters[0];
+    double s = parameters[1];
+    double wavelengthCenter = lambdaSF;
+    double wavelengthDispersion = s * wavelengthCenter / Constants::c();
+    return L * unitGaussian((wavelength - wavelengthCenter) / wavelengthDispersion) / wavelengthDispersion;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double SpinFlipSEDFamily::cdf(Array& lambdav, Array& pv, Array& Pv, const Range& wavelengthRange,
+                                 const Array& parameters) const
+{
+    double L = parameters[0];
+    double s = parameters[1];
+    double wavelengthCenter = lambdaSF;
+    double wavelengthDispersion = s * wavelengthCenter / Constants::c();
+
+    // build an appropriate grid
+    size_t n = numWavelengthsPerDispersionUnit * wavelengthRange.width() / wavelengthDispersion;
+    NR::buildLinearGrid(lambdav, wavelengthRange.min(), wavelengthRange.max(), n);
+
+    // calculate the tabulated values
+    pv.resize(n + 1);
+    for (size_t i = 0; i <= n; ++i)
+        pv[i] = L * unitGaussian((lambdav[i] - wavelengthCenter) / wavelengthDispersion) / wavelengthDispersion;
+
+    // calculate the cumulative distribution and normalization
+    return NR::cdf2(false, lambdav, pv, Pv);
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SpinFlipSEDFamily.hpp
+++ b/SKIRT/core/SpinFlipSEDFamily.hpp
@@ -10,18 +10,18 @@
 
 //////////////////////////////////////////////////////////////////////
 
-/** An instance of the SpinFlipSEDFamily class represents a family of Gaussian spectra around
-    the central 21-cm spin-flip wavelength \f$\lambda_\mathrm{sf}\f$, reflecting the thermal sub-grid motion
-    in the source. The %SED family is parameterized on the bolometric 21-cm line luminosity
-    \f$L_\mathrm{sf}\f$ and the spectral dispersion \f$s\f$ in velocity units. Using the photon velocity
-    shift \f[ v = \frac{\lambda - \lambda_\mathrm{sf}} {\lambda_\mathrm{sf}} \,c \f] as the spectral
-    variable, the spectrum can be written as (see also the LyaGaussianSED class): \f[ L_v(v) =
-    \frac{L_\mathrm{sf}}{s\,\sqrt{2\pi}} \,\exp\left( -\frac{v^2}{2s^2} \right). \f]
+/** An instance of the SpinFlipSEDFamily class represents a family of Gaussian spectra around the
+    central 21-cm spin-flip wavelength \f$\lambda_\mathrm{sf}\f$, reflecting the thermal sub-grid
+    motion in the source. The %SED family is parameterized on the bolometric 21-cm line luminosity
+    \f$L_\mathrm{sf}\f$ and the spectral dispersion \f$s\f$ in velocity units. Using the photon
+    velocity shift \f[ v = \frac{\lambda - \lambda_\mathrm{sf}} {\lambda_\mathrm{sf}} \,c \f] as
+    the spectral variable, the spectrum can be written as (see also the LyaGaussianSED class): \f[
+    L_v(v) = \frac{L_\mathrm{sf}}{s\,\sqrt{2\pi}} \,\exp\left( -\frac{v^2}{2s^2} \right). \f]
 
     The intrinsic range for the complete %SED family is taken to be approximately \f$\pm 9s\f$
     around the center for a dispersion of \f$s=1000\,\mathrm{km/s}\f$. This results in a range of
-    \f$20.47 \text{\mathrm{cm}} \le \lambda \le 21.74 \text{\mathrm{cm}}\f$. The source wavelength range configured
-    by the user must fully contain this intrinsic wavelength range.
+    \f$20.47 \mathrm{cm} \le \lambda \le 21.74 \mathrm{cm}\f$. The source wavelength range
+    configured by the user must fully contain this intrinsic wavelength range.
 
     Whenever a tabular form of a Gaussian %SED is requested, this class uses 100 wavelength points
     per dispersion unit on a regular linear grid.
@@ -31,9 +31,7 @@
     header info): \f[ L_\mathrm{sf}\,(\mathrm{W}) \quad s\,(\mathrm{km/s}) \f] */
 class SpinFlipSEDFamily : public SEDFamily
 {
-    ITEM_CONCRETE(SpinFlipSEDFamily, SEDFamily,
-                  "a family of Gaussian spectra around the central spin-flip wavelength")
-
+    ITEM_CONCRETE(SpinFlipSEDFamily, SEDFamily, "a family of Gaussian spectra around the central spin-flip wavelength")
     ITEM_END()
 
     //====================== Other functions =====================

--- a/SKIRT/core/SpinFlipSEDFamily.hpp
+++ b/SKIRT/core/SpinFlipSEDFamily.hpp
@@ -1,0 +1,69 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef SPINFLIPSEDFAMILY_HPP
+#define SPINFLIPSEDFAMILY_HPP
+
+#include "SEDFamily.hpp"
+
+//////////////////////////////////////////////////////////////////////
+
+/** An instance of the SpinFlipSEDFamily class represents a family of Gaussian spectra around
+    the central 21-cm spin-flip wavelength \f$\lambda_\mathrm{sf}\f$, reflecting the thermal sub-grid motion
+    in the source. The %SED family is parameterized on the bolometric 21-cm line luminosity
+    \f$L_\mathrm{sf}\f$ and the spectral dispersion \f$s\f$ in velocity units. Using the photon velocity
+    shift \f[ v = \frac{\lambda - \lambda_\mathrm{sf}} {\lambda_\mathrm{sf}} \,c \f] as the spectral
+    variable, the spectrum can be written as (see also the LyaGaussianSED class): \f[ L_v(v) =
+    \frac{L_\mathrm{sf}}{s\,\sqrt{2\pi}} \,\exp\left( -\frac{v^2}{2s^2} \right). \f]
+
+    The intrinsic range for the complete %SED family is taken to be approximately \f$\pm 9s\f$
+    around the center for a dispersion of \f$s=1000\,\mathrm{km/s}\f$. This results in a range of
+    \f$20.47 \text{\mathrm{cm}} \le \lambda \le 21.74 \text{\mathrm{cm}}\f$. The source wavelength range configured
+    by the user must fully contain this intrinsic wavelength range.
+
+    Whenever a tabular form of a Gaussian %SED is requested, this class uses 100 wavelength points
+    per dispersion unit on a regular linear grid.
+
+    When imported from a text column file, the parameters for this %SED family must appear in the
+    following order in the specified default units (unless these units are overridden by column
+    header info): \f[ L_\mathrm{sf}\,(\mathrm{W}) \quad s\,(\mathrm{km/s}) \f] */
+class SpinFlipSEDFamily : public SEDFamily
+{
+    ITEM_CONCRETE(SpinFlipSEDFamily, SEDFamily,
+                  "a family of Gaussian spectra around the central spin-flip wavelength")
+
+    ITEM_END()
+
+    //====================== Other functions =====================
+
+public:
+    /** This function returns the number and type of parameters used by this particular %SED family
+        as a list of SnapshotParameter objects. Each of these objects specifies unit information
+        and a human-readable descripton for the parameter. */
+    vector<SnapshotParameter> parameterInfo() const override;
+
+    /** This function returns the intrinsic wavelength range of the %SED family. For the
+        SpinFlipSEDFamily, the intrinsic range is determined as decribed in the class header. */
+    Range intrinsicWavelengthRange() const override;
+
+    /** This function returns the specific luminosity \f$L_\lambda\f$ (i.e. radiative power per
+        unit of wavelength) for the %SED with the specified parameters at the specified wavelength,
+        or zero if the wavelength is outside of the %SED's intrinsic wavelength range. The number
+        and type of parameters must match the information returned by the parameterInfo() function;
+        if not the behavior is undefined. */
+    double specificLuminosity(double wavelength, const Array& parameters) const override;
+
+    /** This function constructs both the normalized probability density function (pdf) and the
+        corresponding normalized cumulative distribution function (cdf) for the %SED with the
+        specified parameters over the specified wavelength range. The function returns the
+        normalization factor. The number and type of parameters must match the information returned
+        by the parameterInfo() function; if not the behavior is undefined. */
+    double cdf(Array& lambdav, Array& pv, Array& Pv, const Range& wavelengthRange,
+               const Array& parameters) const override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif


### PR DESCRIPTION
**Description**
This update adds a new simulation flow for the 21-cm spin-flip transition, using the SKIRT ExtinctionOnly simulation mode: The emission of 21-cm photons happens as primary emission (SpinFlipSEDFamily based on LyaSEDFamily), and HI self-absorption happens in the medium (SpinFlipAbsorptionMix based on ElectronMix). 

**Motivation**
For a medium in which the atomic hydrogen distribution is known, the previous simulation flow which required hydrogen partitioning based on the UV radiation field is outdated. When the atomic hydrogen distribution is known a priori (i.e. before running SKIRT), then the ExtinctionOnly mode is appropriate.

**Tests**
For the configuration of a single emitting point source and a single absorbing SPH particle (offset to the point source), the SKIRT simulation reproduces analytical results. Various gas densities, temperatures, and kinematics were tested.
