### PR TITLE
Add observer info to output of distant instruments

### DIFF
--- a/SKIRT/core/DistantInstrument.cpp
+++ b/SKIRT/core/DistantInstrument.cpp
@@ -14,6 +14,9 @@ void DistantInstrument::setupSelfBefore()
 {
     Instrument::setupSelfBefore();
 
+    // pass the observer angles to the flux recorder
+    instrumentFluxRecorder()->setObserverAngles(_inclination, _azimuth, _roll);
+
     // configure the flux recorder with the appropriate frame and distances
     if (distance() > 0.)
     {

--- a/SKIRT/core/FITSInOut.cpp
+++ b/SKIRT/core/FITSInOut.cpp
@@ -164,9 +164,9 @@ void FITSInOut::write(string filepath, const Array& data, string dataUnits, int 
         ffpkyd(fptr, "CROTA2", obsInfo->azimuth, 9, "Azimuth angle, in deg", &status);
         ffpkyd(fptr, "CROTA3", obsInfo->roll, 9, "Roll angle, in deg", &status);
         ffpkyd(fptr, "REDSHIFT", obsInfo->redshift, 9, "Redshift (if zero, distances are equal)", &status);
-        ffpkyd(fptr, "DISTANGD", obsInfo->angularDiameterDistance, 9, "Angular diameter distance", &status);
         ffpkyd(fptr, "DISTLUMI", obsInfo->luminosityDistance, 9, "Luminosity distance", &status);
-        ffpkys(fptr, "DISTUNIT", const_cast<char*>(obsInfo->distanceUnits.c_str()), "Units of the distances", &status);
+        ffpkyd(fptr, "DISTANGD", obsInfo->angularDiameterDistance, 9, "Angular diameter distance", &status);
+        ffpkys(fptr, "DISTUNIT", const_cast<char*>(obsInfo->distanceUnits.c_str()), "Units of distances", &status);
     }
     if (status) report_error(filepath, "writing", status);
 

--- a/SKIRT/core/FITSInOut.cpp
+++ b/SKIRT/core/FITSInOut.cpp
@@ -33,7 +33,7 @@ void FITSInOut::read(const SimulationItem* item, string filename, Array& data, i
 
 void FITSInOut::write(const SimulationItem* item, string description, string filename, const Array& data,
                       string dataUnits, int nx, int ny, double incx, double incy, double xc, double yc, string xyUnits,
-                      const Array& z, string zUnits)
+                      const Array& z, string zUnits, const ObserverInfo* obsInfo)
 {
     // Only write the FITS file if this process is the root
     if (ProcessManager::isRoot())
@@ -42,7 +42,7 @@ void FITSInOut::write(const SimulationItem* item, string description, string fil
         string filepath = item->find<FilePaths>()->output(filename + ".fits");
 
         // Write the FITS file
-        FITSInOut::write(filepath, data, dataUnits, nx, ny, incx, incy, xc, yc, xyUnits, z, zUnits);
+        FITSInOut::write(filepath, data, dataUnits, nx, ny, incx, incy, xc, yc, xyUnits, z, zUnits, obsInfo);
 
         // Log the file path
         item->find<Log>()->info(item->typeAndName() + " wrote " + description + " to FITS file " + filepath);
@@ -105,7 +105,7 @@ void FITSInOut::read(string filepath, Array& data, int& nx, int& ny, int& nz)
 ////////////////////////////////////////////////////////////////////
 
 void FITSInOut::write(string filepath, const Array& data, string dataUnits, int nx, int ny, double incx, double incy,
-                      double xc, double yc, string xyUnits, const Array& z, string zUnits)
+                      double xc, double yc, string xyUnits, const Array& z, string zUnits, const ObserverInfo* obsInfo)
 {
     // Get the z-axis size
     //   0:  a single frame that is not part of a datacube
@@ -158,6 +158,16 @@ void FITSInOut::write(string filepath, const Array& data, string dataUnits, int 
     ffpkys(fptr, "CUNIT2", const_cast<char*>(xyUnits.c_str()), "Physical units of the Y-axis", &status);
     ffpkys(fptr, "CTYPE2", " ", "Linear Y coordinates", &status);
     if (nz) ffpkys(fptr, "CUNIT3", const_cast<char*>(zUnits.c_str()), "Physical units of the Z-axis", &status);
+    if (obsInfo)
+    {
+        ffpkyd(fptr, "CROTA1", obsInfo->inclination, 9, "Inclination angle, in deg", &status);
+        ffpkyd(fptr, "CROTA2", obsInfo->azimuth, 9, "Azimuth angle, in deg", &status);
+        ffpkyd(fptr, "CROTA3", obsInfo->roll, 9, "Roll angle, in deg", &status);
+        ffpkyd(fptr, "REDSHIFT", obsInfo->redshift, 9, "Redshift (if zero, distances are equal)", &status);
+        ffpkyd(fptr, "DISTANGD", obsInfo->angularDiameterDistance, 9, "Angular diameter distance", &status);
+        ffpkyd(fptr, "DISTLUMI", obsInfo->luminosityDistance, 9, "Luminosity distance", &status);
+        ffpkys(fptr, "DISTUNIT", const_cast<char*>(obsInfo->distanceUnits.c_str()), "Units of the distances", &status);
+    }
     if (status) report_error(filepath, "writing", status);
 
     // Write the array of pixels to the image

--- a/SKIRT/core/FITSInOut.hpp
+++ b/SKIRT/core/FITSInOut.hpp
@@ -26,6 +26,18 @@ public:
         function in this class. */
     static void read(const SimulationItem* item, string filename, Array& data, int& nx, int& ny, int& nz);
 
+    /** This basic data structure holds information on the observer associated with a data cube
+        being written. These fields are included in the FITS header as a convenience to the user.
+        Note: if the redshift is zero, the angular-diameter and luminosity distances must be equal.
+        */
+    struct ObserverInfo
+    {
+        double inclination{0}, azimuth{0}, roll{0};                // must be in degrees, regardless of output units
+        double redshift{0};                                        // if redshift is zero, both distances must be equal
+        double angularDiameterDistance{0}, luminosityDistance{0};  // distances in output units
+        string distanceUnits;                                      // describes distance output units
+    };
+
     /** This function writes a 2D data frame or a 3D data cube to a FITS file in the context of the
         simulation item hierarchy specified through the first argument. This allows the function to
         issue log messages using the human-readable description of the data given as the second
@@ -34,10 +46,10 @@ public:
         the simulation's output path. The output filename should \em not include the filename
         extension nor the simulation prefix. The remaining arguments of this function are the same
         as those described for the basic write() function in this class. Note that the arguments
-        describing the z-axis may be omitted when writing a 2D data frame. */
+        describing the z-axis and observer info may be omitted when writing a 2D data frame. */
     static void write(const SimulationItem* item, string description, string filename, const Array& data,
                       string dataUnits, int nx, int ny, double incx, double incy, double xc, double yc, string xyUnits,
-                      const Array& z = Array(), string zUnits = string());
+                      const Array& z = Array(), string zUnits = string(), const ObserverInfo* obsInfo = nullptr);
 
     // ================== Basic read/write ==================
 
@@ -87,10 +99,11 @@ private:
         specify the number of values in each spatial direction, \em incx and \em incy specify the
         increment between subsequent grid points in each spatial direction, \em xc and \em yc
         specify the center of the frame(s), and \em xyUnits describes the units of the xy-grid
-        increments. Finally, \em z contains the z-axis grid points (often wavelengths), and \em
-        zUnits describes the units of these grid points. */
+        increments. \em z contains the z-axis grid points (often wavelengths), and \em zUnits
+        describes the units of these grid points. Finally, \em obsInfo is a pointer to an optional
+        data structure holding observer information (or the null pointer). */
     static void write(string filepath, const Array& data, string dataUnits, int nx, int ny, double incx, double incy,
-                      double xc, double yc, string xyUnits, const Array& z, string zUnits);
+                      double xc, double yc, string xyUnits, const Array& z, string zUnits, const ObserverInfo* obsInfo);
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/FITSInOut.hpp
+++ b/SKIRT/core/FITSInOut.hpp
@@ -34,7 +34,7 @@ public:
     {
         double inclination{0}, azimuth{0}, roll{0};                // must be in degrees, regardless of output units
         double redshift{0};                                        // if redshift is zero, both distances must be equal
-        double angularDiameterDistance{0}, luminosityDistance{0};  // distances in output units
+        double luminosityDistance{0}, angularDiameterDistance{0};  // distances in output units
         string distanceUnits;                                      // describes distance output units
     };
 

--- a/SKIRT/core/FluxRecorder.cpp
+++ b/SKIRT/core/FluxRecorder.cpp
@@ -473,8 +473,29 @@ void FluxRecorder::calibrateAndWrite()
                 sedArrays.push_back(_recordTotalOnly ? &empty : &_sed[PrimaryScatteredLevel + i]);
             }
 
+        // construct header comment line
+        string header = "# SED at ";
+        header += "inclination " + StringUtils::toString(units->oposangle(_inclination)) + " " + units->uposangle();
+        header += ", azimuth " + StringUtils::toString(units->oposangle(_azimuth)) + " " + units->uposangle();
+        if (_recordPolarization)
+        {
+            header += ", roll " + StringUtils::toString(units->oposangle(_roll)) + " " + units->uposangle();
+        }
+        if (_redshift)
+        {
+            header += ", redshift " + StringUtils::toString(_redshift);
+            header += ", luminosity distance " + StringUtils::toString(units->odistance(_luminosityDistance)) + " "
+                      + units->udistance();
+        }
+        else
+        {
+            header +=
+                ", distance " + StringUtils::toString(units->odistance(_luminosityDistance)) + " " + units->udistance();
+        }
+
         // open the file and add the column headers
         TextOutFile sedFile(_parentItem, _instrumentName + "_sed", "SED");
+        sedFile.writeLine(header);
         sedFile.addColumn("wavelength; " + units->swavelength(), units->uwavelength());
         for (const string& name : sedNames)
         {
@@ -625,8 +646,8 @@ void FluxRecorder::calibrateAndWrite()
             obsInfo->azimuth = _azimuth * (180. / M_PI);
             obsInfo->roll = _roll * (180. / M_PI);
             obsInfo->redshift = _redshift;
-            obsInfo->angularDiameterDistance = units->odistance(_angularDiameterDistance);
             obsInfo->luminosityDistance = units->odistance(_luminosityDistance);
+            obsInfo->angularDiameterDistance = units->odistance(_angularDiameterDistance);
             obsInfo->distanceUnits = units->udistance();
         }
 

--- a/SKIRT/core/FluxRecorder.hpp
+++ b/SKIRT/core/FluxRecorder.hpp
@@ -191,6 +191,11 @@ public:
         information. */
     void setUserFlags(bool recordComponents, int numScatteringLevels, bool recordPolarization, bool recordStatistics);
 
+    /** This function sets the observer angles for a distant instrument associated with this flux
+        recorder. These values are listed in the output files as a convenience to the user but are
+        not otherwise used. This function should not be called for a local instrument. */
+    void setObserverAngles(double inclination, double azimuth, double roll);
+
     /** This function configures the distance of the recorder in the model's rest frame for a
         distant instrument. The specified distance must be nonzero. The client must call either the
         setRestFrameDistance() or setObserverFrameRedshift() functions, not both. This function
@@ -329,6 +334,11 @@ private:
     bool _recordStatistics{false};
     bool _includeFluxDensity{false};
     bool _includeSurfaceBrightness{false};
+
+    // recorder configuration on observer angles, received from client during configuration
+    double _inclination{0};
+    double _azimuth{0};
+    double _roll{0};
 
     // recorder configuration on distance and redshift, received from client during configuration
     double _redshift{0};


### PR DESCRIPTION
**Description**
With this update, parallel-projected instruments such as Frame and SED instruments add information on the observer sight line and model-observer distance to the output files, as a convenience to the user.

Specifically, FITS file headers now include additional keywords in the file header as in the following example:

        CROTA1  =      4.500000000E+01 / Inclination angle, in deg                      
        CROTA2  =      4.500000000E+01 / Azimuth angle, in deg                          
        CROTA3  =      3.000000000E+01 / Roll angle, in deg                             
        REDSHIFT=      2.000000000E+00 / Redshift (if zero, distances are equal)        
        DISTLUMI=      1.607026089E+04 / Luminosity distance                            
        DISTANGD=      1.785584544E+03 / Angular diameter distance                      
        DISTUNIT= 'Mpc     '           / Units of distances                             

Similarly, SED column text files now include a header line as in the following example:

        # SED at inclination 45 deg, azimuth 45 deg, redshift 2, luminosity distance 16070.26089 Mpc

**Motivation**
This information may facilitate automated processing of the SKIRT output without the need for referring to the ski file. The feature was suggested by user @djsavic.

**Compatibility**
The extra header line in SED column text files will break code that skips a predefined number of header lines rather than relying on the `#` prefix to skip all comment lines.

