### PR TITLE
Allow mass fraction of 1 in clumpy decorator; avoid some CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,12 @@
 # ensure minimum level of functionality
 cmake_minimum_required(VERSION 3.2.2...3.5 FATAL_ERROR)
 
+# if suppported (by CMake version 3.29 and up), de-duplicate libraries on link lines based on linker capabilities
+# to avoid link warnings for duplicate libraries
+if(POLICY CMP0156)
+  cmake_policy(SET CMP0156 NEW)
+endif()
+
 # define project
 project(SKIRTproject)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,11 @@
 # Builds all targets defined in the SKIRT project
 # ------------------------------------------------------------------
 
-# define project and ensure minimum level of functionality
+# ensure minimum level of functionality
+cmake_minimum_required(VERSION 3.2.2...3.5 FATAL_ERROR)
+
+# define project
 project(SKIRTproject)
-cmake_minimum_required(VERSION 3.2.2 FATAL_ERROR)
 
 # define a user-configurable option to build SKIRT
 option(BUILD_SKIRT "build SKIRT, advanced radiative transfer" ON)

--- a/SKIRT/core/ClumpyGeometryDecorator.cpp
+++ b/SKIRT/core/ClumpyGeometryDecorator.cpp
@@ -27,8 +27,9 @@ void ClumpyGeometryDecorator::setupSelfAfter()
 
 double ClumpyGeometryDecorator::density(Position bfr) const
 {
-    double rhosmooth = (1.0 - _clumpFraction) * _geometry->density(bfr);
+    double rhosmooth = _geometry->density(bfr);
     if (_cutoffClumps && !rhosmooth) return 0.0;  // don't allow clumps outside of smooth distribution
+    rhosmooth *= (1.0 - _clumpFraction);
 
     double rhoclumpy = 0.0;
     double Mclump = _clumpFraction / _numClumps;  // total mass per clump

--- a/SKIRT/core/FilePolarizedPointSource.hpp
+++ b/SKIRT/core/FilePolarizedPointSource.hpp
@@ -23,6 +23,12 @@ class ContSED;
     user-configured properties to specify the position of the point source, the orientation of the
     symmetry axis of the angular dependence, and a "bulk" velocity.
 
+    <em>Luminosity normalization</em>
+
+    The luminosity normalization property of this class can be configured in the ski file as usual,
+    keeping in mind that the given value refers to the (specific or wavelength-integrated)
+    luminosity integrated over the unit sphere.
+
     <em>Inclination angle</em>
 
     For the purposes of this class, the inclination angle \f$\theta\f$ is defined as the angle


### PR DESCRIPTION
**Description**
This pull request fixes a few minor issues:
 
- The `ClumpyGeometryDecorator` now allows the fraction of the mass locked up in clumps to be 1 (previously, this would not work if the _cutoffClumps_ option was turned on).

- Build-time deprecation warnings issued by recent versions of `CMake` are now avoided.

- The "duplicate libraries" warning issued by some recent linkers (e.g. by Apple clang 15 on macOS) is now avoided when using `CMake` version **3.29.2** or higher (so you may need to upgrade CMake to get rid of this warning).

