### PR TITLE
Add Hirashita (2015) grain size distribution

### DIFF
--- a/SKIRT/core/HirashitaLogNormalGrainSizeDistribution.cpp
+++ b/SKIRT/core/HirashitaLogNormalGrainSizeDistribution.cpp
@@ -7,8 +7,9 @@
 
 ////////////////////////////////////////////////////////////////////
 
-HirashitaLogNormalGrainSizeDistribution::HirashitaLogNormalGrainSizeDistribution(SimulationItem* parent, double minSize, double maxSize,
-                                                               double centroid, double width)
+HirashitaLogNormalGrainSizeDistribution::HirashitaLogNormalGrainSizeDistribution(SimulationItem* parent, double minSize,
+                                                                                 double maxSize, double centroid,
+                                                                                 double width)
     : RangeGrainSizeDistribution(minSize, maxSize), _centroid(centroid), _width(width)
 {
     parent->addChild(this);

--- a/SKIRT/core/HirashitaLogNormalGrainSizeDistribution.cpp
+++ b/SKIRT/core/HirashitaLogNormalGrainSizeDistribution.cpp
@@ -1,0 +1,26 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "HirashitaLogNormalGrainSizeDistribution.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+HirashitaLogNormalGrainSizeDistribution::HirashitaLogNormalGrainSizeDistribution(SimulationItem* parent, double minSize, double maxSize,
+                                                               double centroid, double width)
+    : RangeGrainSizeDistribution(minSize, maxSize), _centroid(centroid), _width(width)
+{
+    parent->addChild(this);
+    setup();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double HirashitaLogNormalGrainSizeDistribution::dnda(double a) const
+{
+    double x = log(a / _centroid) / _width;
+    return 1. / pow(a, 4) * exp(-0.5 * x * x);
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/HirashitaLogNormalGrainSizeDistribution.hpp
+++ b/SKIRT/core/HirashitaLogNormalGrainSizeDistribution.hpp
@@ -10,7 +10,7 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** LogNormalGrainSizeDistribution is a GrainSizeDistribution subclass that represents a log-normal
+/** HirashitaLogNormalGrainSizeDistribution is a GrainSizeDistribution subclass that represents a log-normal
     dust grain size distribution of the form \f[ \frac{\text{d}n_\text{D}}{\text{d}a} \propto
     \frac{1}{a^4} \,\exp\left[ - \frac{(\ln(a/a_0))^2}{2\sigma^2} \right] \qquad \text{for}\quad
     a_\text{min} \leq a \leq a_\text{max}. \f]
@@ -24,7 +24,7 @@
 class HirashitaLogNormalGrainSizeDistribution : public RangeGrainSizeDistribution
 {
     ITEM_CONCRETE(HirashitaLogNormalGrainSizeDistribution, RangeGrainSizeDistribution,
-                  "a log-normal dust grain size distribution")
+                  "a Hirashita (2015) log-normal dust grain size distribution")
 
         PROPERTY_DOUBLE(centroid, "the centroid a0 of the log-normal law")
         ATTRIBUTE_QUANTITY(centroid, "grainsize")

--- a/SKIRT/core/HirashitaLogNormalGrainSizeDistribution.hpp
+++ b/SKIRT/core/HirashitaLogNormalGrainSizeDistribution.hpp
@@ -1,0 +1,64 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef HIRASHITALOGNORMALGRAINSIZEDISTRIBUTION_HPP
+#define HIRASHITALOGNORMALGRAINSIZEDISTRIBUTION_HPP
+
+#include "RangeGrainSizeDistribution.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** LogNormalGrainSizeDistribution is a GrainSizeDistribution subclass that represents a log-normal
+    dust grain size distribution of the form \f[ \frac{\text{d}n_\text{D}}{\text{d}a} \propto
+    \frac{1}{a^4} \,\exp\left[ - \frac{(\ln(a/a_0))^2}{2\sigma^2} \right] \qquad \text{for}\quad
+    a_\text{min} \leq a \leq a_\text{max}. \f]
+
+    The size range of the distribution can be configured in the RangeGrainSizeDistribution base
+    class. The remaining two parameters, the centroid \f$a_0\f$ and the width \f$\sigma\f$, can be
+    configured as attributes in this class. The function is scaled arbitrarily.
+
+    The functional form for the grain size distribution implemented by this class is taken from
+    Hirashita (2015) (https://ui.adsabs.harvard.edu/abs/2015MNRAS.447.2937H/abstract).*/
+class HirashitaLogNormalGrainSizeDistribution : public RangeGrainSizeDistribution
+{
+    ITEM_CONCRETE(HirashitaLogNormalGrainSizeDistribution, RangeGrainSizeDistribution,
+                  "a log-normal dust grain size distribution")
+
+        PROPERTY_DOUBLE(centroid, "the centroid a0 of the log-normal law")
+        ATTRIBUTE_QUANTITY(centroid, "grainsize")
+        ATTRIBUTE_MIN_VALUE(centroid, "]0")
+        ATTRIBUTE_MAX_VALUE(centroid, "1 mm]")
+        ATTRIBUTE_DEFAULT_VALUE(centroid, "1 nm")
+
+        PROPERTY_DOUBLE(width, "the width σ of the log-normal law")
+        ATTRIBUTE_MIN_VALUE(width, "]0")
+        ATTRIBUTE_MAX_VALUE(width, "5]")
+        ATTRIBUTE_DEFAULT_VALUE(width, "0.4")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+public:
+    /** This constructor can be invoked by classes that wish to hard-code the creation of a new
+        grain size distribution object of this type (as opposed to creation through the ski file).
+        Before the constructor returns, the newly created object is hooked up as a child to the
+        specified parent in the simulation hierarchy (so it will automatically be deleted), its
+        properties have been initialized to the specified values, and its setup() function has been
+        called. */
+    explicit HirashitaLogNormalGrainSizeDistribution(SimulationItem* parent, double minSize, double maxSize, double centroid,
+                                            double width);
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function returns the value of \f$\frac{\text{d}n_\text{D}}{\text{d}a}\f$ as described
+        in the header for this class (with an arbitrary proportionality factor of one). */
+    double dnda(double a) const override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/HirashitaLogNormalGrainSizeDistribution.hpp
+++ b/SKIRT/core/HirashitaLogNormalGrainSizeDistribution.hpp
@@ -10,17 +10,17 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** HirashitaLogNormalGrainSizeDistribution is a GrainSizeDistribution subclass that represents a log-normal
-    dust grain size distribution of the form \f[ \frac{\text{d}n_\text{D}}{\text{d}a} \propto
-    \frac{1}{a^4} \,\exp\left[ - \frac{(\ln(a/a_0))^2}{2\sigma^2} \right] \qquad \text{for}\quad
-    a_\text{min} \leq a \leq a_\text{max}. \f]
+/** HirashitaLogNormalGrainSizeDistribution is a GrainSizeDistribution subclass that represents a
+    log-normal dust grain size distribution of the form \f[ \frac{\text{d}n_\text{D}}{\text{d}a}
+    \propto \frac{1}{a^4} \,\exp\left[ - \frac{(\ln(a/a_0))^2}{2\sigma^2} \right] \qquad
+    \text{for}\quad a_\text{min} \leq a \leq a_\text{max}. \f]
 
     The size range of the distribution can be configured in the RangeGrainSizeDistribution base
     class. The remaining two parameters, the centroid \f$a_0\f$ and the width \f$\sigma\f$, can be
     configured as attributes in this class. The function is scaled arbitrarily.
 
     The functional form for the grain size distribution implemented by this class is taken from
-    Hirashita (2015) (https://ui.adsabs.harvard.edu/abs/2015MNRAS.447.2937H/abstract).*/
+    Hirashita (2015) (https://ui.adsabs.harvard.edu/abs/2015MNRAS.447.2937H/abstract). */
 class HirashitaLogNormalGrainSizeDistribution : public RangeGrainSizeDistribution
 {
     ITEM_CONCRETE(HirashitaLogNormalGrainSizeDistribution, RangeGrainSizeDistribution,
@@ -48,8 +48,8 @@ public:
         specified parent in the simulation hierarchy (so it will automatically be deleted), its
         properties have been initialized to the specified values, and its setup() function has been
         called. */
-    explicit HirashitaLogNormalGrainSizeDistribution(SimulationItem* parent, double minSize, double maxSize, double centroid,
-                                            double width);
+    explicit HirashitaLogNormalGrainSizeDistribution(SimulationItem* parent, double minSize, double maxSize,
+                                                     double centroid, double width);
 
     //======================== Other Functions =======================
 

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -595,9 +595,9 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<ZubkoSilicateGrainSizeDistribution>();
     ItemRegistry::add<ZubkoGraphiteGrainSizeDistribution>();
     ItemRegistry::add<ZubkoPAHGrainSizeDistribution>();
+    ItemRegistry::add<HirashitaLogNormalGrainSizeDistribution>();
     ItemRegistry::add<FileGrainSizeDistribution>();
     ItemRegistry::add<ListGrainSizeDistribution>();
-    ItemRegistry::add<HirashitaLogNormalGrainSizeDistribution>();
 
     // grain compositions
     ItemRegistry::add<GrainComposition>();

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -102,6 +102,7 @@
 #include "GrainPopulation.hpp"
 #include "HEALPixSkyInstrument.hpp"
 #include "HammerAitoffProjection.hpp"
+#include "HirashitaLogNormalGrainSizeDistribution.hpp"
 #include "HofmeisterPericlaseGrainComposition.hpp"
 #include "HollowRadialVectorField.hpp"
 #include "HyperboloidGeometry.hpp"
@@ -596,6 +597,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<ZubkoPAHGrainSizeDistribution>();
     ItemRegistry::add<FileGrainSizeDistribution>();
     ItemRegistry::add<ListGrainSizeDistribution>();
+    ItemRegistry::add<HirashitaLogNormalGrainSizeDistribution>();
 
     // grain compositions
     ItemRegistry::add<GrainComposition>();


### PR DESCRIPTION
**Description**
We added a new class for dust grain size distributions from Hirashita (2015, https://ui.adsabs.harvard.edu/abs/2015MNRAS.447.2937H/abstract).

**Motivation**
The Hirashita (2015) dust grain size distribution is used for their popular two-size dust model. This grain size distributions has an additional prefactor (one over grain size to the fourth) in front of the "fiducial" log-normal dust grain size distribution in SKIRT.

**Tests**
We have used this grain size distribution to postprocess galaxies from the COLIBRE simulations.

**Guidelines**
-

**Context**
-
