### PR TITLE
Update atomic/molecular partitioning scheme in SpinFlipHydrogenGasMix

### DIFF
--- a/SKIRT/core/SpinFlipAbsorptionMix.cpp
+++ b/SKIRT/core/SpinFlipAbsorptionMix.cpp
@@ -14,15 +14,11 @@
 
 namespace
 {
-    // special wavelengths
-    constexpr double lambdaSF = 21.10611405413e-2;  // 21 cm
+    // central wavelength
+    constexpr double lambdaSF = Constants::lambdaSpinFlip();
 
-    // wavelength range outside of which we consider absorption to be zero
-    // (range of plus-min 9 dispersion elements using a velocity dispersion of 1000 km/s)
-    constexpr Range absorptionRange(0.2047, 0.2174);
-
-    // Einstein coefficient of the 21cm spin-flip transition
-    constexpr double ASF = 2.8843e-15;
+    // wavelength range outside of which we consider absorption to be zero (range of plus-min 0.21 mm)
+    constexpr Range absorptionRange(lambdaSF * 0.999, lambdaSF * 1.001);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -74,8 +70,8 @@ namespace
     // returns the absorption cross section per neutral hydrogen atom for the given wavelength and gas temperature
     double crossSection(double lambda, double T)
     {
-        constexpr double front = 3. * M_SQRT2 * M_2_SQRTPI / M_PI / 128. * ASF * Constants::h() * Constants::c()
-                                 * lambdaSF * lambdaSF / Constants::k();
+        constexpr double front = 3. * M_SQRT2 * M_2_SQRTPI / M_PI / 128. * Constants::EinsteinASpinFlip()
+                                 * Constants::h() * Constants::c() * lambdaSF * lambdaSF / Constants::k();
         double Tspin = 6000. * (1 - exp(-0.0002 * T));
         double sigma = sqrt(Constants::k() / Constants::Mproton() * T);
         double u = Constants::c() * (lambda - lambdaSF) / lambda;

--- a/SKIRT/core/SpinFlipAbsorptionMix.cpp
+++ b/SKIRT/core/SpinFlipAbsorptionMix.cpp
@@ -17,8 +17,8 @@ namespace
     // central wavelength
     constexpr double lambdaSF = Constants::lambdaSpinFlip();
 
-    // wavelength range outside of which we consider absorption to be zero (range of plus-min 0.21 mm)
-    constexpr Range absorptionRange(lambdaSF * 0.999, lambdaSF * 1.001);
+    // wavelength range outside of which we consider absorption to be zero (approximately 20.47 - 21.74 cm)
+    constexpr Range absorptionRange(lambdaSF*(1. - 0.03), lambdaSF*(1. + 0.03));
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SpinFlipAbsorptionMix.hpp
+++ b/SKIRT/core/SpinFlipAbsorptionMix.hpp
@@ -17,7 +17,7 @@
 
     <b>Configuring the simulation</b>
 
-    Simulations of 21 cm the spin-flip transition usually include 21 cm emission (see
+    Simulations of 21 cm the spin-flip transition usually include 21 cm emission (see the
     SpinFlipSEDFamily class) in addition to a medium component configured with the spin flip
     material mix (this class). Hence, the simulation mode should be set to "ExtinctionOnly".
 

--- a/SKIRT/core/SpinFlipHydrogenGasMix.cpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.cpp
@@ -18,8 +18,8 @@ namespace
     constexpr double lambdaUV = 1000e-10;  // 1000 Angstrom
     constexpr double lambdaSF = Constants::lambdaSpinFlip();
 
-    // wavelength range outside of which we consider absorption to be zero (range of plus-min 0.21 mm)
-    constexpr Range absorptionRange(lambdaSF * 0.999, lambdaSF * 1.001);
+    // wavelength range outside of which we consider absorption to be zero (approximately 20.47 - 21.74 cm)
+    constexpr Range absorptionRange(lambdaSF*(1. - 0.03), lambdaSF*(1. + 0.03));
 
     // indices for custom state variables
     constexpr int NEUTRAL_SURFACE_DENSITY = 0;

--- a/SKIRT/core/SpinFlipHydrogenGasMix.cpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.cpp
@@ -25,7 +25,7 @@ namespace
     constexpr double ASF = 2.8843e-15;
 
     // indices for custom state variables
-    constexpr int NEUTRAL_FRACTION = 0;
+    constexpr int NEUTRAL_SURFACE_DENSITY = 0;
     constexpr int ATOMIC_FRACTION = 1;
 }
 
@@ -68,17 +68,17 @@ bool SpinFlipHydrogenGasMix::hasLineEmission() const
 
 vector<SnapshotParameter> SpinFlipHydrogenGasMix::parameterInfo() const
 {
-    return {SnapshotParameter::custom("neutral hydrogen fraction")};
+    return {SnapshotParameter::custom("neutral hydrogen mass surface density", "masssurfacedensity", "Msun/pc2")};
 }
 
 ////////////////////////////////////////////////////////////////////
 
 vector<StateVariable> SpinFlipHydrogenGasMix::specificStateVariableInfo() const
 {
-    return vector<StateVariable>{StateVariable::numberDensity(), StateVariable::metallicity(),
-                                 StateVariable::temperature(),
-                                 StateVariable::custom(NEUTRAL_FRACTION, "neutral hydrogen fraction", ""),
-                                 StateVariable::custom(ATOMIC_FRACTION, "atomic hydrogen fraction", "")};
+    return vector<StateVariable>{
+        StateVariable::numberDensity(), StateVariable::metallicity(), StateVariable::temperature(),
+        StateVariable::custom(NEUTRAL_SURFACE_DENSITY, "neutral hydrogen mass surface density", "masssurfacedensity"),
+        StateVariable::custom(ATOMIC_FRACTION, "atomic hydrogen fraction", "")};
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -93,7 +93,7 @@ void SpinFlipHydrogenGasMix::initializeSpecificState(MaterialState* state, doubl
         // make sure the temperature is at least the local universe CMB temperature
         state->setMetallicity(metallicity >= 0. ? metallicity : defaultMetallicity());
         state->setTemperature(max(Constants::Tcmb(), temperature >= 0. ? temperature : defaultTemperature()));
-        state->setCustom(NEUTRAL_FRACTION, params.size() ? params[0] : defaultNeutralFraction());
+        state->setCustom(NEUTRAL_SURFACE_DENSITY, params.size() ? params[1] : defaultNeutralSurfaceDensity());
         state->setCustom(ATOMIC_FRACTION, 0.);
     }
 }
@@ -105,11 +105,15 @@ UpdateStatus SpinFlipHydrogenGasMix::updateSpecificState(MaterialState* state, c
     if (_indexUV < 0) throw FATALERROR("State update should not be called if there is no radiation field");
     UpdateStatus status;
 
-    // if the cell has no hydrogen or the neutral fraction is zero, then leave the atomic fraction at zero
-    double nH = state->numberDensity();
-    double fHIpH2 = state->custom(NEUTRAL_FRACTION);
-    if (nH > 0. && fHIpH2 > 0.)
+    // if the cell has no neutral hydrogen, then leave the atomic fraction at zero
+    if (state->numberDensity() > 0.)
     {
+        // get the neutral hydrogen surface mass density
+        double SigmaHIpH2 = state->custom(NEUTRAL_SURFACE_DENSITY);
+
+        // get the dust-to-gas ratio (metallicity scaled to solar value)
+        double DMW = state->metallicity() / 0.0127;
+
         // get the radiation field
         // scaled to the reference Milky Way radiation field at 1000 Angstrom
         // converted from 1e6 photons/cm2/s/sr/eV to internal units W/m2/m/sr
@@ -117,23 +121,26 @@ UpdateStatus SpinFlipHydrogenGasMix::updateSpecificState(MaterialState* state, c
         constexpr double c = Constants::c();
         constexpr double Qel = Constants::Qelectron();
         constexpr double JMW = 1e6 * 1e4 * (h * c * h * c / (lambdaUV * lambdaUV * lambdaUV)) / Qel;
-        double U = Jv[_indexUV] / JMW;
+        double UMW = Jv[_indexUV] / JMW;
 
-        // get the metallicity scaled to the solar reference value
-        double D = state->metallicity() / 0.0127;
+        // get the length scale
+        double Lcell = cbrt(state->volume());
 
         // perform the partitioning scheme
-        double Dstar = 1.5e-3 * log(1. + pow(3 * U, 1.7));
-        double nstar = 25e6;
-        double alpha = 2.5 * U / (1. + 0.25 * U * U);
-        double s = 0.04 / (Dstar + D);
-        double g = (1. + alpha * s + s * s) / (1. + s);
-        double Lambda = log(1. + g * pow(D, 3. / 7.) * pow(U / 15., 4. / 7.));
-        double x = pow(Lambda, 3. / 7.) * log(D / Lambda * nH / nstar);
-        double fH2 = 1. / (1. + exp(-4. * x - 3. * x * x * x));
+        constexpr double pc100 = 100. * Constants::pc();
+        double S = Lcell / pc100;
+        double S5 = pow(S, 5);
+        double Dstar = 0.17 * (2. + S5) / (1. + S5);
+        double g = sqrt(DMW * DMW + Dstar * Dstar);
+        constexpr double front = 5e7 * Constants::Msun() / (1e6 * Constants::pc() * Constants::pc());
+        double root = sqrt(0.001 + 0.1 * UMW);
+        double Sigmac = front * root / (g * (1. + 1.69 * root));
+        double alpha = 0.5 + 1. / (1. + sqrt(UMW * DMW * DMW / 600.));
+        double Rmol = pow(SigmaHIpH2 / Sigmac, alpha);
+        double fmol = Rmol / (Rmol + 1.);
 
         // set the atomic fraction
-        state->setCustom(ATOMIC_FRACTION, max(0., fHIpH2 - fH2));
+        state->setCustom(ATOMIC_FRACTION, max(0., 1. - fmol));
         status.updateConverged();
     }
     return status;

--- a/SKIRT/core/SpinFlipHydrogenGasMix.cpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.cpp
@@ -90,7 +90,7 @@ void SpinFlipHydrogenGasMix::initializeSpecificState(MaterialState* state, doubl
         // make sure the temperature is at least the local universe CMB temperature
         state->setMetallicity(metallicity >= 0. ? metallicity : defaultMetallicity());
         state->setTemperature(max(Constants::Tcmb(), temperature >= 0. ? temperature : defaultTemperature()));
-        state->setCustom(NEUTRAL_SURFACE_DENSITY, params.size() ? params[1] : defaultNeutralSurfaceDensity());
+        state->setCustom(NEUTRAL_SURFACE_DENSITY, params.size() ? params[0] : defaultNeutralSurfaceDensity());
         state->setCustom(ATOMIC_FRACTION, 0.);
     }
 }

--- a/SKIRT/core/SpinFlipHydrogenGasMix.cpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.cpp
@@ -15,14 +15,11 @@
 namespace
 {
     // special wavelengths
-    constexpr double lambdaUV = 1000e-10;           // 1000 Angstrom
-    constexpr double lambdaSF = 21.10611405413e-2;  // 21 cm
+    constexpr double lambdaUV = 1000e-10;  // 1000 Angstrom
+    constexpr double lambdaSF = Constants::lambdaSpinFlip();
 
     // wavelength range outside of which we consider absorption to be zero (range of plus-min 0.21 mm)
     constexpr Range absorptionRange(lambdaSF * 0.999, lambdaSF * 1.001);
-
-    // Einstein coefficient of the 21cm spin-flip transition
-    constexpr double ASF = 2.8843e-15;
 
     // indices for custom state variables
     constexpr int NEUTRAL_SURFACE_DENSITY = 0;
@@ -160,8 +157,8 @@ namespace
     // returns the absorption cross section per neutral hydrogen atom for the given wavelength and gas temperature
     double crossSection(double lambda, double T)
     {
-        constexpr double front = 3. * M_SQRT2 * M_2_SQRTPI / M_PI / 128. * ASF * Constants::h() * Constants::c()
-                                 * lambdaSF * lambdaSF / Constants::k();
+        constexpr double front = 3. * M_SQRT2 * M_2_SQRTPI / M_PI / 128. * Constants::EinsteinASpinFlip()
+                                 * Constants::h() * Constants::c() * lambdaSF * lambdaSF / Constants::k();
         double Tspin = 6000. * (1 - exp(-0.0002 * T));
         double sigma = sqrt(Constants::k() / Constants::Mproton() * T);
         double u = Constants::c() * (lambda - lambdaSF) / lambda;
@@ -255,7 +252,7 @@ Array SpinFlipHydrogenGasMix::lineEmissionMasses() const
 Array SpinFlipHydrogenGasMix::lineEmissionSpectrum(const MaterialState* state, const Array& /*Jv*/) const
 {
     // calculate the 21 cm luminosity
-    constexpr double front = 0.75 * ASF * Constants::h() * Constants::c() / lambdaSF;
+    constexpr double front = 0.75 * Constants::EinsteinASpinFlip() * Constants::h() * Constants::c() / lambdaSF;
     double L = front * state->custom(ATOMIC_FRACTION) * state->numberDensity() * state->volume();
 
     // encapsulate the result in an array

--- a/SKIRT/core/SpinFlipSEDFamily.cpp
+++ b/SKIRT/core/SpinFlipSEDFamily.cpp
@@ -30,7 +30,8 @@ vector<SnapshotParameter> SpinFlipSEDFamily::parameterInfo() const
 
 Range SpinFlipSEDFamily::intrinsicWavelengthRange() const
 {
-    return Range(0.2047, 0.2174);
+    constexpr Range range(Constants::lambdaSpinFlip() * (1. - 0.03), Constants::lambdaSpinFlip() * (1. + 0.03));
+    return range;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SpinFlipSEDFamily.cpp
+++ b/SKIRT/core/SpinFlipSEDFamily.cpp
@@ -16,8 +16,6 @@ namespace
 
     // Gaussian centered on 0 with dispersion of 1, evaluated at x
     double unitGaussian(double x) { return (0.5 * M_SQRT1_2 * M_2_SQRTPI) * exp(-0.5 * x * x); }
-
-    constexpr double lambdaSF = 21.10611405413e-2;  // 21 cm
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -41,7 +39,7 @@ double SpinFlipSEDFamily::specificLuminosity(double wavelength, const Array& par
 {
     double L = parameters[0];
     double s = parameters[1];
-    double wavelengthCenter = lambdaSF;
+    double wavelengthCenter = Constants::lambdaSpinFlip();
     double wavelengthDispersion = s * wavelengthCenter / Constants::c();
     return L * unitGaussian((wavelength - wavelengthCenter) / wavelengthDispersion) / wavelengthDispersion;
 }
@@ -53,7 +51,7 @@ double SpinFlipSEDFamily::cdf(Array& lambdav, Array& pv, Array& Pv, const Range&
 {
     double L = parameters[0];
     double s = parameters[1];
-    double wavelengthCenter = lambdaSF;
+    double wavelengthCenter = Constants::lambdaSpinFlip();
     double wavelengthDispersion = s * wavelengthCenter / Constants::c();
 
     // build an appropriate grid

--- a/SKIRT/core/SpinFlipSEDFamily.hpp
+++ b/SKIRT/core/SpinFlipSEDFamily.hpp
@@ -20,8 +20,8 @@
 
     The intrinsic range for the complete %SED family is taken to be approximately \f$\pm 9s\f$
     around the center for a dispersion of \f$s=1000\,\mathrm{km/s}\f$. This results in a range of
-    \f$20.47 \mathrm{cm} \le \lambda \le 21.74 \mathrm{cm}\f$. The source wavelength range
-    configured by the user must fully contain this intrinsic wavelength range.
+    approximately \f$20.47 \mathrm{cm} \le \lambda \le 21.74 \mathrm{cm}\f$. The source wavelength
+    range configured by the user must fully contain this intrinsic wavelength range.
 
     Whenever a tabular form of a Gaussian %SED is requested, this class uses 100 wavelength points
     per dispersion unit on a regular linear grid.

--- a/SKIRT/utils/Constants.hpp
+++ b/SKIRT/utils/Constants.hpp
@@ -67,6 +67,12 @@ namespace Constants
     /** This function returns the Einstein A-coefficient of the Lyman-alpha transition. */
     constexpr double EinsteinALya() { return 6.25e8; }
 
+    /** This function returns the central wavelength of the hydrogen spinflip transition. */
+    constexpr double lambdaSpinFlip() { return 21.10611405413e-2; }
+
+    /** This function returns the Einstein A-coefficient of the hydrogen spinflip transition. */
+    constexpr double EinsteinASpinFlip() { return 2.8843e-15; }
+
     /** This function returns the Thomson cross section for an electron. */
     constexpr double sigmaThomson() { return 6.6524587158e-29; }
 


### PR DESCRIPTION
**Motivation and description**
The `SpinFlipHydrogenGasMix` class uses a hydrogen partitioning scheme to split neutral hydrogen (typically available from hydrodynamical cosmological simulations) into its atomic and molecular constituents. The current implementation (before this update) uses the _local_ (based on volumetric gas density) partitioning scheme of Gnedin & Kravtsov 2011, ApJ, 728, 88. However, this scheme produces HI column densities in excess of the typically observed threshold, which is probably related to the usage of volumetric densities. 

The default approach in the literature (e.g. Diemer et al., 2018, ApJS, 238, 33 and Gebek et al., 2023, MNRAS, 521, 5645) is to use column-density based partitioning schemes. To conform to this default approach which seems to yield more realistic results, this update changes the partitioning scheme implementation in `SpinFlipHydrogenGasMix` to the column-density based scheme of Gnedin & Draine 2014, ApJ, 795, 37.

See the `SpinFlipHydrogenGasMix` class header for a detailed description of the new scheme.

**Incompatible changes**
The new partitioning scheme causes the updated `SpinFlipHydrogenGasMix` class to be incompatible with the previous version. Running a ski file configuration including an "old" SpinFlipHydrogenGasMix instance will cause a fatal error. Both the ski file and the input file being imported for the gas mix must be updated manually. Because the input file changes as well, it is not possible to provide an automated update procedure.

Important changes include:
 - The first column of the input file after the cell/particle coordinates now describes the distribution of **neutral** hydrogen (as opposed to the sum of neutral and ionized hydrogen).
 - The last column of the input file now specifies the neutral hydrogen **surface mass density**, a quantity required by the new column-density-based scheme (replacing the neutral fraction in the previous scheme).
 - Accordingly, the _defaultNeutralSurfaceDensity_ option replaces the previous  _defaultNeutralFraction_ option in the ski file.

**Tests**
The functional tests had to be updated manually for the incompatible changes listed above.

**Context**
This new partitioning scheme was requested and first implemented by @andreagebek.
