### PR TITLE
Allow probing density and opacity for individual grain populations

### DIFF
--- a/SKIRT/core/DensityProbe.cpp
+++ b/SKIRT/core/DensityProbe.cpp
@@ -5,6 +5,7 @@
 
 #include "DensityProbe.hpp"
 #include "Configuration.hpp"
+#include "FragmentDustMixDecorator.hpp"
 #include "MediumSystem.hpp"
 #include "ProbeFormBridge.hpp"
 
@@ -62,6 +63,34 @@ void DensityProbe::probe()
                         bridge.writeQuantity(sh + "_n", sh + "_N", "numbervolumedensity", "numbersurfacedensity",
                                              "number density", "column density",
                                              [ms, h](int m) { return ms->numberDensity(m, h); });
+                    }
+                }
+                break;
+            }
+            case Aggregation::Fragment:
+            {
+                for (int h : ms->dustMediumIndices())
+                {
+                    auto mix = ms->mix(0, h)->find<FragmentDustMixDecorator>(false);
+                    if (mix)
+                    {
+                        int numPops = mix->numPopulations();
+                        for (int f = 0; f != numPops; ++f)
+                        {
+                            auto densityInCell = [ms, mix, h, f](int m) {
+                                return mix->populationMass(f)
+                                       * ms->callWithMaterialState(
+                                           [mix, f](const MaterialState* mst) {
+                                               return mix->populationNumberDensity(f, mst);
+                                           },
+                                           m, h);
+                            };
+
+                            string shf = std::to_string(h) + "_" + std::to_string(f);
+                            bridge.writeQuantity(shf + "_rho", shf + "_Sigma", "massvolumedensity",
+                                                 "masssurfacedensity", "mass density", "mass surface density",
+                                                 densityInCell);
+                        }
                     }
                 }
                 break;

--- a/SKIRT/core/DensityProbe.hpp
+++ b/SKIRT/core/DensityProbe.hpp
@@ -17,14 +17,23 @@
     density or number surface density (column density) depending on the material type.
 
     The user can select the aggregation level, i.e. whether to produce an output file per medium
-    component or per medium type (dust, electrons, gas). There is also an option to decide whether
-    the probe should be performed after setup or after the full simulation run. The latter option
-    is meaningful if the density of the media may change during the simulation. */
+    component or per medium type (dust, electrons, gas). If one or more medium components in the
+    simulation are equipped with a FragmentDustMixDecorator, the probe can provide the masss
+    density for each of the dust grain populations represented by the decorator. Depending on the
+    value of the \em fragmentSizeBins flag on the decorator, there are fragments for each of the
+    grain material types or even for each of the grain size bins defined by the underlying dust
+    mixture. The probed information is written in a separate file for each fragment, identified by
+    a zero-based fragment index in addition to the zero-based component index.
+
+    There is also an option to decide whether the probe should be performed after setup or after
+    the full simulation run. The latter option is meaningful if the density of the media may change
+    during the simulation. */
 class DensityProbe : public SpatialGridWhenFormProbe
 {
     /** The enumeration type indicating how to aggregate the output: per medium component or per
         medium type (dust, electrons, gas). */
-    ENUM_DEF(Aggregation, Component, Type)
+    ENUM_DEF(Aggregation, Fragment, Component, Type)
+        ENUM_VAL(Aggregation, Fragment, "per fragment (dust grain material type and/or size bin)")
         ENUM_VAL(Aggregation, Component, "per medium component")
         ENUM_VAL(Aggregation, Type, "per medium type (dust, electrons, gas)")
     ENUM_END()

--- a/SKIRT/core/DensityProbe.hpp
+++ b/SKIRT/core/DensityProbe.hpp
@@ -18,7 +18,7 @@
 
     The user can select the aggregation level, i.e. whether to produce an output file per medium
     component or per medium type (dust, electrons, gas). If one or more medium components in the
-    simulation are equipped with a FragmentDustMixDecorator, the probe can provide the masss
+    simulation are equipped with a FragmentDustMixDecorator, the probe can provide the mass
     density for each of the dust grain populations represented by the decorator. Depending on the
     value of the \em fragmentSizeBins flag on the decorator, there are fragments for each of the
     grain material types or even for each of the grain size bins defined by the underlying dust

--- a/SKIRT/core/FragmentDustMixDecorator.cpp
+++ b/SKIRT/core/FragmentDustMixDecorator.cpp
@@ -356,6 +356,13 @@ double FragmentDustMixDecorator::populationNumberDensity(int f, const MaterialSt
 
 ////////////////////////////////////////////////////////////////////
 
+double FragmentDustMixDecorator::populationOpacityExt(int f, double lambda, const MaterialState* state) const
+{
+    return WEIGHT(f) * _fragments[f]->opacityExt(lambda, state, nullptr);
+}
+
+////////////////////////////////////////////////////////////////////
+
 double FragmentDustMixDecorator::populationTemperature(int f, const Array& Jv) const
 {
     return _fragments[f]->indicativeTemperature(nullptr, Jv);  // material state is not used by dust mixes

--- a/SKIRT/core/FragmentDustMixDecorator.hpp
+++ b/SKIRT/core/FragmentDustMixDecorator.hpp
@@ -271,6 +271,11 @@ public:
         with index \f$f\f$, given the material state for a spatial cell. */
     double populationNumberDensity(int f, const MaterialState* state) const;
 
+    /** This function returns the extinction opacity of the dust population represented by the
+        fragment with index \f$f\f$ for the given wavelength and material state, taking into
+        account the fragment weights in the material state as described in the class header. */
+    double populationOpacityExt(int f, double lambda, const MaterialState* state) const;
+
     /** This function returns the equilibrium temperature of the dust population represented by the
         fragment with index \f$f\f$ when it would be embedded in a given radiation field. */
     double populationTemperature(int f, const Array& Jv) const;

--- a/SKIRT/core/OpacityProbe.hpp
+++ b/SKIRT/core/OpacityProbe.hpp
@@ -23,10 +23,18 @@
     ignored and the radiation is assumed to be unpolarized.
 
     The user can select the aggregation level, i.e. whether to produce an output file per medium
-    component, per medium type (dust, electrons, gas), or for the complete medium system. There is
-    also an option to decide whether the probe should be performed after setup or after the full
-    simulation run. The latter option is meaningful if the density and/or cross section of the
-    media may change during the simulation.
+    component, per medium type (dust, electrons, gas), or for the complete medium system. If one or
+    more medium components in the simulation are equipped with a FragmentDustMixDecorator, the
+    probe can provide information for each of the dust grain populations represented by the
+    decorator. Depending on the value of the \em fragmentSizeBins flag on the decorator, there are
+    fragments for each of the grain material types or even for each of the grain size bins defined
+    by the underlying dust mixture. The probed information is written in a separate file for each
+    fragment, identified by a zero-based fragment index in addition to the zero-based component
+    index.
+
+    There is also an option to decide whether the probe should be performed after setup or after
+    the full simulation run. The latter option is meaningful if the density and/or cross section of
+    the media may change during the simulation.
 
     This probe implements the MaterialWavelengthRangeInterface to indicate that
     wavelength-dependent material properties may be required for the configured wavelength. */
@@ -34,7 +42,8 @@ class OpacityProbe : public SpatialGridWhenFormProbe, public MaterialWavelengthR
 {
     /** The enumeration type indicating how to aggregate the output: per medium component, per
         medium type (dust, electrons, gas), or for the complete medium system. */
-    ENUM_DEF(Aggregation, Component, Type, System)
+    ENUM_DEF(Aggregation, Fragment, Component, Type, System)
+        ENUM_VAL(Aggregation, Fragment, "per fragment (dust grain material type and/or size bin)")
         ENUM_VAL(Aggregation, Component, "per medium component")
         ENUM_VAL(Aggregation, Type, "per medium type (dust, electrons, gas)")
         ENUM_VAL(Aggregation, System, "for the complete medium system")

--- a/SKIRT/core/TemperatureProbe.hpp
+++ b/SKIRT/core/TemperatureProbe.hpp
@@ -83,10 +83,10 @@ class TemperatureProbe : public SpatialGridWhenFormProbe
 {
     /** The enumeration type indicating how to aggregate the output: per medium component or per
         medium type (dust, electrons, gas). */
-    ENUM_DEF(Aggregation, Component, Type, Fragment)
+    ENUM_DEF(Aggregation, Fragment, Component, Type)
+        ENUM_VAL(Aggregation, Fragment, "per fragment (dust grain material type and/or size bin)")
         ENUM_VAL(Aggregation, Component, "per medium component")
         ENUM_VAL(Aggregation, Type, "per medium type (dust, electrons, gas)")
-        ENUM_VAL(Aggregation, Fragment, "per fragment (dust grain material type and/or size bin)")
     ENUM_END()
 
     ITEM_CONCRETE(TemperatureProbe, SpatialGridWhenFormProbe,


### PR DESCRIPTION
**Description**
In analogy with the feature recently added for temperature probing, this update adds `Fragment` aggregation to the `DensityProbe` and `OpacityProbe` classes. This allows producing information for the individual grain populations formed by the `FragmentDustMixDecorator` class.

**Motivation**
This feature is especially meaningful for evaluating the results of simulations that include dust destruction.
It was requested by user Niklas Moszczynski.

**Tests**
Two new functional tests were added.
