### PR TITLE
Add FilePolarizedPointSource, using user-tabulated emission properties

### DIFF
--- a/SKIRT/core/AllSkyInstrument.cpp
+++ b/SKIRT/core/AllSkyInstrument.cpp
@@ -100,7 +100,7 @@ Direction AllSkyInstrument::bfkobs(const Position& bfr) const
     if (d <= _radius) return Direction();
 
     // otherwise return a unit vector in the direction from launch to observer
-    return Direction(k / d);
+    return Direction(k / d, false);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -117,10 +117,9 @@ Direction AllSkyInstrument::bfky(const Position& bfr) const
     // vector in the plane normal to the line launch-observer
     // oriented along the projection of the up direction in that plane
     Vec ku(_Ux, _Uy, _Uz);
-    Vec ky = Vec::cross(k, Vec::cross(ku, k));
 
     // return unit vector along y-axis
-    return Direction(ky / ky.norm());
+    return Direction(Vec::cross(k, Vec::cross(ku, k)), true);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/AllSkyProjectionForm.cpp
+++ b/SKIRT/core/AllSkyProjectionForm.cpp
@@ -100,7 +100,7 @@ void AllSkyProjectionForm::writeQuantity(const ProbeFormBridge* bridge) const
                 if (inrange)
                 {
                     // transform the direction from observer to model coordinates
-                    Direction kz = Direction(transform.transform(Direction(theta, phi)));
+                    Direction kz(transform.transform(Direction(theta, phi)), false);
 
                     // get the projected quantity values
                     bridge->valuesAlongPath(Position(_Ox, _Oy, _Oz), kz, values);
@@ -110,10 +110,8 @@ void AllSkyProjectionForm::writeQuantity(const ProbeFormBridge* bridge) const
                     {
                         // obtain the x and y axis directions in model coordinates
                         Vec ku(_Ux, _Uy, _Uz);
-                        Vec kx = Vec::cross(ku, kz);
-                        Vec ky = Vec::cross(kz, kx);
-                        kx = kx / kx.norm();
-                        ky = ky / ky.norm();
+                        Direction kx(Vec::cross(ku, kz), true);
+                        Direction ky(Vec::cross(kz, kx), true);
 
                         // project the vector on each of the axes
                         Vec v(values[0], values[1], values[2]);

--- a/SKIRT/core/AxAngularDistribution.cpp
+++ b/SKIRT/core/AxAngularDistribution.cpp
@@ -13,9 +13,8 @@ void AxAngularDistribution::setupSelfBefore()
 {
     AngularDistribution::setupSelfBefore();
 
-    Vec sym(symmetryX(), symmetryY(), symmetryZ());
-    if (sym.norm() == 0) throw FATALERROR("Symmetry axis direction cannot be null vector");
-    _sym = Direction(sym / sym.norm());
+    _sym.set(symmetryX(), symmetryY(), symmetryZ(), true);
+    if (_sym.isNull()) throw FATALERROR("Symmetry axis direction cannot be null vector");
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/BroadBand.cpp
+++ b/SKIRT/core/BroadBand.cpp
@@ -37,14 +37,14 @@ void BroadBand::setupSelfBefore()
 
 size_t BroadBand::dataSize() const
 {
-    return _table.size();
+    return _table.axisSize<0>();
 }
 
 ////////////////////////////////////////////////////////////////////
 
 const double* BroadBand::wavelengthData() const
 {
-    return _table.axisData();
+    return _table.axisData<0>();
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ComptonPhaseFunction.cpp
+++ b/SKIRT/core/ComptonPhaseFunction.cpp
@@ -259,10 +259,8 @@ Direction ComptonPhaseFunction::performScattering(double& lambda, Direction bfk,
         applyMueller(x, costheta, sv);
 
         // rotate the propagation direction in the scattering plane
-        Vec newdir = bfk * costheta + Vec::cross(sv->normal(), bfk) * sin(acos(costheta));
-
-        // normalize the new direction to prevent degradation
-        return Direction(newdir / newdir.norm());
+        // (re)normalize the new direction to prevent degradation
+        return Direction(bfk * costheta + Vec::cross(sv->normal(), bfk) * sin(acos(costheta)), true);
     }
 }
 

--- a/SKIRT/core/ConvergenceInfoProbe.cpp
+++ b/SKIRT/core/ConvergenceInfoProbe.cpp
@@ -25,7 +25,7 @@ namespace
         double eps = 1e-12 * ms->grid()->boundingBox().widths().norm();
         SpatialGridPath path(Position(eps, eps, eps), axis);
         double tau = ms->getExtinctionOpticalDepth(&path, lambda, type);
-        path.setDirection(Direction(-axis.x(), -axis.y(), -axis.z()));
+        path.setDirection(-axis);
         tau += ms->getExtinctionOpticalDepth(&path, lambda, type);
         return tau;
     }
@@ -84,9 +84,9 @@ namespace
         }
 
         // calculate the gridded optical depth along each of the coordinate axes
-        double tau_X_g = griddedOpticalDepth(ms, lambda, type, Direction(1., 0., 0.));
-        double tau_Y_g = griddedOpticalDepth(ms, lambda, type, Direction(0., 1., 0.));
-        double tau_Z_g = griddedOpticalDepth(ms, lambda, type, Direction(0., 0., 1.));
+        double tau_X_g = griddedOpticalDepth(ms, lambda, type, Direction(1., 0., 0., false));
+        double tau_Y_g = griddedOpticalDepth(ms, lambda, type, Direction(0., 1., 0., false));
+        double tau_Z_g = griddedOpticalDepth(ms, lambda, type, Direction(0., 0., 1., false));
 
         // output the optical depth along each of the coordinate axes
         out.writeLine("");

--- a/SKIRT/core/CubicalBackgroundSource.cpp
+++ b/SKIRT/core/CubicalBackgroundSource.cpp
@@ -24,12 +24,12 @@ namespace
     Direction generateLaunchWall(Random* random)
     {
         double X = random->uniform();
-        if (X < 1. / 6.) return Direction(-1., 0., 0.);
-        if (X < 2. / 6.) return Direction(1., 0., 0.);
-        if (X < 3. / 6.) return Direction(0., -1., 0.);
-        if (X < 4. / 6.) return Direction(0., 1., 0.);
-        if (X < 5. / 6.) return Direction(0., 0., -1.);
-        return Direction(0., 0., 1.);
+        if (X < 1. / 6.) return Direction(-1., 0., 0., false);
+        if (X < 2. / 6.) return Direction(1., 0., 0., false);
+        if (X < 3. / 6.) return Direction(0., -1., 0., false);
+        if (X < 4. / 6.) return Direction(0., 1., 0., false);
+        if (X < 5. / 6.) return Direction(0., 0., -1., false);
+        return Direction(0., 0., 1., false);
     }
 
     // this function generates a random launch position on the wall specified by its outward normal
@@ -54,12 +54,12 @@ namespace
         bfkp.cartesian(kpx, kpy, kpz);
 
         // conversion to the regular coordinate system
-        if (bfu.x() == -1.) return Direction(-kpz, -kpy, -kpx);
-        if (bfu.x() == 1.) return Direction(kpz, kpy, -kpx);
-        if (bfu.y() == -1.) return Direction(kpy, -kpz, -kpx);
-        if (bfu.y() == 1.) return Direction(-kpy, kpz, -kpx);
-        if (bfu.z() == -1.) return Direction(-kpx, kpy, -kpz);
-        return Direction(kpx, kpy, kpz);
+        if (bfu.x() == -1.) return Direction(-kpz, -kpy, -kpx, false);
+        if (bfu.x() == 1.) return Direction(kpz, kpy, -kpx, false);
+        if (bfu.y() == -1.) return Direction(kpy, -kpz, -kpx, false);
+        if (bfu.y() == 1.) return Direction(-kpy, kpz, -kpx, false);
+        if (bfu.z() == -1.) return Direction(-kpx, kpy, -kpz, false);
+        return Direction(kpx, kpy, kpz, false);
     }
 
     // this function returns the normalized probability of launching in a certain direction

--- a/SKIRT/core/DipolePhaseFunction.cpp
+++ b/SKIRT/core/DipolePhaseFunction.cpp
@@ -184,10 +184,8 @@ Direction DipolePhaseFunction::performScattering(Direction bfk, StokesVector* sv
         applyMueller(theta, sv);
 
         // rotate the propagation direction in the scattering plane
-        Vec newdir = bfk * cos(theta) + Vec::cross(sv->normal(), bfk) * sin(theta);
-
-        // normalize the new direction to prevent degradation
-        return Direction(newdir / newdir.norm());
+        // (re)normalize the new direction to prevent degradation
+        return Direction(bfk * cos(theta) + Vec::cross(sv->normal(), bfk) * sin(theta), true);
     }
 }
 

--- a/SKIRT/core/DistantInstrument.cpp
+++ b/SKIRT/core/DistantInstrument.cpp
@@ -44,7 +44,7 @@ void DistantInstrument::setupSelfBefore()
     // calculate relevant directions
     _bfkobs = Direction(_inclination, _azimuth);
     _bfky = Direction(-cosphi * costheta * cosomega - sinphi * sinomega,
-                      -sinphi * costheta * cosomega + cosphi * sinomega, +sintheta * cosomega);
+                      -sinphi * costheta * cosomega + cosphi * sinomega, +sintheta * cosomega, false);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/DustMix.cpp
+++ b/SKIRT/core/DustMix.cpp
@@ -531,10 +531,9 @@ void DustMix::performScattering(double lambda, const MaterialState* state, Photo
             applyMueller(lambda, theta, pp);
 
             // rotate the propagation direction in the scattering plane
-            Vec newdir = pp->direction() * cos(theta) + Vec::cross(pp->normal(), pp->direction()) * sin(theta);
-
-            // normalize the new direction to prevent degradation
-            bfknew = Direction(newdir / newdir.norm());
+            // (re)normalize the new direction to prevent degradation
+            bfknew =
+                Direction(pp->direction() * cos(theta) + Vec::cross(pp->normal(), pp->direction()) * sin(theta), true);
             break;
         }
     }

--- a/SKIRT/core/DustSecondarySource.cpp
+++ b/SKIRT/core/DustSecondarySource.cpp
@@ -341,8 +341,8 @@ namespace
         vector<int> _hv;             // a list of the media indices for the media containing dust
 
         // information on a particular spatial cell, initialized by calculateIfNeeded()
-        int _m{-1};        // spatial cell index
-        Vec _B_direction;  // direction of the magnetic field
+        int _m{-1};              // spatial cell index
+        Direction _B_direction;  // direction of the magnetic field
 
         // information on a particular photon packet, initialized by calculateIfNeeded()
         double _lambda{-1.};  // wavelength of the photon packet
@@ -373,8 +373,7 @@ namespace
             _m = m;
 
             // normalise the magnetic field direction
-            _B_direction = _ms->magneticField(_m);
-            _B_direction /= _B_direction.norm();
+            _B_direction.set(_ms->magneticField(_m), true);
         }
 
         // this AngularDistributionInterface implementation returns the probability for the given direction
@@ -466,11 +465,10 @@ namespace
                 const double beta = std::acos(cosbeta);
                 const double sinbeta = std::sin(beta);
                 // compute the direction of the rotation axis, z x B
-                const Direction n(Vec::cross(Vec(0., 0., 1.), _B_direction));
+                const Direction n(Vec::cross(Vec(0., 0., 1.), _B_direction), true);
                 // now use Rodrigues' rotation formula to carry out the rotation
-                const Direction krand2(krand * cosbeta + Vec::cross(n, krand) * sinbeta
-                                       + n * Vec::dot(n, krand) * (1. - cosbeta));
-                return krand2;
+                return Direction(
+                    krand * cosbeta + Vec::cross(n, krand) * sinbeta + n * Vec::dot(n, krand) * (1. - cosbeta), false);
             }
             else
             {
@@ -499,7 +497,7 @@ namespace
             }
             // the reference direction is any direction perpendicular to the
             // propagation direction and the magnetic field direction
-            return StokesVector(Qabsval, Qabspolval, 0., 0., Direction(Vec::cross(bfk, _B_direction)));
+            return StokesVector(Qabsval, Qabspolval, 0., 0., Direction(Vec::cross(bfk, _B_direction), true));
         }
     };
 

--- a/SKIRT/core/FilePolarizedPointSource.cpp
+++ b/SKIRT/core/FilePolarizedPointSource.cpp
@@ -87,10 +87,8 @@ void FilePolarizedPointSource::setupSelfBefore()
     _sed = new MeanSED(this, _tables.I);
 
     // get the symmetry axis orientation
-    Vec sym(symmetryX(), symmetryY(), symmetryZ());
-    double norm = sym.norm();
-    if (norm == 0) throw FATALERROR("Symmetry axis direction cannot be null vector");
-    _sym = Direction(sym / norm);
+    _sym.set(symmetryX(), symmetryY(), symmetryZ(), true);
+    if (_sym.isNull()) throw FATALERROR("Symmetry axis direction cannot be null vector");
 
     // cache wavelength sampling parameters depending on whether this is an oligo- or panchromatic simulation
     auto config = find<Configuration>();
@@ -248,7 +246,7 @@ namespace
             double Q = _tables->Q(cosine, _lambda);
             double U = _tables->U(cosine, _lambda);
             double V = _tables->V(cosine, _lambda);
-            Direction n(Vec::cross(_sym, bfk));
+            Direction n(Vec::cross(_sym, bfk), true);
             return StokesVector(I, Q, U, V, n);
         }
 

--- a/SKIRT/core/FilePolarizedPointSource.cpp
+++ b/SKIRT/core/FilePolarizedPointSource.cpp
@@ -4,12 +4,72 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "FilePolarizedPointSource.hpp"
-#include "AngularDistribution.hpp"
+#include "AngularDistributionInterface.hpp"
 #include "Configuration.hpp"
-#include "ContSED.hpp"
+#include "FatalError.hpp"
+#include "Parallel.hpp"
+#include "ParallelFactory.hpp"
 #include "PhotonPacket.hpp"
-#include "PolarizationProfile.hpp"
+#include "PolarizationProfileInterface.hpp"
+#include "ProcessManager.hpp"
 #include "Random.hpp"
+#include "TabulatedSED.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // this helper class integrates the intensity tabulated in the user input over the unit sphere
+    // and exposes the resulting mean spectrum (with arbitrary normalization) as a regular ContSED subclass.
+    class MeanSED : public TabulatedSED
+    {
+    public:
+        // this constructor remembers a reference to the intensity table, installs the newly created object
+        // as a child to the specified parent so it will automatically be deleted, and calls its setup() function
+        explicit MeanSED(SimulationItem* parent, const StoredTable<2>& tableI) : _tableI(tableI)
+        {
+            parent->addChild(this);
+            setup();
+        }
+
+    protected:
+        // this function calculates the unit-sphere-integrated spectrum and stores it into the provided argument arrays
+        void getWavelengthsAndLuminosities(Array& lambdav, Array& pv) const override
+        {
+            // get the cosine grid points and the distances between the grid points
+            Array cosv;
+            _tableI.axisArray<0>(cosv);
+            size_t numCos = cosv.size();
+            Array deltacosv(numCos);
+            for (size_t t = 1; t != numCos; ++t) deltacosv = cosv[t] - cosv[t - 1];
+
+            // get the wavelength grid points
+            _tableI.axisArray<1>(lambdav);
+            size_t numLambda = lambdav.size();
+
+            // loop over all wavelengths, in parallel
+            pv.resize(numLambda);
+            find<ParallelFactory>()->parallelDistributed()->call(numLambda, [this, numCos, &deltacosv, &pv](
+                                                                                size_t firstIndex, size_t numIndices) {
+                for (size_t ell = firstIndex; ell != firstIndex + numIndices; ++ell)
+                {
+                    // perform the integration using the trapezium rule, with arbitrary normalization
+                    double total = 0.;
+                    for (size_t t = 1; t != numCos; ++t)
+                    {
+                        total += (_tableI.valueAtIndices(t - 1, ell) + _tableI.valueAtIndices(t, ell)) * deltacosv[t];
+                    }
+                    pv[ell] = total;
+                }
+            });
+            ProcessManager::sumToAll(pv);
+        }
+
+    private:
+        // a reference to the intensity table
+        const StoredTable<2>& _tableI;
+    };
+}
 
 ////////////////////////////////////////////////////////////////////
 
@@ -17,22 +77,20 @@ void FilePolarizedPointSource::setupSelfBefore()
 {
     Source::setupSelfBefore();
 
-    // open the tables with Stokes vector components as a function of wavelength and inclination angle
-    _tableI.open(this, _filename, "theta(rad),lambda(m)", "I(W/m)", false, false);
-    _tableQ.open(this, _filename, "theta(rad),lambda(m)", "Q(W/m)", false, false);
-    _tableU.open(this, _filename, "theta(rad),lambda(m)", "U(W/m)", false, false);
-    _tableV.open(this, _filename, "theta(rad),lambda(m)", "V(W/m)", false, false);
+    // open the tables with Stokes vector components as a function of wavelength and inclination angle cosine
+    _tableI.open(this, filename(), "costheta(1),lambda(m)", "I(W/m)", false, false);
+    _tableQ.open(this, filename(), "costheta(1),lambda(m)", "Q(W/m)", false, false);
+    _tableU.open(this, filename(), "costheta(1),lambda(m)", "U(W/m)", false, false);
+    _tableV.open(this, filename(), "costheta(1),lambda(m)", "V(W/m)", false, false);
 
-    // construct the SED averaged over all angles from the input file
-    // _sed = ...
-    _tableI.valueAtIndices(3,4);
-    Array thetav, lambdav;
-    _tableI.axisArray<0>(thetav);
-    _tableI.axisArray<1>(lambdav);
+    // construct the mean SED (averaged over the unit sphere) from the input file
+    _sed = new MeanSED(this, _tableI);
 
-    // construct angular distribution object for each wavelength point
-    // construct polarization profile object for each wavelength point
-    // adjust for symmetry axis orientation in both sets of objects
+    // get the symmetry axis orientation
+    Vec sym(symmetryX(), symmetryY(), symmetryZ());
+    double norm = sym.norm();
+    if (norm == 0) throw FATALERROR("Symmetry axis direction cannot be null vector");
+    _sym = Direction(sym / norm);
 
     // cache wavelength sampling parameters depending on whether this is an oligo- or panchromatic simulation
     auto config = find<Configuration>();
@@ -116,6 +174,54 @@ double FilePolarizedPointSource::specificLuminosity(double wavelength) const
 
 ////////////////////////////////////////////////////////////////////
 
+namespace
+{
+    // this helper class represents the angular distribution at a given wavelength,
+    // derived from the intensity tabulated in the user input as a function of inclination,
+    // and taking into account the orientation of the symmetry axis
+    class LocalAngularDistribution : public AngularDistributionInterface
+    {
+    public:
+        // this function obtains the angular probability distribution for the specified wavelength
+        // and stores the symmetry axis orientation and the simulation's random generator
+        void initialize(const StoredTable<2>& tableI, double lambda, Direction sym, Random* random)
+        {
+            tableI.cdf(_cosv, _pv, _Pv, Range(-1., 1.), lambda);
+            _sym = sym;
+            _random = random;
+        }
+
+        // this function returns the probability for the angle between the given direction and the symmetry axis
+        double probabilityForDirection(Direction bfk) const override
+        {
+            double cosine = Vec::dot(_sym, bfk);
+            return NR::value<NR::interpolateLinLin>(cosine, _cosv, _pv);
+        }
+
+        // this function generates a random cosine from the probability distribution, and then
+        // returns a direction with the corresponding angle relative to the symmetry axis and a random azimuth
+        Direction generateDirection() const
+        {
+            double cosine = _random->cdfLinLin(_cosv, _Pv);
+            return _random->direction(_sym, cosine);
+        }
+
+    private:
+        Array _cosv;  // cosine grid points
+        Array _pv;    // corresponding normalized probability distribution
+        Array _Pv;    // corresponding normalized cumulative probability distribution
+
+        Direction _sym;   // orientation of the symmetry axis
+        Random* _random;  // the simulation's random generator
+    };
+
+    // setup an angular distribution instance for each parallel execution thread; this works even if
+    // there are multiple sources of this type because each thread handles a single photon packet at a time
+    thread_local LocalAngularDistribution t_angularDistribution;
+}
+
+////////////////////////////////////////////////////////////////////
+
 void FilePolarizedPointSource::launch(PhotonPacket* pp, size_t historyIndex, double L) const
 {
     // generate a random wavelength from the SED and/or from the bias distribution
@@ -154,16 +260,16 @@ void FilePolarizedPointSource::launch(PhotonPacket* pp, size_t historyIndex, dou
     // get the source position
     Position bfr(positionX(), positionY(), positionZ());
 
-    // get or construct angular distribution object for this wavelength point
-    AngularDistribution* angularDistribution = nullptr;
+    // initialize thread-local angular distribution object for this wavelength point
+    t_angularDistribution.initialize(_tableI, lambda, _sym, random());
 
     // get or construct polarization profile object for this wavelength point
-    PolarizationProfile* polarizationProfile = nullptr;
+    PolarizationProfileInterface* polarizationProfile = nullptr;
 
     // launch the photon packet with the proper wavelength, weight, position, direction,
     // bulk veloclity, angular distribution and polarization profile
-    pp->launch(historyIndex, lambda, L * w, bfr, angularDistribution->generateDirection(), _bvi, angularDistribution,
-               polarizationProfile);
+    pp->launch(historyIndex, lambda, L * w, bfr, t_angularDistribution.generateDirection(), _bvi,
+               &t_angularDistribution, polarizationProfile);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/FilePolarizedPointSource.cpp
+++ b/SKIRT/core/FilePolarizedPointSource.cpp
@@ -78,10 +78,10 @@ void FilePolarizedPointSource::setupSelfBefore()
     Source::setupSelfBefore();
 
     // open the tables with Stokes vector components as a function of wavelength and inclination angle cosine
-    _tables.I.open(this, filename(), "costheta(1),lambda(m)", "I(W/m)", false, false);
-    _tables.Q.open(this, filename(), "costheta(1),lambda(m)", "Q(W/m)", false, false);
-    _tables.U.open(this, filename(), "costheta(1),lambda(m)", "U(W/m)", false, false);
-    _tables.V.open(this, filename(), "costheta(1),lambda(m)", "V(W/m)", false, false);
+    _tables.I.open(this, filename(), "costheta(1),lambda(m)", "I(W/m)", true, false);
+    _tables.Q.open(this, filename(), "costheta(1),lambda(m)", "Q(W/m)", true, false);
+    _tables.U.open(this, filename(), "costheta(1),lambda(m)", "U(W/m)", true, false);
+    _tables.V.open(this, filename(), "costheta(1),lambda(m)", "V(W/m)", true, false);
 
     // construct the mean SED (averaged over the unit sphere) from the input file
     _sed = new MeanSED(this, _tables.I);

--- a/SKIRT/core/FilePolarizedPointSource.cpp
+++ b/SKIRT/core/FilePolarizedPointSource.cpp
@@ -192,10 +192,11 @@ namespace
         }
 
         // this function returns the probability for the angle between the given direction and the symmetry axis
+        // properly normalized to 4 pi over the unit sphere (or to 2 over the inclination angles)
         double probabilityForDirection(Direction bfk) const override
         {
             double cosine = Vec::dot(_sym, bfk);
-            return NR::value<NR::interpolateLinLin>(cosine, _cosv, _pv);
+            return 2. * NR::value<NR::interpolateLinLin>(cosine, _cosv, _pv);
         }
 
         // this function generates a random cosine from the probability distribution, and then

--- a/SKIRT/core/FilePolarizedPointSource.cpp
+++ b/SKIRT/core/FilePolarizedPointSource.cpp
@@ -1,0 +1,159 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "FilePolarizedPointSource.hpp"
+#include "AngularDistribution.hpp"
+#include "Configuration.hpp"
+#include "ContSED.hpp"
+#include "PhotonPacket.hpp"
+#include "PolarizationProfile.hpp"
+#include "Random.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void FilePolarizedPointSource::setupSelfBefore()
+{
+    Source::setupSelfBefore();
+
+    // read the input file
+    // construct the SED averaged over all angles from the input file
+    // _sed = ...
+    // construct angular distribution object for each wavelength point
+    // construct polarization profile object for each wavelength point
+    // adjust for symmetry axis orientation in both sets of objects
+
+    // cache wavelength sampling parameters depending on whether this is an oligo- or panchromatic simulation
+    auto config = find<Configuration>();
+    if (config->oligochromatic())
+    {
+        _xi = 1.;  // always use bias distribution for oligochromatic simulations
+        _biasDistribution = config->oligoWavelengthBiasDistribution();
+    }
+    else
+    {
+        _xi = wavelengthBias();
+        _biasDistribution = wavelengthBiasDistribution();
+    }
+
+    // if we have a nonzero bulk velocity, set the interface object to ourselves; otherwise leave it at null pointer
+    if (hasVelocity()) _bvi = this;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void FilePolarizedPointSource::setupSelfAfter()
+{
+    Source::setupSelfAfter();
+
+    // warn the user if this source's intrinsic wavelength range does not fully cover the configured wavelength range
+    informAvailableWavelengthRange(_sed->intrinsicWavelengthRange(), _sed->type());
+}
+
+////////////////////////////////////////////////////////////////////
+
+int FilePolarizedPointSource::dimension() const
+{
+    if (positionX() || positionY() || symmetryX() || symmetryY()) return 3;
+    if (hasVelocity() && (velocityX() || velocityY())) return 3;
+    return 2;
+}
+
+////////////////////////////////////////////////////////////////////
+
+bool FilePolarizedPointSource::hasVelocity() const
+{
+    if (velocityX() || velocityY() || velocityZ())
+    {
+        // refuse velocity for oligochromatic simulations
+        // (this function is called from Configure so we cannot precompute this during setup)
+        auto config = find<Configuration>();
+        if (!config->oligochromatic()) return true;
+    }
+    return false;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Vec FilePolarizedPointSource::velocity() const
+{
+    return Vec(velocityX(), velocityY(), velocityZ());
+}
+
+////////////////////////////////////////////////////////////////////
+
+Range FilePolarizedPointSource::wavelengthRange() const
+{
+    return _sed->normalizationWavelengthRange();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double FilePolarizedPointSource::luminosity() const
+{
+    return _normalization->luminosityForSED(_sed);
+}
+
+////////////////////////////////////////////////////////////////////
+
+double FilePolarizedPointSource::specificLuminosity(double wavelength) const
+{
+    return _sed->normalizationWavelengthRange().containsFuzzy(wavelength)
+               ? _sed->specificLuminosity(wavelength) * luminosity()
+               : 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void FilePolarizedPointSource::launch(PhotonPacket* pp, size_t historyIndex, double L) const
+{
+    // generate a random wavelength from the SED and/or from the bias distribution
+    double lambda, w;
+    if (!_xi)
+    {
+        // no biasing -- simply use the intrinsic spectral distribution
+        lambda = _sed->generateWavelength();
+        w = 1.;
+    }
+    else
+    {
+        // biasing -- use one or the other distribution
+        if (random()->uniform() > _xi)
+            lambda = _sed->generateWavelength();
+        else
+            lambda = _biasDistribution->generateWavelength();
+
+        // calculate the compensating weight factor
+        double s = _sed->specificLuminosity(lambda);
+        if (!s)
+        {
+            // if the wavelength can't occur in the intrinsic distribution,
+            // the weight factor is zero regardless of the probability in the bias distribution
+            // (handling this separately also avoids NaNs in the pathological case s=b=0)
+            w = 0.;
+        }
+        else
+        {
+            // regular composite bias weight
+            double b = _biasDistribution->probability(lambda);
+            w = s / ((1 - _xi) * s + _xi * b);
+        }
+    }
+
+    // get the source position
+    Position bfr(positionX(), positionY(), positionZ());
+
+    // get or construct angular distribution object for this wavelength point
+    AngularDistribution* angularDistribution = nullptr;
+
+    // get or construct polarization profile object for this wavelength point
+    PolarizationProfile* polarizationProfile = nullptr;
+
+    // launch the photon packet with the proper wavelength, weight, position, direction,
+    // bulk veloclity, angular distribution and polarization profile
+    pp->launch(historyIndex, lambda, L * w, bfr, angularDistribution->generateDirection(), _bvi, angularDistribution,
+               polarizationProfile);
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/FilePolarizedPointSource.cpp
+++ b/SKIRT/core/FilePolarizedPointSource.cpp
@@ -17,9 +17,19 @@ void FilePolarizedPointSource::setupSelfBefore()
 {
     Source::setupSelfBefore();
 
-    // read the input file
+    // open the tables with Stokes vector components as a function of wavelength and inclination angle
+    _tableI.open(this, _filename, "theta(rad),lambda(m)", "I(W/m)", false, false);
+    _tableQ.open(this, _filename, "theta(rad),lambda(m)", "Q(W/m)", false, false);
+    _tableU.open(this, _filename, "theta(rad),lambda(m)", "U(W/m)", false, false);
+    _tableV.open(this, _filename, "theta(rad),lambda(m)", "V(W/m)", false, false);
+
     // construct the SED averaged over all angles from the input file
     // _sed = ...
+    _tableI.valueAtIndices(3,4);
+    Array thetav, lambdav;
+    _tableI.axisArray<0>(thetav);
+    _tableI.axisArray<1>(lambdav);
+
     // construct angular distribution object for each wavelength point
     // construct polarization profile object for each wavelength point
     // adjust for symmetry axis orientation in both sets of objects

--- a/SKIRT/core/FilePolarizedPointSource.hpp
+++ b/SKIRT/core/FilePolarizedPointSource.hpp
@@ -9,6 +9,7 @@
 #include "LuminosityNormalization.hpp"
 #include "Source.hpp"
 #include "VelocityInterface.hpp"
+#include "StoredTable.hpp"
 class ContSED;
 
 //////////////////////////////////////////////////////////////////////
@@ -139,6 +140,12 @@ public:
     //======================== Data Members ========================
 
 private:
+    // user-provided Stokes vector components as a function of wavelength and inclination angle
+    StoredTable<2> _tableI;
+    StoredTable<2> _tableQ;
+    StoredTable<2> _tableU;
+    StoredTable<2> _tableV;
+
     // spectral data initialized during setup
     ContSED* _sed{nullptr};  // the SED averaged over all angles as derived from the input file
 

--- a/SKIRT/core/FilePolarizedPointSource.hpp
+++ b/SKIRT/core/FilePolarizedPointSource.hpp
@@ -20,10 +20,44 @@ class ContSED;
     components of the emitted radiation, as a function of wavelength and inclination angle cosine,
     are loaded from a user-provided file. The input file specifies these quantities as an intensity
     or luminosity per unit of wavelength, with arbitrary normalization. The bolometric output is
-    characterized by a LuminosityNormalization object configured in the ski file.
+    characterized by a LuminosityNormalization object configured in the ski file. The class
+    furthermore offers user-configured properties to specify the position of the point source, the
+    orientation of the symmetry axis of the angular dependence, and a "bulk" velocity.
 
-    The class offers properties to specify the position of the point source, the orientation of the
-    symmetry axis of the angular dependence, and a "bulk" velocity. */
+    <em>Inclination angle</em>
+
+    For the purposes of this class, the inclination angle is defined as the angle between the
+    user-configured symmetry axis \f$\bf{s}\f$ and the propagation direction \f$\bf{k}\f$ of the
+    emitted photon packet. The inclination cosine values given in the input file must conform to
+    this convention.
+
+    In formula form, assuming that both directions \f$\bf{s}\f$ and \f$\bf{k}\f$ are given as unit
+    vectors, the inclination angle cosine simply is \f$\cos\theta=\bf{s}\cdot\bf{k}\f$.
+
+    <em>Reference direction</em>
+
+    The components of a Stokes vector (and hence the polarization angle derived from it) are
+    specified relative to some reference direction \f$\bf{d}\f$ which must be perpendicular to the
+    propagation direction \f$\bf{k}\f$ of the emitted photon packet. For the purposes of this
+    class, the reference direction is taken to be the orthogonal projection of the user-configured
+    symmetry axis \f$\bf{s}\f$ on the plane perpendicular to the propagation direction
+    \f$\bf{k}\f$. The Stokes vector values given in the input file must conform to this convention.
+
+    In formula form, assuming that the propagation direction \f$\bf{k}\f$ is given as a unit
+    vector, the (unnormalized) orthogonal projection of \f$\bf{s}\f$ on the plane with normal
+    \f$\bf{k}\f$ is given by \f$\bf{d} = \bf{s} - (\bf{k}\cdot\bf{s})\bf{k}\f$. Rather than the
+    reference direction itself, the implementation instead uses the normal \f$\bf{n}\f$ to the
+    reference plane, which is defined as the plane through both the reference direction and the
+    propagation direction. The normalized normal vector \f$\bf{n}\f$ is obtained from
+
+    \f[ \bf{n} = \frac{\bf{d} \times \bf{k}}{||\bf{d} \times \bf{k}||} = \frac{\bf{s} \times
+    \bf{k}}{||\bf{s} \times \bf{k}||} \f]
+
+    after substitution of the above expression for \f$\bf{d}\f$. If the symmetry axis and the
+    propogation direction are (anti)parallel, the normal vector \f$\bf{n}\f$ is undefined and the
+    emitted radiation is taken to be unpolarized.
+
+    */
 class FilePolarizedPointSource : public Source, public VelocityInterface
 {
     ITEM_CONCRETE(FilePolarizedPointSource, Source, "a primary point source with a polarized spectrum read from file")

--- a/SKIRT/core/FilePolarizedPointSource.hpp
+++ b/SKIRT/core/FilePolarizedPointSource.hpp
@@ -1,0 +1,155 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef FILEPOLARIZEDPOINTSOURCE_HPP
+#define FILEPOLARIZEDPOINTSOURCE_HPP
+
+#include "LuminosityNormalization.hpp"
+#include "Source.hpp"
+#include "VelocityInterface.hpp"
+class ContSED;
+
+//////////////////////////////////////////////////////////////////////
+
+/** FilePolarizedPointSource represents a primary source limited to a single point in space and
+    emitting polarized radiation with an axi-symmetric angular dependence. The Stokes vector
+    components of the emitted radiation, as a function of wavelength and inclination angle, are
+    loaded from a user-provided file. The input file specifies these quantities with arbitrary
+    normalization; the bolometric output is characterized by a LuminosityNormalization object
+    configured in the ski file.
+
+    The class offers properties to specify the position of the point source, the orientation of the
+    symmetry axis of the angular dependence, and a "bulk" velocity. */
+class FilePolarizedPointSource : public Source, public VelocityInterface
+{
+    ITEM_CONCRETE(FilePolarizedPointSource, Source, "a primary point source with a polarized spectrum read from file")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(FilePolarizedPointSource, "Level2")
+        ATTRIBUTE_TYPE_INSERT(FilePolarizedPointSource, "Dimension2")
+
+        PROPERTY_STRING(filename, "the name of the stored table file listing the Stokes vector components")
+
+        PROPERTY_ITEM(normalization, LuminosityNormalization, "the type of luminosity normalization for the source")
+        ATTRIBUTE_DEFAULT_VALUE(normalization, "IntegratedLuminosityNormalization")
+
+        PROPERTY_DOUBLE(positionX, "the position of the point source, x component")
+        ATTRIBUTE_QUANTITY(positionX, "length")
+        ATTRIBUTE_DEFAULT_VALUE(positionX, "0")
+        ATTRIBUTE_INSERT(positionX, "positionX:Dimension3")
+
+        PROPERTY_DOUBLE(positionY, "the position of the point source, y component")
+        ATTRIBUTE_QUANTITY(positionY, "length")
+        ATTRIBUTE_DEFAULT_VALUE(positionY, "0")
+        ATTRIBUTE_INSERT(positionY, "positionY:Dimension3")
+
+        PROPERTY_DOUBLE(positionZ, "the position of the point source, z component")
+        ATTRIBUTE_QUANTITY(positionZ, "length")
+        ATTRIBUTE_DEFAULT_VALUE(positionZ, "0")
+
+        PROPERTY_DOUBLE(symmetryX, "the direction of the positive symmetry axis, x component")
+        ATTRIBUTE_QUANTITY(symmetryX, "length")
+        ATTRIBUTE_DEFAULT_VALUE(symmetryX, "0")
+        ATTRIBUTE_INSERT(symmetryX, "symmetryX:Dimension3")
+
+        PROPERTY_DOUBLE(symmetryY, "the direction of the positive symmetry axis, y component")
+        ATTRIBUTE_QUANTITY(symmetryY, "length")
+        ATTRIBUTE_DEFAULT_VALUE(symmetryY, "0")
+        ATTRIBUTE_INSERT(symmetryY, "symmetryY:Dimension3")
+
+        PROPERTY_DOUBLE(symmetryZ, "the direction of the positive symmetry axis, z component")
+        ATTRIBUTE_QUANTITY(symmetryZ, "length")
+        ATTRIBUTE_DEFAULT_VALUE(symmetryZ, "1")
+
+        PROPERTY_DOUBLE(velocityX, "the bulk velocity of the point source, x component")
+        ATTRIBUTE_QUANTITY(velocityX, "velocity")
+        ATTRIBUTE_MIN_VALUE(velocityX, "[-100000 km/s")
+        ATTRIBUTE_MAX_VALUE(velocityX, "100000 km/s]")
+        ATTRIBUTE_DEFAULT_VALUE(velocityX, "0")
+        ATTRIBUTE_RELEVANT_IF(velocityX, "Panchromatic")
+        ATTRIBUTE_INSERT(velocityX, "Panchromatic&velocityX:Dimension3")
+
+        PROPERTY_DOUBLE(velocityY, "the bulk velocity of the point source, y component")
+        ATTRIBUTE_QUANTITY(velocityY, "velocity")
+        ATTRIBUTE_MIN_VALUE(velocityY, "[-100000 km/s")
+        ATTRIBUTE_MAX_VALUE(velocityY, "100000 km/s]")
+        ATTRIBUTE_DEFAULT_VALUE(velocityY, "0")
+        ATTRIBUTE_RELEVANT_IF(velocityY, "Panchromatic")
+        ATTRIBUTE_INSERT(velocityY, "Panchromatic&velocityY:Dimension3")
+
+        PROPERTY_DOUBLE(velocityZ, "the bulk velocity of the point source, z component")
+        ATTRIBUTE_QUANTITY(velocityZ, "velocity")
+        ATTRIBUTE_MIN_VALUE(velocityZ, "[-100000 km/s")
+        ATTRIBUTE_MAX_VALUE(velocityZ, "100000 km/s]")
+        ATTRIBUTE_DEFAULT_VALUE(velocityZ, "0")
+        ATTRIBUTE_RELEVANT_IF(velocityZ, "Panchromatic")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function reads the user-provided input file and caches the relevant information. */
+    void setupSelfBefore() override;
+
+    /** This function warns the user if this source's intrinsic wavelength range does not fully
+        cover the configured wavelength range. */
+    void setupSelfAfter() override;
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function returns the dimension of the point source, which depends on the (lack of)
+        symmetry of its geometry. */
+    int dimension() const override;
+
+    /** This function returns true if the velocity of the source is nonzero. */
+    bool hasVelocity() const override;
+
+    /** This function implements the VelocityInterface interface. It returns the bulk velocity
+         of this source, as configured by the user. */
+    Vec velocity() const override;
+
+    /** This function returns the wavelength range for this source. Outside this range, all
+        luminosities are zero. This source's wavelength range is determined as the intersection of
+        the simulation's source wavelength range (obtained from the simulation configuration) and
+        the intrinsic wavelength range of the spectrum read from the input file.
+
+        This function implements the SourceWavelengthRangeInterface interface. */
+    Range wavelengthRange() const override;
+
+    /** This function returns the luminosity \f$L\f$ (i.e. radiative power) of the source
+        integrated over the wavelength range of primary sources (configured for the source system
+        as a whole). */
+    double luminosity() const override;
+
+    /** This function returns the specific luminosity \f$L_\lambda\f$ (i.e. radiative power per
+        unit of wavelength) of the source at the specified wavelength, or zero if the wavelength is
+        outside the wavelength range of primary sources (configured for the source system as a
+        whole) or if the source simply does not emit at the wavelength. */
+    double specificLuminosity(double wavelength) const override;
+
+    /** This function causes the photon packet \em pp to be launched from the source using the
+        given history index and luminosity contribution. The function samples a wavelength and a
+        propagation direction from the spectral and angular dependencies derived from the input
+        file, constructs proper objects for angular distribution, polarization profile and bulk
+        velocity, and finally emits the photon packet with these properties. */
+    void launch(PhotonPacket* pp, size_t historyIndex, double L) const override;
+
+    //======================== Data Members ========================
+
+private:
+    // spectral data initialized during setup
+    ContSED* _sed{nullptr};  // the SED averaged over all angles as derived from the input file
+
+    // sampling parameters initialized during setup
+    double _xi{0.};                                      // the wavelength bias fraction
+    WavelengthDistribution* _biasDistribution{nullptr};  // the wavelength bias distribution
+
+    // velocity data initialized during setup
+    VelocityInterface* _bvi{nullptr};  // pointer to an object offering the velocity interface, if needed
+};
+
+//////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/FilePolarizedPointSource.hpp
+++ b/SKIRT/core/FilePolarizedPointSource.hpp
@@ -140,12 +140,15 @@ public:
 
     //======================== Data Members ========================
 
+    // structure combining the input tables representing the user-provided Stokes vector components
+    struct Tables
+    {
+        StoredTable<2> I, Q, U, V;
+    };
+
 private:
     // user-provided Stokes vector components as a function of wavelength and inclination angle cosine
-    StoredTable<2> _tableI;
-    StoredTable<2> _tableQ;
-    StoredTable<2> _tableU;
-    StoredTable<2> _tableV;
+    Tables _tables;
 
     // spectral data initialized during setup
     ContSED* _sed{nullptr};  // the mean SED (averaged over the unit sphere) as derived from the input file

--- a/SKIRT/core/FilePolarizedPointSource.hpp
+++ b/SKIRT/core/FilePolarizedPointSource.hpp
@@ -6,20 +6,21 @@
 #ifndef FILEPOLARIZEDPOINTSOURCE_HPP
 #define FILEPOLARIZEDPOINTSOURCE_HPP
 
+#include "Direction.hpp"
 #include "LuminosityNormalization.hpp"
 #include "Source.hpp"
-#include "VelocityInterface.hpp"
 #include "StoredTable.hpp"
+#include "VelocityInterface.hpp"
 class ContSED;
 
 //////////////////////////////////////////////////////////////////////
 
 /** FilePolarizedPointSource represents a primary source limited to a single point in space and
     emitting polarized radiation with an axi-symmetric angular dependence. The Stokes vector
-    components of the emitted radiation, as a function of wavelength and inclination angle, are
-    loaded from a user-provided file. The input file specifies these quantities with arbitrary
-    normalization; the bolometric output is characterized by a LuminosityNormalization object
-    configured in the ski file.
+    components of the emitted radiation, as a function of wavelength and inclination angle cosine,
+    are loaded from a user-provided file. The input file specifies these quantities as an intensity
+    or luminosity per unit of wavelength, with arbitrary normalization. The bolometric output is
+    characterized by a LuminosityNormalization object configured in the ski file.
 
     The class offers properties to specify the position of the point source, the orientation of the
     symmetry axis of the angular dependence, and a "bulk" velocity. */
@@ -140,18 +141,21 @@ public:
     //======================== Data Members ========================
 
 private:
-    // user-provided Stokes vector components as a function of wavelength and inclination angle
+    // user-provided Stokes vector components as a function of wavelength and inclination angle cosine
     StoredTable<2> _tableI;
     StoredTable<2> _tableQ;
     StoredTable<2> _tableU;
     StoredTable<2> _tableV;
 
     // spectral data initialized during setup
-    ContSED* _sed{nullptr};  // the SED averaged over all angles as derived from the input file
+    ContSED* _sed{nullptr};  // the mean SED (averaged over the unit sphere) as derived from the input file
 
     // sampling parameters initialized during setup
     double _xi{0.};                                      // the wavelength bias fraction
     WavelengthDistribution* _biasDistribution{nullptr};  // the wavelength bias distribution
+
+    // symmetry axis initialized during setup
+    Direction _sym;  // direction of symmetry axis
 
     // velocity data initialized during setup
     VelocityInterface* _bvi{nullptr};  // pointer to an object offering the velocity interface, if needed

--- a/SKIRT/core/HEALPixSkyInstrument.cpp
+++ b/SKIRT/core/HEALPixSkyInstrument.cpp
@@ -109,7 +109,7 @@ Direction HEALPixSkyInstrument::bfkobs(const Position& bfr) const
     if (d < _radius) return Direction();
 
     // otherwise return a unit vector in the direction from launch to observer
-    return Direction(k / d);
+    return Direction(k / d, false);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -126,10 +126,9 @@ Direction HEALPixSkyInstrument::bfky(const Position& bfr) const
     // vector in the plane normal to the line launch-observer
     // oriented along the projection of the up direction in that plane
     Vec ku(_Ux, _Uy, _Uz);
-    Vec ky = Vec::cross(k, Vec::cross(ku, k));
 
     // return unit vector along y-axis
-    return Direction(ky / ky.norm());
+    return Direction(Vec::cross(k, Vec::cross(ku, k)), true);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/LyaUtils.cpp
+++ b/SKIRT/core/LyaUtils.cpp
@@ -41,13 +41,8 @@ std::pair<Vec, bool> LyaUtils::sampleAtomVelocity(double lambda, double T, doubl
     double x = (la - lambda) / lambda * c / vth;  // dimensionless frequency
 
     // generate two directions that are orthogonal to each other and to the incoming photon packet direction
-    Direction k1(1., 0., 0.);
-    if (kin.kx() != 0. || kin.ky() != 0.)
-    {
-        k1 = Direction(kin.ky(), -kin.kx(), 0.);
-        k1 /= k1.norm();
-    }
-    Direction k2(Vec::cross(k1, kin));
+    Direction k1 = (kin.kx() || kin.ky()) ? Direction(kin.ky(), -kin.kx(), 0., true) : Direction(1., 0., 0., false);
+    Direction k2(Vec::cross(k1, kin), false);
 
     // select the critical value of the dimensionless frequency depending on the acceleration scheme;
     // leaving the value at zero is equivalent to no acceleration

--- a/SKIRT/core/ParallelProjectionForm.cpp
+++ b/SKIRT/core/ParallelProjectionForm.cpp
@@ -41,11 +41,11 @@ void ParallelProjectionForm::writeQuantity(const ProbeFormBridge* bridge) const
 
     // determine the observer axes as directions in model coordinates (inverse transform of frame instrument)
     // k_z is the direction from observer to model (i.e. left-handed coordinate frame)
-    Direction kz(-cosphi * sintheta, -sinphi * sintheta, -costheta);
+    Direction kz(-cosphi * sintheta, -sinphi * sintheta, -costheta, false);
     Direction ky(-cosphi * costheta * cosomega - sinphi * sinomega, -sinphi * costheta * cosomega + cosphi * sinomega,
-                 sintheta * cosomega);
+                 sintheta * cosomega, false);
     Direction kx(cosphi * costheta * sinomega - sinphi * cosomega, sinphi * costheta * sinomega + cosphi * cosomega,
-                 -sintheta * sinomega);
+                 -sintheta * sinomega, false);
 
     // get a distance that should be well outside of the model (but with a similar order of magnitude)
     double zp = 10. * (fieldOfViewX() + fieldOfViewY());

--- a/SKIRT/core/PerspectiveInstrument.cpp
+++ b/SKIRT/core/PerspectiveInstrument.cpp
@@ -43,7 +43,7 @@ void PerspectiveInstrument::setupSelfBefore()
     Vec kn(_Vx - _Cx, _Vy - _Cy, _Vz - _Cz);
     Vec ku(_Ux, _Uy, _Uz);
     Vec ky = Vec::cross(kn, Vec::cross(ku, kn));
-    _bfky = Direction(ky / ky.norm());
+    _bfky = Direction(ky, true);
 
     // the perspective transformation
 
@@ -114,7 +114,7 @@ Direction PerspectiveInstrument::bfkobs(const Position& bfr) const
     if (D < _s / 10.) return Direction();
 
     // otherwise return a unit vector in the direction from launch to eye
-    return Direction((_Ex - Px) / D, (_Ey - Py) / D, (_Ez - Pz) / D);
+    return Direction((_Ex - Px) / D, (_Ey - Py) / D, (_Ez - Pz) / D, false);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/Random.cpp
+++ b/SKIRT/core/Random.cpp
@@ -153,7 +153,7 @@ Direction Random::direction(Direction bfk, double costheta)
         kynew = -sintheta / root * (ky * kz * cosphi + kx * sinphi) + ky * costheta;
         kznew = root * sintheta * cosphi + kz * costheta;
     }
-    return Direction(kxnew, kynew, kznew);
+    return Direction(kxnew, kynew, kznew, false);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -85,6 +85,7 @@
 #include "FileIndexedSEDFamily.hpp"
 #include "FileLineSED.hpp"
 #include "FileMesh.hpp"
+#include "FilePolarizedPointSource.hpp"
 #include "FileSED.hpp"
 #include "FileSSPSEDFamily.hpp"
 #include "FileTreeSpatialGrid.hpp"
@@ -326,6 +327,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<StellarSurfaceSource>();
     ItemRegistry::add<CubicalBackgroundSource>();
     ItemRegistry::add<SphericalBackgroundSource>();
+    ItemRegistry::add<FilePolarizedPointSource>();
 
     // luminosity normalizations
     ItemRegistry::add<LuminosityNormalization>();

--- a/SKIRT/core/SineSquarePolarizationProfile.cpp
+++ b/SKIRT/core/SineSquarePolarizationProfile.cpp
@@ -12,9 +12,8 @@ void SineSquarePolarizationProfile::setupSelfBefore()
 {
     PolarizationProfile::setupSelfBefore();
 
-    Vec sym(symmetryX(), symmetryY(), symmetryZ());
-    if (sym.norm() == 0) throw FATALERROR("Symmetry axis direction cannot be null vector");
-    _sym = Direction(sym / sym.norm());
+    _sym.set(symmetryX(), symmetryY(), symmetryZ(), true);
+    if (_sym.isNull()) throw FATALERROR("Symmetry axis direction cannot be null vector");
 
     _cos2gamma = cos(2 * polarizationAngle());
     _sin2gamma = sin(2 * polarizationAngle());
@@ -41,7 +40,7 @@ StokesVector SineSquarePolarizationProfile::polarizationForDirection(Direction b
         double PL = maxPolarizationDegree() * (1 - costheta) * (1 + costheta);
         double Q = PL * _cos2gamma;
         double U = PL * _sin2gamma;
-        Direction n(Vec::cross(_sym, bfk));
+        Direction n(Vec::cross(_sym, bfk), true);
         return StokesVector(1., Q, U, 0., n);
     }
 }

--- a/SKIRT/core/SineSquarePolarizationProfile.hpp
+++ b/SKIRT/core/SineSquarePolarizationProfile.hpp
@@ -24,7 +24,7 @@
     Q &= P_\mathrm{L}\,\cos 2\gamma \\
     U &= P_\mathrm{L}\,\sin 2\gamma \\
     V &= 0 \\
-    \bf{n} &= \bf{s} \times \bf{k}
+    \bf{n} &= \frac{\bf{s} \times \bf{k}}{||\bf{s} \times \bf{k}||}
     \end{aligned}\f]
 
     where \f$\bf{n}\f$ is the normal to the reference plane. The reference plane is the plane through

--- a/SKIRT/core/SphericalBackgroundSource.cpp
+++ b/SKIRT/core/SphericalBackgroundSource.cpp
@@ -41,7 +41,7 @@ namespace
         double kx = costheta * cosphi * kpx - sinphi * kpy + sintheta * cosphi * kpz;
         double ky = costheta * sinphi * kpx + cosphi * kpy + sintheta * sinphi * kpz;
         double kz = -sintheta * kpx + costheta * kpz;
-        return Direction(kx, ky, kz);
+        return Direction(kx, ky, kz, false);
     }
 
     // this function returns the normalized probability of launching in a certain direction

--- a/SKIRT/core/StellarSurfaceSource.cpp
+++ b/SKIRT/core/StellarSurfaceSource.cpp
@@ -41,7 +41,7 @@ namespace
         double kx = costheta * cosphi * kpx - sinphi * kpy + sintheta * cosphi * kpz;
         double ky = costheta * sinphi * kpx + cosphi * kpy + sintheta * sinphi * kpz;
         double kz = -sintheta * kpx + costheta * kpz;
-        return Direction(kx, ky, kz);
+        return Direction(kx, ky, kz, false);
     }
 
     // this function returns the normalized probability of launching in a certain direction

--- a/SKIRT/core/StoredTable.hpp
+++ b/SKIRT/core/StoredTable.hpp
@@ -520,25 +520,31 @@ public:
         return Range(_axBeg[axisIndex][0], _axBeg[axisIndex][_axLen[axisIndex] - 1]);
     }
 
-    // ================== Accessing the raw data in a 1D table ==================
+    // ================== Accessing the raw data ==================
 
 public:
-    /** This function is available only for one-dimensional tables. It returns the number of
-        entries in the table, i.e. the number of grid points in the single axis and the number of
-        corresponding quantity values. */
-    size_t size() const
+    /** This function returns the number of grid points in the table axis indicated by the
+        zero-based index in the template argument. */
+    template<size_t axisIndex, typename = std::enable_if_t<axisIndex <= N>> size_t axisSize() const
     {
-        static_assert(N == 1, "This function is available only for one-dimensional tables");
-        return _axLen[0];
+        return _axLen[axisIndex];
     }
 
-    /** This function is available only for one-dimensional tables. It returns a pointer to the
-        first element in the axis data array. The number of elements in this array can be obtained
-        through the size() function. */
-    const double* axisData() const
+    /** This function returns a pointer to the first element in the data array containing the grid
+        points of the table axis indicated by the zero-based index in the template argument. The
+        number of elements in this array can be obtained through the axisSize() function. */
+    template<size_t axisIndex, typename = std::enable_if_t<axisIndex <= N>> const double* axisData() const
     {
-        static_assert(N == 1, "This function is available only for one-dimensional tables");
-        return _axBeg[0];
+        return _axBeg[axisIndex];
+    }
+
+    /** This function returns an array containing the grid points of the table axis indicated by
+        the zero-based index in the template argument. */
+    template<size_t axisIndex, typename = std::enable_if_t<axisIndex <= N>> void axisArray(Array& xv) const
+    {
+        size_t size = _axLen[axisIndex];
+        xv.resize(size);
+        for (size_t index = 0; index != size; ++index) xv[index] = _axBeg[axisIndex][index];
     }
 
     /** This function is available only for one-dimensional tables. It returns a pointer to the
@@ -550,17 +556,15 @@ public:
         return _qtyBeg;
     }
 
-    // ================== Accessing the raw data ==================
-
-private:
     /** This template function returns a copy of the value at the specified N indices. There is no
         range checking. Out-of-range index values cause unpredictable behavior. */
-    template<typename... Indices, typename = std::enable_if_t<CompileTimeUtils::isFloatArgList<N, Indices...>()>>
+    template<typename... Indices, typename = std::enable_if_t<CompileTimeUtils::isIntegralArgList<N, Indices...>()>>
     double valueAtIndices(Indices... indices) const
     {
         return _qtyBeg[flattenedIndex(std::array<size_t, N>({{static_cast<size_t>(indices)...}}))];
     }
 
+private:
     /** This function returns a copy of the value at the specified N indices. There is no range
         checking. Out-of-range index values cause unpredictable behavior. */
     double valueAtIndices(const std::array<size_t, N>& indices) const { return _qtyBeg[flattenedIndex(indices)]; }

--- a/SKIRT/utils/Direction.cpp
+++ b/SKIRT/utils/Direction.cpp
@@ -57,3 +57,22 @@ void Direction::spherical(double& theta, double& phi) const
 }
 
 //////////////////////////////////////////////////////////////////////
+
+void Direction::normalize()
+{
+    double s = norm();
+    if (s > 0.)
+    {
+        _x /= s;
+        _y /= s;
+        _z /= s;
+    }
+    else
+    {
+        // explicitly clear the components because the norm can be zero even when the coordinates are nonzero
+        // (because the square of a very small number can undeflow to zero)
+        clear();
+    }
+}
+
+//////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/Direction.hpp
+++ b/SKIRT/utils/Direction.hpp
@@ -17,7 +17,7 @@
     coordinates must satisfy the normalization relation \f[ k_x^2+k_y^2+k_z^2=1. \f]
 
     To assist client code using the Direction class with ensuring this normalization, the
-    constructors and the set() function offer the Boolean \em normalize argument. If set to true,
+    constructors and the set() functions offer the Boolean \em normalize argument. If set to true,
     the constructor or function will automatically normalize the components passed by the caller.
     If set to false, the components are copied as given without any further verification. This can
     be used to avoid redundant calculations in case the caller has already ensured normalization.

--- a/SKIRT/utils/Direction.hpp
+++ b/SKIRT/utils/Direction.hpp
@@ -14,12 +14,24 @@
     principle only two coordinates are necessary to fully characterize a direction; a possible
     choice is spherical coordinates on the unit sphere. However in this class, a direction is
     internally represented by means of its three cartesian coordinates \f$(k_x,k_y,k_z)\f$. These
-    coordinates must satisfy the normalization relation \f[ k_x^2+k_y^2+k_z^2=1. \f] Direction is
-    publicly based on the Vec class, and the direction coordinates \f$(k_x,k_y,k_z)\f$ are stored
-    in the Vec components \em x, \em y and \em z. Consequently all functions and operators
-    defined for Vec are automatically available for Position as well. However this also means that
-    the normalization relation can be broken by careless access to functions such as set()
-    inherited from the Vec class. */
+    coordinates must satisfy the normalization relation \f[ k_x^2+k_y^2+k_z^2=1. \f]
+
+    To assist client code using the Direction class with ensuring this normalization, the
+    constructors and the set() function offer the Boolean \em normalize argument. If set to true,
+    the constructor or function will automatically normalize the components passed by the caller.
+    If set to false, the components are copied as given without any further verification. This can
+    be used to avoid redundant calculations in case the caller has already ensured normalization.
+
+    An important exception to the normalization invariant occurs when all three direction
+    components are zero, resulting in an invalid "null" direction. This can happen, for example,
+    when constructing a direction from user input or from the cross product of two parallel
+    vectors. In situations where a null direction may occur, client code should test for this using
+    the Vec::isNull() function.
+
+    The Direction class is publicly based on the Vec class, and the direction coordinates
+    \f$(k_x,k_y,k_z)\f$ are stored in the Vec components \em x, \em y and \em z. Consequently the
+    functions and operators defined for Vec are automatically available for Direction, except for
+    functions that would break the normalization (e.g. the compound-assignment operators). */
 class Direction : public Vec
 {
 public:
@@ -29,17 +41,28 @@ public:
     inline Direction() : Vec(0, 0, 1) {}
 
     /** Constructor for a direction with given cartesian coordinates \f$k_x\f$, \f$k_y\f$ and
-        \f$k_z\f$. In order to avoid abundant calculations, it is not checked whether the three
-        cartesian coordinates satisfy the condition \f[ k_x^2+k_y^2+k_z^2=1. \f] It is the user's
-        responsibility to provide valid coordinates. */
-    inline Direction(double kx, double ky, double kz) : Vec(kx, ky, kz) {}
+        \f$k_z\f$. If \em normalize is true, the constructor scales these coordinates so that they
+        conform to the normalization relation \f$k_x^2+k_y^2+k_z^2=1\f$; if this is not possible
+        because the coordinates are zero, the direction is set to the invalid null vector. If \em
+        normalize is false, the components are copied as given without any further verification.
+        This can be used to avoid redundant calculations in case the caller has already ensured
+        normalization. */
+    inline Direction(double kx, double ky, double kz, bool normalize) : Vec(kx, ky, kz)
+    {
+        if (normalize) this->normalize();
+    }
 
     /** Constructor for a direction with given cartesian coordinates \f${\bf{k}}_x\f$,
-        \f${\bf{k}}_y\f$ and \f${\bf{k}}_z\f$. It is declared <tt>explicit</tt> to avoid implicit
-        type conversions. In order to avoid abundant calculations, it is not checked whether the
-        three cartesian coordinates satisfy the condition \f[ k_x^2+k_y^2+k_z^2=1. \f] It is the
-        user's responsibility to provide valid coordinates. */
-    explicit inline Direction(Vec k) : Vec(k) {}
+        \f${\bf{k}}_y\f$ and \f${\bf{k}}_z\f$. If \em normalize is true, the constructor scales
+        these coordinates so that they conform to the normalization relation
+        \f$k_x^2+k_y^2+k_z^2=1\f$; if this is not possible because the coordinates are zero, the
+        direction is set to the invalid null vector. If \em normalize is false, the components are
+        copied as given without any further verification. This can be used to avoid redundant
+        calculations in case the caller has already ensured normalization. */
+    inline Direction(Vec k, bool normalize) : Vec(k)
+    {
+        if (normalize) this->normalize();
+    }
 
     /** Constructor for a direction with a given azimuth and polar angle. The cartesian coordinates
         are calculated as \f[ \begin{split} k_x &= \sin\theta\,\cos\varphi, \\ k_y &=
@@ -47,6 +70,40 @@ public:
         whether \f$\theta\f$ lies within the interval \f$[0,\pi]\f$. If not so, this does not
         correspond to a viable direction, and a FatalError is thrown. */
     Direction(double theta, double phi);
+
+    /** Disable the setter inherited from Vec so that callers are forced to specify a normalization
+        option. */
+    inline void set(double, double, double) = delete;
+
+    /** This function sets the direction to the given cartesian coordinates \f${\bf{k}}_x\f$,
+        \f${\bf{k}}_y\f$ and \f${\bf{k}}_z\f$. If \em normalize is true, the constructor scales
+        these coordinates so that they conform to the normalization relation
+        \f$k_x^2+k_y^2+k_z^2=1\f$; if this is not possible because the coordinates are zero, the
+        direction is set to the invalid null vector. If \em normalize is false, the components are
+        copied as given without any further verification. This can be used to avoid redundant
+        calculations in case the caller has already ensured normalization. */
+    inline void set(double kx, double ky, double kz, bool normalize)
+    {
+        _x = kx;
+        _y = ky;
+        _z = kz;
+        if (normalize) this->normalize();
+    }
+
+    /** This function sets the direction to the given cartesian coordinates \f${\bf{k}}_x\f$,
+        \f${\bf{k}}_y\f$ and \f${\bf{k}}_z\f$. If \em normalize is true, the constructor scales
+        these coordinates so that they conform to the normalization relation
+        \f$k_x^2+k_y^2+k_z^2=1\f$; if this is not possible because the coordinates are zero, the
+        direction is set to the invalid null vector. If \em normalize is false, the components are
+        copied as given without any further verification. This can be used to avoid redundant
+        calculations in case the caller has already ensured normalization. */
+    inline void set(Vec k, bool normalize)
+    {
+        _x = k.x();
+        _y = k.y();
+        _z = k.z();
+        if (normalize) this->normalize();
+    }
 
     /** This function returns the direction coordinate \f$k_x\f$. It is equivalent to the function
         x() inherited from the Vec class. */
@@ -71,8 +128,32 @@ public:
         \arctan\left(\frac{k_y}{k_x}\right). \end{split} \f] */
     void spherical(double& theta, double& phi) const;
 
-    /** This operator returns the opposite direction (negating each component). */
-    Direction operator-() const { return Direction(-_x, -_y, -_z); }
+    /** This operator returns the opposite direction (negating each coordinate). */
+    Direction operator-() const { return Direction(-_x, -_y, -_z, false); }
+
+    /** Disable this compound assignment operator inherited from Vec because it breaks the
+        normalization. */
+    inline Vec& operator+=(Vec v) = delete;
+
+    /** Disable this compound assignment operator inherited from Vec because it breaks the
+        normalization. */
+    inline Vec& operator-=(Vec v) = delete;
+
+    /** Disable this compound assignment operator inherited from Vec because it breaks the
+        normalization. */
+    inline Vec& operator*=(Vec v) = delete;
+
+    /** Disable this compound assignment operator inherited from Vec because it breaks the
+        normalization. */
+    inline Vec& operator/=(Vec v) = delete;
+
+private:
+    /** This private function normalizes the coordinates already stored in this instance by
+        dividing them by the value of the Vec::norm() function. As an exception, if the norm()
+        function returns zero, all coordinates are set to zero, resulting in an invalid direction.
+        The function is called from constructors and setters for this class in case the client code
+        sets \em normalize to true. */
+    void normalize();
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/PathSegmentGenerator.hpp
+++ b/SKIRT/utils/PathSegmentGenerator.hpp
@@ -111,7 +111,7 @@ protected:
 
     /** This function returns the path's direction. This value is initialized by the start()
         function and remains immutable during segment generation for the path. */
-    Direction k() { return Direction(_kx, _ky, _kz); }
+    Direction k() { return Direction(_kx, _ky, _kz, false); }
 
     /** This function returns the x component of the path's direction. This value is initialized by
         the start() function and remains immutable during segment generation for the path. */

--- a/SKIRT/utils/StokesVector.hpp
+++ b/SKIRT/utils/StokesVector.hpp
@@ -29,7 +29,7 @@ public:
     // -------- constructors and setters ----------
 
     /** The default constructor initializes the Stokes vector to an unpolarized state. */
-    StokesVector() : _polarized(false), _Q(0), _U(0), _V(0), _normal(0, 0, 0) {}
+    StokesVector() : _polarized(false), _Q(0), _U(0), _V(0), _normal(0, 0, 0, false) {}
 
     /** This constructor initializes the Stokes vector to the specified parameter values, after
         normalizing them through division by \f$I\f$. If \f$I=0\f$, the Stokes vector is set to an
@@ -43,7 +43,7 @@ public:
         _Q = 0;
         _U = 0;
         _V = 0;
-        _normal.set(0, 0, 0);
+        _normal.clear();
     }
 
     /** This function sets the Stokes vector to the specified vector components and the specified

--- a/SKIRT/utils/Vec.hpp
+++ b/SKIRT/utils/Vec.hpp
@@ -26,7 +26,7 @@ protected:
 
 public:
     /** This is the default constructor; all vector components are initialized to zero. */
-    inline Vec() : _x(0), _y(0), _z(0) {}
+    inline Vec() : _x(0.), _y(0.), _z(0.) {}
 
     /** This constructor initializes the vector components to the values provided as arguments. */
     inline Vec(double x, double y, double z) : _x(x), _y(y), _z(z) {}
@@ -37,6 +37,14 @@ public:
         _x = x;
         _y = y;
         _z = z;
+    }
+
+    /** This function sets all vector components to a value of zero. */
+    inline void clear()
+    {
+        _x = 0.;
+        _y = 0.;
+        _z = 0.;
     }
 
     /** This function returns true if all components of the vector are trivially zero, and false


### PR DESCRIPTION
**Description**
This pull request adds the `FilePolarizedPointSource` class, representing a primary source limited to a single point in space and emitting polarized radiation with an axi-symmetric angular dependence. The Stokes vector components of the emitted radiation, as a function of wavelength and inclination angle cosine, are loaded from a user-provided file. The bolometric output is characterized by a `LuminosityNormalization` object configured in the ski file. The class furthermore offers user-configured properties to specify the position of the point source, the orientation of the symmetry axis of the angular dependence, and a "bulk" velocity.

**Motivation**
This functionality was requested by the IXPE team in Rome through @BertVdM for use in AGN models.

**Secondary changes**
The `Direction` class has been updated to assist client code with ensuring proper normalization of the three coordinates. Specifically, all constructors and setters now include a Boolean _normalize_ argument, indicating whether the constructor/function should perform normalization. The motivation for this change is that we discovered a few instances where unnormalized directions were constructed. The impact on results was insignificant, but this may not always be the case. 

The `StoredTable` template class has been updated to allow direct public access to the table elements through indices. In cases where this is meaningful, it is much faster than obtaining interpolated quantities for arbitrary axis values.

**Tests**
The new `FilePolarizedPointSource` class has undergone several "lab" tests but more in-depth testing is required before using it in "production". 
