### PR TITLE
Fix crash during setup when using some grain compositions with stochastic heating

### DIFF
--- a/SKIRT/core/CrystalEnstatiteGrainComposition.cpp
+++ b/SKIRT/core/CrystalEnstatiteGrainComposition.cpp
@@ -30,7 +30,7 @@ string CrystalEnstatiteGrainComposition::resourceNameForOpticalProps() const
 
 string CrystalEnstatiteGrainComposition::resourceNameForEnthalpies() const
 {
-    return "DustEM_aSil_Entalphies";
+    return "DustEM_aSil_Enthalpies";
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/CrystalForsteriteGrainComposition.cpp
+++ b/SKIRT/core/CrystalForsteriteGrainComposition.cpp
@@ -30,7 +30,7 @@ string CrystalForsteriteGrainComposition::resourceNameForOpticalProps() const
 
 string CrystalForsteriteGrainComposition::resourceNameForEnthalpies() const
 {
-    return "DustEM_aSil_Entalphies";
+    return "DustEM_aSil_Enthalpies";
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/MinSilicateGrainComposition.cpp
+++ b/SKIRT/core/MinSilicateGrainComposition.cpp
@@ -30,7 +30,7 @@ string MinSilicateGrainComposition::resourceNameForOpticalProps() const
 
 string MinSilicateGrainComposition::resourceNameForEnthalpies() const
 {
-    return "DustEM_aSil_Entalphies";
+    return "DustEM_aSil_Enthalpies";
 }
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
A spelling error in the resource filename for the enthalpy data caused the following grain compositions to crash during setup when used with stochastic heating:

- `CrystalEnstatiteGrainComposition`
- `CrystalForsteriteGrainComposition`
- `MinSilicateGrainComposition`

This has now been fixed.

**Tests**
The functional tests for all grain compositions were updated to verify the proper resource is being used.

**Context**
This issue was reported by @andreagebek - thank you!
