### PR TITLE
Add probe for dust luminosity spectrum (with probe form)

### DIFF
--- a/SKIRT/core/ProbeFormBridge.cpp
+++ b/SKIRT/core/ProbeFormBridge.cpp
@@ -109,6 +109,8 @@ void ProbeFormBridge::writeQuantity(string fileid, string quantity, string descr
     _form->writeQuantity(this);
 }
 
+////////////////////////////////////////////////////////////////////
+
 void ProbeFormBridge::writeQuantity(string fileid, string projectedFileid, string quantity, string projectedQuantity,
                                     string description, string projectedDescription, const Array& axis, string axisUnit,
                                     AddColumnDefinitions addColumnDefinitions, CompoundValueInCell valueInCell)
@@ -121,6 +123,33 @@ void ProbeFormBridge::writeQuantity(string fileid, string projectedFileid, strin
     _projectedUnit = _units->unit(projectedQuantity);
     _unitFactor = _units->out(quantity, 1.);
     _projectedUnitFactor = _units->out(projectedQuantity, 1.);
+    _description = description;
+    _projectedDescription = projectedDescription;
+    _axis = axis;
+    _axisUnit = axisUnit;
+    _numValues = axis.size();
+
+    _addColumnDefinitions = addColumnDefinitions;
+    _compoundValueInCell = valueInCell;
+
+    _form->writeQuantity(this);
+}
+
+////////////////////////////////////////////////////////////////////
+
+void ProbeFormBridge::writeQuantity(string fileid, string projectedFileid, string unit, string projectedUnit,
+                                    double projectedUnitFactor, string description, string projectedDescription,
+                                    const Array& axis, string axisUnit, AddColumnDefinitions addColumnDefinitions,
+                                    CompoundValueInCell valueInCell)
+{
+    _type = Type::GridCompoundAccumulated;
+
+    _fileid = fileid;
+    _projectedFileid = projectedFileid;
+    _unit = unit;
+    _projectedUnit = projectedUnit;
+    _unitFactor = 1.;
+    _projectedUnitFactor = projectedUnitFactor;
     _description = description;
     _projectedDescription = projectedDescription;
     _axis = axis;

--- a/SKIRT/core/ProbeFormBridge.hpp
+++ b/SKIRT/core/ProbeFormBridge.hpp
@@ -106,6 +106,9 @@ class Units;
     does not perform any unit conversions and the probe is expected to provide values in output
     units.
 
+    - \em projectedUnitFactor: an additional conversion factor from straight to projected
+    quantities, to be provided only in cases where this factor cannot be automatically determined.
+
     - \em description, \em projectedDescription: the user-oriented descriptions corresponding to
     the straight and projected quantities. These strings may differ even if the quantity names or
     unit strings are the same, for example, to indicate the weighting mechanism.
@@ -171,9 +174,9 @@ public:
     using VectorValueInCell = std::function<Vec(int m)>;
 
     /** This is the type declaration for the callback function provided by the spatial grid probe
-        to retrieve the compound value (in output units) of the quantity being probed in the
-        spatial cell with index \f$m\f$. The returned array must have the same number of elements
-        as the \em axis array passed to the writeQuantity() function. */
+        to retrieve the compound value (in internal or output units) of the quantity being probed
+        in the spatial cell with index \f$m\f$. The returned array must have the same number of
+        elements as the \em axis array passed to the writeQuantity() function. */
     using CompoundValueInCell = std::function<Array(int m)>;
 
     /** This is the type declaration for the callback function provided by the spatial grid probe
@@ -259,6 +262,14 @@ public:
     void writeQuantity(string fileid, string projectedFileid, string quantity, string projectedQuantity,
                        string description, string projectedDescription, const Array& axis, string axisUnit,
                        AddColumnDefinitions addColumnDefinitions, CompoundValueInCell valueInCell);
+
+    /** This function causes the form associated with this bridge to output a file for a compound
+        quantity that needs to be accumulated along a path according to the provided information.
+        It should be called only from spatial grid probes. Refer to the class header for more
+        information on the arguments. */
+    void writeQuantity(string fileid, string projectedFileid, string unit, string projectedUnit,
+                       double projectedUnitFactor, string description, string projectedDescription, const Array& axis,
+                       string axisUnit, AddColumnDefinitions addColumnDefinitions, CompoundValueInCell valueInCell);
 
     /** This function causes the form associated with this bridge to output a file for a compound
         quantity that needs to be averaged along a path according to the provided information. It

--- a/SKIRT/core/SecondaryDustLuminosityProbe.cpp
+++ b/SKIRT/core/SecondaryDustLuminosityProbe.cpp
@@ -1,0 +1,110 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "SecondaryDustLuminosityProbe.hpp"
+#include "Configuration.hpp"
+#include "DisjointWavelengthGrid.hpp"
+#include "Indices.hpp"
+#include "MediumSystem.hpp"
+#include "ProbeFormBridge.hpp"
+#include "SpecialFunctions.hpp"
+#include "StringUtils.hpp"
+#include "TextOutFile.hpp"
+#include "Units.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+Probe::When SecondaryDustLuminosityProbe::when() const
+{
+    switch (probeAfter())
+    {
+        case ProbeAfter::Run: return When::Run;
+        case ProbeAfter::Secondary: return When::Secondary;
+    }
+    return When::Run;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void SecondaryDustLuminosityProbe::probe()
+{
+    // locate the configuration and medium system; abort if there is no output for this probe
+    auto config = find<Configuration>();
+    if (!config->hasDustEmission()) return;
+    auto ms = find<MediumSystem>();
+    if (!ms->hasDust()) return;
+
+    // get the units system and dust emission wavelength grid
+    auto units = find<Units>();
+    auto wlg = config->dustEmissionWLG();
+
+    // construct lists of wavelength information in **output order**
+    Array axis(wlg->numBins());  // representative wavelengths in output units
+    Array cvol(wlg->numBins());  // conversion factors for luminosity volume density
+    Array csrf(wlg->numBins());  // conversion factors for luminosity surface density (i.e. surface brightness)
+    int outell = 0;
+    for (int ell : Indices(wlg->numBins(), units->rwavelength()))
+    {
+        axis[outell] = units->owavelength(wlg->wavelength(ell));
+        cvol[outell] = units->omonluminosityvolumedensity(wlg->wavelength(ell), 1.);
+        csrf[outell] = units->osurfacebrightness(wlg->wavelength(ell), 1.) * (0.25 / M_PI);
+        outell++;
+    }
+
+    // define the call-back function to add column definitions
+    auto addColumnDefinitions = [axis, units](TextOutFile& outfile) {
+        for (double outwave : axis)
+        {
+            // we assume that text files always contain values at a given position;
+            // this will be incorrect if a new form would list projected quantities
+            outfile.addColumn(units->smonluminosityvolumedensity() + " at " + units->swavelength() + " = "
+                                  + StringUtils::toString(outwave, 'g') + " " + units->uwavelength(),
+                              units->umonluminosityvolumedensity());
+        }
+    };
+
+    // get the extended dust emission wavelength grid including outer borders
+    Array ewlg = wlg->extlambdav();
+
+    // define the call-back function to retrieve a luminosity volume density spectrum in output ordering
+    auto valueInCell = [ms, units, &ewlg, &cvol](int m) {
+        // get the emmissivity spectrum for all dust in the cell with arbitrary normalization
+        const Array& ev = ms->dustEmissionSpectrum(m);
+
+        // calculate the normalization factor, assuming logarithmic interpolation (see NR::cdf2(...))
+        double norm = 0.;
+        size_t n = ewlg.size() - 1;
+        for (size_t i = 0; i != n; ++i)
+        {
+            if (ev[i] > 0 && ev[i + 1] > 0)
+            {
+                double alpha = log(ev[i + 1] / ev[i]) / log(ewlg[i + 1] / ewlg[i]);
+                norm += ev[i] * ewlg[i] * SpecialFunctions::gln(-alpha, ewlg[i + 1] / ewlg[i]);
+            }
+        }
+
+        // determine the total dust luminosity volume density in the cell, adjusted with the normalization factor
+        double front = norm > 0. ? ms->dustLuminosity(m) / ms->grid()->volume(m) / norm : 0.;
+
+        // copy and renormalize the values in output order and units, omitting the outer borders
+        int numBins = ewlg.size() - 2;
+        Array Lv(numBins);
+        int outell = 0;
+        for (int ell : Indices(numBins, units->rwavelength()))
+        {
+            Lv[outell] = cvol[outell] * front * ev[ell + 1];  // skip left outer border
+            outell++;
+        }
+        return Lv;
+    };
+
+    // construct a bridge and tell it to output the luminosity
+    ProbeFormBridge bridge(this, form());
+    bridge.writeQuantity("dust_L", "dust_S", units->umonluminosityvolumedensity(), units->usurfacebrightness(),
+                         csrf[0] / cvol[0], "luminosity density", "surface brightness", axis, units->uwavelength(),
+                         addColumnDefinitions, valueInCell);
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SecondaryDustLuminosityProbe.hpp
+++ b/SKIRT/core/SecondaryDustLuminosityProbe.hpp
@@ -15,14 +15,14 @@
     configured for the simulation. It produces output only if the simulation has at least one dust
     medium component and includes dust emission.
 
-    When associated with a form that samples the luminosity at a set of positions, such as for a
-    linear or planar cut, the probe outputs a monochromatic luminosity volume density (with SI
-    units of W/m/m3 for the per-wavelength flavor). When associated with a form that projects the
-    luminosity along a path, the probe outputs a monochromatic luminosity surface density divided
-    by the area of the unit sphere (with resulting SI units of W/m/m2/sr for the per-wavelength
-    flavor). In case of parallel projection towards a distant observer, this quantity is equivalent
-    to surface brightness. In other words, this probe can be used to produce transparent noise-free
-    images of the dust emission. */
+    When associated with a form that samples the luminosity per spatial cell or at a set of
+    positions, such as for a linear or planar cut, the probe outputs a monochromatic luminosity
+    volume density (with SI units of W/m/m3 for the per-wavelength flavor). When associated with a
+    form that projects the luminosity along a path, the probe outputs a monochromatic luminosity
+    surface density divided by the area of the unit sphere (with resulting SI units of W/m/m2/sr
+    for the per-wavelength flavor). In case of parallel projection towards a distant observer, this
+    quantity is equivalent to surface brightness. In other words, this probe can be used to produce
+    transparent noise-free images of the dust emission. */
 class SecondaryDustLuminosityProbe : public SpatialGridFormProbe
 {
     /** The enumeration type indicating when probing occurs. */
@@ -33,7 +33,7 @@ class SecondaryDustLuminosityProbe : public SpatialGridFormProbe
 
     ITEM_CONCRETE(SecondaryDustLuminosityProbe, SpatialGridFormProbe,
                   "internal spatial grid: secondary dust luminosity")
-        ATTRIBUTE_TYPE_DISPLAYED_IF(SecondaryDustLuminosityProbe, "DustMix,DustEmission")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(SecondaryDustLuminosityProbe, "DustMix&DustEmission")
 
         PROPERTY_ENUM(probeAfter, ProbeAfter, "perform the probe after")
         ATTRIBUTE_DEFAULT_VALUE(probeAfter, "Run")

--- a/SKIRT/core/SecondaryDustLuminosityProbe.hpp
+++ b/SKIRT/core/SecondaryDustLuminosityProbe.hpp
@@ -1,0 +1,60 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef SECONDARYDUSTLUMINOSITYPROBE_HPP
+#define SECONDARYDUSTLUMINOSITYPROBE_HPP
+
+#include "SpatialGridFormProbe.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** SecondaryDustLuminosityProbe probes the specific luminosity aggregated over all dust medium
+    components in the simulation at the wavelengths specified by the dust emission wavelength grid
+    configured for the simulation. It produces output only if the simulation has at least one dust
+    medium component and includes dust emission.
+
+    When associated with a form that samples the luminosity at a set of positions, such as for a
+    linear or planar cut, the probe outputs a monochromatic luminosity volume density (with SI
+    units of W/m/m3 for the per-wavelength flavor). When associated with a form that projects the
+    luminosity along a path, the probe outputs a monochromatic luminosity surface density divided
+    by the area of the unit sphere (with resulting SI units of W/m/m2/sr for the per-wavelength
+    flavor). In case of parallel projection towards a distant observer, this quantity is equivalent
+    to surface brightness. In other words, this probe can be used to produce transparent noise-free
+    images of the dust emission. */
+class SecondaryDustLuminosityProbe : public SpatialGridFormProbe
+{
+    /** The enumeration type indicating when probing occurs. */
+    ENUM_DEF(ProbeAfter, Run, Secondary)
+        ENUM_VAL(ProbeAfter, Run, "after the complete simulation run")
+        ENUM_VAL(ProbeAfter, Secondary, "after each iteration over secondary emission")
+    ENUM_END()
+
+    ITEM_CONCRETE(SecondaryDustLuminosityProbe, SpatialGridFormProbe,
+                  "internal spatial grid: secondary dust luminosity")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(SecondaryDustLuminosityProbe, "DustMix,DustEmission")
+
+        PROPERTY_ENUM(probeAfter, ProbeAfter, "perform the probe after")
+        ATTRIBUTE_DEFAULT_VALUE(probeAfter, "Run")
+        ATTRIBUTE_DISPLAYED_IF(probeAfter, "IterateSecondary")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function returns an enumeration indicating when probing for this probe should be
+        performed corresponding to the configured value of the \em probeAfter property. */
+    When when() const override;
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function performs probing. */
+    void probe() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -218,6 +218,7 @@
 #include "SEDInstrument.hpp"
 #include "SIUnits.hpp"
 #include "ScaledGaussianSmoothingKernel.hpp"
+#include "SecondaryDustLuminosityProbe.hpp"
 #include "SecondaryLineLuminosityProbe.hpp"
 #include "SelectDustMixFamily.hpp"
 #include "SersicGeometry.hpp"
@@ -689,6 +690,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<MagneticFieldProbe>();
     ItemRegistry::add<CustomStateProbe>();
     ItemRegistry::add<RadiationFieldProbe>();
+    ItemRegistry::add<SecondaryDustLuminosityProbe>();
     ItemRegistry::add<SecondaryLineLuminosityProbe>();
     //   .. properties
     ItemRegistry::add<SpatialCellPropertiesProbe>();


### PR DESCRIPTION
**Description**
The new `SecondaryDustLuminosityProbe` class allows probing the secondary dust luminosity as a function of wavelength, in combination with any of the available probe forms. For example, one can obtain the dust luminosity spectrum for each cell in the simulation's spatial grid, or construct noise-free images of the transparent dust surface brightness (i.e. ignoring the effects of scattering or absorption on the secondary radiation).

**Motivation**
This probe was suggested by user Niklas Moszczynski.

**Tests**
A functional test was added.
