### PR TITLE
Add `SearchTree` Class and integrate with `VoronoiMeshSnapshot`

### DIFF
--- a/SKIRT/core/VoronoiMeshSnapshot.hpp
+++ b/SKIRT/core/VoronoiMeshSnapshot.hpp
@@ -7,6 +7,7 @@
 #define VORONOIMESHSNAPSHOT_HPP
 
 #include "Array.hpp"
+#include "SearchTree.hpp"
 #include "Snapshot.hpp"
 class PathSegmentGenerator;
 class SiteListInterface;
@@ -192,6 +193,11 @@ private:
         and buildSearch() functions. */
     class Node;
 
+    /** This private function removes cells that satisfy a specified condition. The function 
+        iterates over all indices of the sites/cells and checks the \em removeIndex predicate. 
+        If the condition is met, the corresponding Cell and site position are deleted. */
+    int removeCells(std::function<bool(int m)> removeIndex);
+
     /** Given a list of generating sites (represented as partially initialized Cell
         objects), this private function builds the Voronoi tessellation and stores the
         corresponding cell information, including any properties relevant for supporting the
@@ -220,10 +226,6 @@ private:
         either by building a Voronoi tessellation, or by deriving the volume from mass and mass
         density columns being imported. */
     void calculateDensityAndMass();
-
-    /** Private function to recursively build a binary search tree (see
-        en.wikipedia.org/wiki/Kd-tree) */
-    Node* buildTree(vector<int>::iterator first, vector<int>::iterator last, int depth) const;
 
     /** This private function builds data structures that allow accelerating the operation of the
         cellIndex() function. It assumes that the Voronoi mesh has already been built.
@@ -456,6 +458,7 @@ private:
     bool _foregoVoronoiMesh{false};  // true if using search tree instead of Voronoi tessellation
 
     // data members initialized when processing snapshot input and further completed by BuildMesh()
+    vector<Vec> _sites;    // site positions, indexed on m
     vector<Cell*> _cells;  // cell objects, indexed on m
 
     // data members initialized when processing snapshot input, but only if a density policy has been set
@@ -468,7 +471,7 @@ private:
     int _nb2{0};                      // nb*nb
     int _nb3{0};                      // nb*nb*nb
     vector<vector<int>> _blocklists;  // list of cell indices per block, indexed on i*_nb2+j*_nb+k
-    vector<Node*> _blocktrees;        // root node of search tree or null for each block, indexed on i*_nb2+j*_nb+k
+    vector<SearchTree> _blocktrees;   // root node of search tree or null for each block, indexed on i*_nb2+j*_nb+k
 
     // allow our path segment generator to access our private data members
     class MySegmentGenerator;

--- a/SKIRT/utils/SearchTree.cpp
+++ b/SKIRT/utils/SearchTree.cpp
@@ -1,0 +1,251 @@
+#include "SearchTree.hpp"
+#include "FatalError.hpp"
+
+using Node = SearchTree::Node;
+
+namespace
+{
+    // returns the square of its argument
+    inline double sqr(double x)
+    {
+        return x * x;
+    }
+
+    // function to compare two points according to the specified axis (0,1,2)
+    inline bool lessthan(Vec p1, Vec p2, int axis)
+    {
+        switch (axis)
+        {
+            case 0:  // split on x
+                if (p1.x() < p2.x()) return true;
+                if (p1.x() > p2.x()) return false;
+                if (p1.y() < p2.y()) return true;
+                if (p1.y() > p2.y()) return false;
+                if (p1.z() < p2.z()) return true;
+                return false;
+            case 1:  // split on y
+                if (p1.y() < p2.y()) return true;
+                if (p1.y() > p2.y()) return false;
+                if (p1.z() < p2.z()) return true;
+                if (p1.z() > p2.z()) return false;
+                if (p1.x() < p2.x()) return true;
+                return false;
+            case 2:  // split on z
+                if (p1.z() < p2.z()) return true;
+                if (p1.z() > p2.z()) return false;
+                if (p1.x() < p2.x()) return true;
+                if (p1.x() > p2.x()) return false;
+                if (p1.y() < p2.y()) return true;
+                return false;
+            default:  // this should never happen
+                return false;
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////
+
+SearchTree::~SearchTree()
+{
+    delete _root;
+}
+
+////////////////////////////////////////////////////////////////////
+
+SearchTree::SearchTree() {}
+
+////////////////////////////////////////////////////////////////////
+
+void SearchTree::buildTree(const vector<Vec>& nodePositions)
+{
+    vector<int> indices(nodePositions.size());
+    std::iota(indices.begin(), indices.end(), 0);  // just use loop for clarity?
+    _root = buildTree(nodePositions, indices.begin(), indices.end(), 0);
+}
+
+////////////////////////////////////////////////////////////////////
+
+void SearchTree::buildTree(const vector<Vec>& nodePositions, vector<int>& indices)
+{
+    _root = buildTree(nodePositions, indices.begin(), indices.end(), 0);
+}
+
+////////////////////////////////////////////////////////////////////
+
+Node* SearchTree::buildTree(const vector<Vec>& nodePositions, const vector<int>::iterator first,
+                            const vector<int>::iterator last, int depth) const
+{
+    auto length = last - first;
+    if (length > 0)
+    {
+        auto median = length >> 1;
+        std::nth_element(first, first + median, last, [&nodePositions, depth](int m1, int m2) {
+            return m1 != m2 && lessthan(nodePositions[m1], nodePositions[m2], depth % 3);
+        });
+        return new Node(*(first + median), depth, buildTree(nodePositions, first, first + median, depth + 1),
+                        buildTree(nodePositions, first + median + 1, last, depth + 1));
+    }
+    return nullptr;
+}
+
+////////////////////////////////////////////////////////////////////F
+
+int SearchTree::nearest(Vec& bfr, const vector<Vec>& nodePositions) const
+{
+    return _root->nearest(bfr, nodePositions)->m();
+}
+
+////////////////////////////////////////////////////////////////////F
+
+Node* SearchTree::root() const
+{
+    return _root;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Node::Node(int m, int depth, Node* left, Node* right) : _m(m), _axis(depth % 3), _up(0), _left(left), _right(right)
+{
+    if (_left) _left->setParent(this);
+    if (_right) _right->setParent(this);
+}
+
+////////////////////////////////////////////////////////////////////
+
+Node::~Node()
+{
+    delete _left;
+    delete _right;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void Node::setParent(Node* up)
+{
+    _up = up;
+}
+
+////////////////////////////////////////////////////////////////////
+
+int Node::m() const
+{
+    return _m;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Node* Node::up() const
+{
+    return _up;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Node* Node::left() const
+{
+    return _left;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Node* Node::right() const
+{
+    return _right;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Node* Node::child(Vec bfr, const vector<Vec>& nodePositions) const
+{
+    return lessthan(bfr, nodePositions[_m], _axis) ? _left : _right;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Node* Node::otherChild(Vec bfr, const vector<Vec>& nodePositions) const
+{
+    return lessthan(bfr, nodePositions[_m], _axis) ? _right : _left;
+}
+
+////////////////////////////////////////////////////////////////////
+
+const Vec& Node::position(const vector<Vec>& nodePositions) const
+{
+    return nodePositions[_m];
+}
+
+////////////////////////////////////////////////////////////////////
+
+double Node::squaredDistanceToSplitPlane(Vec bfr, const vector<Vec>& nodePositions) const
+{
+    switch (_axis)
+    {
+        case 0:  // split on x
+            return sqr(nodePositions[_m].x() - bfr.x());
+        case 1:  // split on y
+            return sqr(nodePositions[_m].y() - bfr.y());
+        case 2:  // split on z
+            return sqr(nodePositions[_m].z() - bfr.z());
+        default:  // this should never happen
+            return 0;
+    }
+}
+
+////////////////////////////////////////////////////////////////////
+
+Node* Node::nearest(Vec bfr, const vector<Vec>& nodePositions)
+{
+    // recursively descend the tree until a leaf node is reached, going left or right depending on
+    // whether the specified point is less than or greater than the current node in the split dimension
+    Node* current = this;
+    Node* child = current->child(bfr, nodePositions);
+    while (child)
+    {
+        current = child;
+        child = current->child(bfr, nodePositions);
+    }
+
+    // unwind the recursion, looking for the nearest node while climbing up
+    Node* best = current;
+    Vec bestPos = best->position(nodePositions);
+    double bestSD = (bestPos - bfr).norm2();
+    while (true)
+    {
+        // if the current node is closer than the current best, then it becomes the current best
+        Vec currentPos = current->position(nodePositions);
+        double currentSD = (currentPos - bfr).norm2();
+        if (currentSD < bestSD)
+        {
+            best = current;
+            bestSD = currentSD;
+        }
+
+        // if there could be points on the other side of the splitting plane for the current node
+        // that are closer to the search point than the current best, then ...
+        double splitSD = current->squaredDistanceToSplitPlane(bfr, nodePositions);
+        if (splitSD < bestSD)
+        {
+            // move down the other branch of the tree from the current node looking for closer points,
+            // following the same recursive process as the entire search
+            Node* other = current->otherChild(bfr, nodePositions);
+            if (other)
+            {
+                Node* otherBest = other->nearest(bfr, nodePositions);
+                Vec otherBestPos = otherBest->position(nodePositions);
+                double otherBestSD = (otherBestPos - bfr).norm2();
+                if (otherBestSD < bestSD)
+                {
+                    best = otherBest;
+                    bestSD = otherBestSD;
+                }
+            }
+        }
+
+        // move up to the parent until we meet the top node
+        if (current == this) break;
+        current = current->up();
+    }
+    return best;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/SearchTree.hpp
+++ b/SKIRT/utils/SearchTree.hpp
@@ -1,0 +1,133 @@
+
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef SEARCHTREE_HPP
+#define SEARCHTREE_HPP
+
+#include "Box.hpp"
+#include "Vec.hpp"
+#include <functional>
+
+/** The SearchTree class represents a \f$k\f$-d tree \f$(k=3)\f$ used for efficient spatial searches. 
+    It organizes a set of 3-dimensional points, \em Vec, to allow for efficiently querying the nearest
+    neighbor given some input \em Vec. This functionality is implemented in the \em nearest(Vec). For 
+    more information, see the Wikipedia page on \f$k\f$-d trees: https://en.wikipedia.org/wiki/K-d_tree
+    
+    Each node in the tree is represented by the nested \em SearchTree::Node class. */
+class SearchTree
+
+{
+public:
+    // forward declaration of the Node class
+    class Node;
+
+    //================= Construction - Destruction - Moving =================
+
+    /** Recursively destroys the search tree by deleting the root. */
+    ~SearchTree();
+
+    /** Constructor that initializes an empty SearchTree. It is not ready for queries until the tree is built
+        using one of the buildTree functions. */
+    SearchTree();
+
+    /** Builds a SearchTree with the all node positions. */
+    void buildTree(const vector<Vec>& nodePositions);
+
+    /** Builds a SearchTree with the specified node positions. This will reorder the indices
+        in the process of building the tree, the resulting order is not specified. */
+    void buildTree(const vector<Vec>& nodePositions, vector<int>& indices);
+
+private:
+    /** Recursively builds the k-d tree from the specified range of points. The depth determines
+        the axis along which the space is partitioned at each level of the tree. */
+    Node* buildTree(const vector<Vec>& nodePositions, vector<int>::iterator first, vector<int>::iterator last,
+                    int depth) const;
+
+    //================= Interrogation =================
+
+public:
+    /** Returns the index that represents the node nearest to the query point. It recursively descends the 
+        tree to find the nearest neighbor of the \em _nodePositions. */
+    int nearest(Vec& bfr, const vector<Vec>& nodePositions) const;
+
+    Node* root() const;
+
+    //================= Node Class =================
+
+public:
+    /** The Node class represents a node in the \f$k\f$-d tree \f$(k=3)\f$. Each node stores an index to a point in
+        the dataset, the axis along which the space is partitioned at that node, and pointers to
+        its parent and two child nodes. */
+    class Node
+    {
+    private:
+        //================= Node: Construction - Destruction =================
+
+        /** Constructor that initializes a node with the specified site index, depth, and child
+            pointers. The depth determines the axis along which the space is partitioned. */
+        Node(int m, int depth, Node* left, Node* right);
+
+        /** Destructor that deletes the children of the node. */
+        ~Node();
+
+        /** Sets the parent pointer for the node. This function is called from the parent's
+            constructor. */
+        void setParent(Node* up);
+
+        //================= Node: Interrogation =================
+
+        /** Returns the site index stored in the node. */
+        int m() const;
+
+        /** Returns a pointer to the parent node. */
+        Node* up() const;
+
+        /** Returns a pointer to the left child node. */
+        Node* left() const;
+
+        /** Returns a pointer to the right child node. */
+        Node* right() const;
+
+        /** Returns the appropriate child node for the specified query point. The child is
+            determined based on the partitioning axis and the position of the query point. */
+        Node* child(Vec bfr, const vector<Vec>& nodePositions) const;
+
+        /** Returns the other child node than the one that would be appropriate for the specified
+            query point. This function is used during the search process to explore both sides of
+            the partitioning plane. */
+        Node* otherChild(Vec bfr, const vector<Vec>& nodePositions) const;
+
+        /** Returns the positions of the site represented by this node. */
+        const Vec& position(const vector<Vec>& nodePositions) const;
+
+        /** Returns the squared distance from the query point to the partitioning plane at this
+            node. This distance is used to determine whether to explore the other side of the
+            partitioning plane during the search process. */
+        double squaredDistanceToSplitPlane(Vec bfr, const vector<Vec>& nodePositions) const;
+
+        /** Returns the node in this subtree that represents the site nearest to the query point.
+            The search process recursively descends the tree, unwinding the recursion to find the
+            nearest neighbor. */
+        Node* nearest(Vec bfr, const vector<Vec>& nodePositions);
+
+        //================= Node: Data Mebers =================
+
+        int _m;        // index in the _nodePositions vector
+        int _axis;     // split axis for this node (0,1,2)
+        Node* _up;     // pointer to the parent node
+        Node* _left;   // pointer to the left child node
+        Node* _right;  // pointer to the right child node
+
+        friend class SearchTree;  // only allow SearchTree to access private members
+    };
+
+    //================= Data Members =================
+
+private:
+    Node* _root{nullptr};  // pointer to the root node
+};
+
+#endif


### PR DESCRIPTION
**Description**
Introduced a new `SearchTree` class in the `utils/` directory, implemented as a general-purpose k-d tree. The class provides a spatial data structure for efficient nearest-neighbor searches to an input position in `O(log(N))` time.

Additionally, the `VoronoiMeshSnapshot` class has been updated to replace its private nested `Node` class with the new `SearchTree`.

**Motivation**
The upcoming Tetrahedral grid requires a k-d search tree. Moving the search tree implementation to a shared class improves code maintainability. This class is now also available for future features requiring k-d tree functionality.

**Tests**
All tests passed, including all Voronoi tests that rely on the new `SearchTree`. No additional tests were deemed necessary, as the current tests sufficiently cover the implementation of the `SearchTree`.

**Code Guidelines**
Efforts were made to adhere to SKIRT guidelines. Feel free to highlight any required corrections.

**Additional changes to `VoronoiMeshSnapshot`**
- The `Cell` class no longer stores the site positions. Instead, these are maintained in a separate field: `std::vector<Vec> _sites`. This change was necessary to allow for the generic implementation of `SearchTree`, which operates on a `std::vector` of node positions. The `_blocktrees` and `_blocklists` remain within the `VoronoiMeshSnapshot` class, as these are only relevant when the Voronoi cell or its bounding box are available for every node. Since a node belongs to a block precisely if its Voronoi cell (or bounding box for simplicity) intersects that block.
- A new `removeCells` method ensures that `_cells` and `_sites` remain synchronized when cells are removed.
- The `buildMesh` function previously used `std::sort`  for efficiently finding cells that were too close. This sort now has to be applied to both `_cells` and `_sites`, ensuring consistent ordering between the two. The current approach may seem somewhat convoluted, but it remains efficient.