### PR TITLE
Properly sample all properties from imported particle media

### DIFF
--- a/SKIRT/core/AdaptiveMeshSnapshot.cpp
+++ b/SKIRT/core/AdaptiveMeshSnapshot.cpp
@@ -11,9 +11,7 @@
 #include "PathSegmentGenerator.hpp"
 #include "Random.hpp"
 #include "SpatialGridPath.hpp"
-#include "StringUtils.hpp"
 #include "TextInFile.hpp"
-#include "Units.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
@@ -369,13 +367,6 @@ int AdaptiveMeshSnapshot::cellIndex(Position bfr) const
 const Array& AdaptiveMeshSnapshot::properties(int m) const
 {
     return _cells[m]->properties();
-}
-
-////////////////////////////////////////////////////////////////////
-
-int AdaptiveMeshSnapshot::nearestEntity(Position bfr) const
-{
-    return cellIndex(bfr);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/AdaptiveMeshSnapshot.hpp
+++ b/SKIRT/core/AdaptiveMeshSnapshot.hpp
@@ -228,10 +228,6 @@ protected:
         range, the behavior is undefined. */
     const Array& properties(int m) const override;
 
-    /** This function returns the index \f$0\le m \le N_\mathrm{ent}-1\f$ of the cell containing
-        the specified point \f${\bf{r}}\f$, or -1 if the point is outside the domain. */
-    int nearestEntity(Position bfr) const override;
-
 public:
     /** This function sets the specified entity collection to the cell containing the specified
         point \f${\bf{r}}\f$, or to the empty collection if the point is outside the domain. */

--- a/SKIRT/core/CellSnapshot.cpp
+++ b/SKIRT/core/CellSnapshot.cpp
@@ -10,7 +10,6 @@
 #include "Random.hpp"
 #include "StringUtils.hpp"
 #include "TextInFile.hpp"
-#include "Units.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
@@ -400,13 +399,6 @@ Position CellSnapshot::generatePosition() const
 const Array& CellSnapshot::properties(int m) const
 {
     return _propv[m];
-}
-
-////////////////////////////////////////////////////////////////////
-
-int CellSnapshot::nearestEntity(Position bfr) const
-{
-    return _grid ? _grid->cellIndexFor(bfr) : -1;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/CellSnapshot.hpp
+++ b/SKIRT/core/CellSnapshot.hpp
@@ -109,11 +109,6 @@ protected:
         range, the behavior is undefined. */
     const Array& properties(int m) const override;
 
-    /** This function returns the index \f$0\le m \le N_\mathrm{ent}-1\f$ of the cell containing
-        the specified point \f${\bf{r}}\f$, or -1 if the point is outside the domain, if there are
-        no cells in the snapshot, or if the search data structures were not created. */
-    int nearestEntity(Position bfr) const override;
-
 public:
     /** This function sets the specified entity collection to the cell containing the specified
         point \f${\bf{r}}\f$, or to the empty collection if the point is outside the domain or if

--- a/SKIRT/core/ParticleSnapshot.cpp
+++ b/SKIRT/core/ParticleSnapshot.cpp
@@ -11,7 +11,6 @@
 #include "SmoothingKernel.hpp"
 #include "StringUtils.hpp"
 #include "TextInFile.hpp"
-#include "Units.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
@@ -210,24 +209,6 @@ public:
         int j = NR::locateClip(_ygrid, r.y());
         int k = NR::locateClip(_zgrid, r.z());
         return _listv[index(_m, i, j, k)];
-    }
-
-    /** This function returns a pointer to the particle centered nearest to the specified position,
-        or the null pointer if the specified position is outside of the grid. */
-    const Particle* nearestParticle(Vec r) const
-    {
-        const Particle* nearestParticle = nullptr;
-        double nearestSquaredDistance = std::numeric_limits<double>::infinity();
-        for (const Particle* particle : particlesFor(r))
-        {
-            double d2 = (r - particle->center()).norm2();
-            if (d2 < nearestSquaredDistance)
-            {
-                nearestParticle = particle;
-                nearestSquaredDistance = d2;
-            }
-        }
-        return nearestParticle;
     }
 
     /** This function replaces the contents of the specified entity collection by the set of
@@ -551,14 +532,6 @@ Position ParticleSnapshot::generatePosition() const
 const Array& ParticleSnapshot::properties(int m) const
 {
     return _propv[m];
-}
-
-////////////////////////////////////////////////////////////////////
-
-int ParticleSnapshot::nearestEntity(Position bfr) const
-{
-    const Particle* nearestParticle = _grid ? _grid->nearestParticle(bfr) : nullptr;
-    return nearestParticle ? nearestParticle->index() : -1;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ParticleSnapshot.hpp
+++ b/SKIRT/core/ParticleSnapshot.hpp
@@ -108,12 +108,6 @@ protected:
         of range, the behavior is undefined. */
     const Array& properties(int m) const override;
 
-    /** This function returns the index \f$0\le m \le N_\mathrm{ent}-1\f$ of the particle whose
-        center is nearest to the specified point \f${\bf{r}}\f$, or -1 if the point is outside the
-        domain, if there are no particles in the snapshot, or if the search data structures were
-        not created. */
-    int nearestEntity(Position bfr) const override;
-
 public:
     /** This function replaces the contents of the specified entity collection by the set of
         particles with a smoothing kernel that overlaps the specified point \f${\bf{r}}\f$. The

--- a/SKIRT/core/Snapshot.cpp
+++ b/SKIRT/core/Snapshot.cpp
@@ -313,16 +313,6 @@ double Snapshot::velocityDispersion(int m) const
 
 ////////////////////////////////////////////////////////////////////
 
-double Snapshot::velocityDispersion(Position bfr) const
-{
-    thread_local EntityCollection entities;  // can be reused for all queries in a given execution thread
-    getEntities(entities, bfr);
-    return entities.averageValue([this](int m) { return velocityDispersion(m); },
-                                 [this](int m) { return currentMass(m); });
-}
-
-////////////////////////////////////////////////////////////////////
-
 Vec Snapshot::magneticField(int m) const
 {
     const auto& propv = properties(m);

--- a/SKIRT/core/Snapshot.cpp
+++ b/SKIRT/core/Snapshot.cpp
@@ -4,6 +4,7 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "Snapshot.hpp"
+#include "EntityCollection.hpp"
 #include "Log.hpp"
 #include "Random.hpp"
 #include "StringUtils.hpp"
@@ -242,25 +243,9 @@ double Snapshot::initialMass(int m) const
 
 ////////////////////////////////////////////////////////////////////
 
-double Snapshot::initialMass(Position bfr) const
-{
-    int m = nearestEntity(bfr);
-    return m >= 0 ? initialMass(m) : 0.;
-}
-
-////////////////////////////////////////////////////////////////////
-
 double Snapshot::currentMass(int m) const
 {
     return properties(m)[currentMassIndex()];
-}
-
-////////////////////////////////////////////////////////////////////
-
-double Snapshot::currentMass(Position bfr) const
-{
-    int m = nearestEntity(bfr);
-    return m >= 0 ? currentMass(m) : 0.;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -274,8 +259,9 @@ double Snapshot::metallicity(int m) const
 
 double Snapshot::metallicity(Position bfr) const
 {
-    int m = nearestEntity(bfr);
-    return m >= 0 ? metallicity(m) : 0.;
+    thread_local EntityCollection entities;  // can be reused for all queries in a given execution thread
+    getEntities(entities, bfr);
+    return entities.averageValue([this](int m) { return metallicity(m); }, [this](int m) { return currentMass(m); });
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -283,14 +269,6 @@ double Snapshot::metallicity(Position bfr) const
 double Snapshot::age(int m) const
 {
     return properties(m)[ageIndex()];
-}
-
-////////////////////////////////////////////////////////////////////
-
-double Snapshot::age(Position bfr) const
-{
-    int m = nearestEntity(bfr);
-    return m >= 0 ? age(m) : 0.;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -304,8 +282,9 @@ double Snapshot::temperature(int m) const
 
 double Snapshot::temperature(Position bfr) const
 {
-    int m = nearestEntity(bfr);
-    return m >= 0 ? temperature(m) : 0.;
+    thread_local EntityCollection entities;  // can be reused for all queries in a given execution thread
+    getEntities(entities, bfr);
+    return entities.averageValue([this](int m) { return temperature(m); }, [this](int m) { return currentMass(m); });
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -320,8 +299,9 @@ Vec Snapshot::velocity(int m) const
 
 Vec Snapshot::velocity(Position bfr) const
 {
-    int m = nearestEntity(bfr);
-    return m >= 0 ? velocity(m) : Vec();
+    thread_local EntityCollection entities;  // can be reused for all queries in a given execution thread
+    getEntities(entities, bfr);
+    return entities.averageValue([this](int m) { return velocity(m); }, [this](int m) { return currentMass(m); });
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -335,8 +315,10 @@ double Snapshot::velocityDispersion(int m) const
 
 double Snapshot::velocityDispersion(Position bfr) const
 {
-    int m = nearestEntity(bfr);
-    return m >= 0 ? velocityDispersion(m) : 0.;
+    thread_local EntityCollection entities;  // can be reused for all queries in a given execution thread
+    getEntities(entities, bfr);
+    return entities.averageValue([this](int m) { return velocityDispersion(m); },
+                                 [this](int m) { return currentMass(m); });
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -351,8 +333,9 @@ Vec Snapshot::magneticField(int m) const
 
 Vec Snapshot::magneticField(Position bfr) const
 {
-    int m = nearestEntity(bfr);
-    return m >= 0 ? magneticField(m) : Vec();
+    thread_local EntityCollection entities;  // can be reused for all queries in a given execution thread
+    getEntities(entities, bfr);
+    return entities.averageValue([this](int m) { return magneticField(m); }, [this](int m) { return currentMass(m); });
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -369,7 +352,22 @@ void Snapshot::parameters(int m, Array& params) const
 
 void Snapshot::parameters(Position bfr, Array& params) const
 {
-    int m = nearestEntity(bfr);
+    thread_local EntityCollection entities;  // can be reused for all queries in a given execution thread
+    getEntities(entities, bfr);
+
+    // look for the entity with the highest weight
+    double wmax = 0.;
+    int m = -1;
+    for (const auto& entity : entities)
+    {
+        if (entity.second > wmax)
+        {
+            wmax = entity.second;
+            m = entity.first;
+        }
+    }
+
+    // if found, use it
     if (m >= 0)
         parameters(m, params);
     else

--- a/SKIRT/core/Snapshot.hpp
+++ b/SKIRT/core/Snapshot.hpp
@@ -359,13 +359,6 @@ protected:
         range, the behavior is undefined. */
     virtual const Array& properties(int m) const = 0;
 
-    /** This function returns the index \f$0\le m \le N_\mathrm{ent}-1\f$ for the entity at or
-        nearest to the specified point \f${\bf{r}}\f$, or -1 if the point is outside the domain or
-        if there are no entities in the snapshot. For a cell-based snapshot, the function returns
-        the index of the cell containing the given point. For a particle-based snapshot, the
-        function returns the index of the particle whose center is nearest to the given point. */
-    virtual int nearestEntity(Position bfr) const = 0;
-
 public:
     /** This function replaces the contents of the specified entity collection by the set of
         entities that overlap the specified point \f${\bf{r}}\f$, with their corresponding weights.
@@ -407,11 +400,6 @@ public:
         range, the behavior is undefined. */
     double initialMass(int m) const;
 
-    /** This function returns the initial mass of the entity nearest to (or at) the specified point
-        \f${\bf{r}}\f$. If the point is outside the domain, the function returns zero. If the
-        initial mass is not being imported, the behavior is undefined. */
-    double initialMass(Position bfr) const;
-
     /** This function returns true if the current mass is being imported, and false otherwise. */
     bool hasCurrentMass() const { return _currentMassIndex >= 0; }
 
@@ -419,11 +407,6 @@ public:
         N_\mathrm{ent}-1\f$. If the current mass is not being imported, or the index is out of
         range, the behavior is undefined. */
     double currentMass(int m) const;
-
-    /** This function returns the current mass of the entity nearest to (or at) the specified point
-        \f${\bf{r}}\f$. If the point is outside the domain, the function returns zero. If the
-        current mass is not being imported, the behavior is undefined. */
-    double currentMass(Position bfr) const;
 
     /** This function returns true if the metallicity is being imported, and false otherwise. */
     bool hasMetallicity() const { return _metallicityIndex >= 0; }
@@ -433,7 +416,7 @@ public:
         range, the behavior is undefined. */
     double metallicity(int m) const;
 
-    /** This function returns the metallicity of the entity nearest to (or at) the specified point
+    /** This function returns the metallicity at the specified point
         \f${\bf{r}}\f$. If the point is outside the domain, the function returns zero. If the
         metallicity is not being imported, the behavior is undefined. */
     double metallicity(Position bfr) const;
@@ -446,11 +429,6 @@ public:
         */
     double age(int m) const;
 
-    /** This function returns the age of the entity nearest to (or at) the specified point
-        \f${\bf{r}}\f$. If the point is outside the domain, the function returns zero. If the age
-        is not being imported, the behavior is undefined. */
-    double age(Position bfr) const;
-
     /** This function returns true if the temperature is being imported, and false otherwise. */
     bool hasTemperature() const { return _temperatureIndex >= 0; }
 
@@ -459,7 +437,7 @@ public:
         range, the behavior is undefined. */
     double temperature(int m) const;
 
-    /** This function returns the temperature of the entity nearest to (or at) the specified point
+    /** This function returns the temperature at the specified point
         \f${\bf{r}}\f$. If the point is outside the domain, the function returns zero. If the
         temperature is not being imported, the behavior is undefined. */
     double temperature(Position bfr) const;
@@ -472,7 +450,7 @@ public:
         the behavior is undefined. */
     Vec velocity(int m) const;
 
-    /** This function returns the velocity of the entity nearest to (or at) the specified point
+    /** This function returns the velocity at the specified point
         \f${\bf{r}}\f$. If the point is outside the domain, the function returns zero velocity. If
         the velocity is not being imported, the behavior is undefined. */
     Vec velocity(Position bfr) const;
@@ -486,7 +464,7 @@ public:
         of range, the behavior is undefined. */
     double velocityDispersion(int m) const;
 
-    /** This function returns the velocity dispersion of the entity nearest to (or at) the
+    /** This function returns the velocity dispersion at the
         specified point \f${\bf{r}}\f$. If the point is outside the domain, the function returns
         zero dispersion. If the velocity dispersion is not being imported, the behavior is
         undefined. */
@@ -500,7 +478,7 @@ public:
         range, the behavior is undefined. */
     Vec magneticField(int m) const;
 
-    /** This function returns the magnetic field vector of the entity nearest to (or at) the
+    /** This function returns the magnetic field vector at the
         specified point \f${\bf{r}}\f$. If the point is outside the domain, the function returns a
         zero magnetic field. If the magnetic field is not being imported, the behavior is
         undefined. */
@@ -515,7 +493,7 @@ public:
         index is out of range, the behavior is undefined. */
     void parameters(int m, Array& params) const;
 
-    /** This function stores the parameters of the entity nearest to (or at) the specified point
+    /** This function stores the parameters at the specified point
         \f${\bf{r}}\f$ into the given array. If the point is outside the domain, the function
         returns the appropriate number of zero parameter values. If parameters are not being
         imported, the behavior is undefined. */

--- a/SKIRT/core/Snapshot.hpp
+++ b/SKIRT/core/Snapshot.hpp
@@ -464,12 +464,6 @@ public:
         of range, the behavior is undefined. */
     double velocityDispersion(int m) const;
 
-    /** This function returns the velocity dispersion at the
-        specified point \f${\bf{r}}\f$. If the point is outside the domain, the function returns
-        zero dispersion. If the velocity dispersion is not being imported, the behavior is
-        undefined. */
-    double velocityDispersion(Position bfr) const;
-
     /** This function returns true if the magnetic field is being imported, and false otherwise. */
     bool hasMagneticField() const { return _magneticFieldIndex >= 0; }
 

--- a/SKIRT/core/VoronoiMeshSnapshot.cpp
+++ b/SKIRT/core/VoronoiMeshSnapshot.cpp
@@ -19,7 +19,6 @@
 #include "StringUtils.hpp"
 #include "Table.hpp"
 #include "TextInFile.hpp"
-#include "Units.hpp"
 #include <set>
 #include "container.hh"
 
@@ -1104,13 +1103,6 @@ int VoronoiMeshSnapshot::cellIndex(Position bfr) const
 const Array& VoronoiMeshSnapshot::properties(int m) const
 {
     return _cells[m]->properties();
-}
-
-////////////////////////////////////////////////////////////////////
-
-int VoronoiMeshSnapshot::nearestEntity(Position bfr) const
-{
-    return _blocktrees.size() ? cellIndex(bfr) : -1;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/VoronoiMeshSnapshot.hpp
+++ b/SKIRT/core/VoronoiMeshSnapshot.hpp
@@ -346,11 +346,6 @@ protected:
         range, the behavior is undefined. */
     const Array& properties(int m) const override;
 
-    /** This function returns the index \f$0\le m \le N_\mathrm{ent}-1\f$ of the cell containing
-        the specified point \f${\bf{r}}\f$, or -1 if the point is outside the domain, if there
-        are no cells in the snapshot, or if the search data structures were not created. */
-    int nearestEntity(Position bfr) const override;
-
 public:
     /** This function sets the specified entity collection to the cell containing the specified
         point \f${\bf{r}}\f$, or to the empty collection if the point is outside the domain or if

--- a/SKIRT/utils/EntityCollection.cpp
+++ b/SKIRT/utils/EntityCollection.cpp
@@ -63,6 +63,19 @@ std::pair<double, double> EntityCollection::average(std::function<double(int m)>
 
 ////////////////////////////////////////////////////////////////////
 
+double EntityCollection::averageValue(std::function<double(int)> value, std::function<double(int)> weight)
+{
+    auto numEntities = _entities.size();
+    if (numEntities == 0) return 0.;
+    if (numEntities == 1) return value(_entities.cbegin()->first);
+
+    double sumvw, sumw;
+    std::tie(sumvw, sumw) = average(value, weight);
+    return sumw > 0. ? sumvw / sumw : 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
 std::pair<Vec, double> EntityCollection::average(std::function<Vec(int m)> value, std::function<double(int m)> weight)
 {
     Vec sumvw;
@@ -75,6 +88,20 @@ std::pair<Vec, double> EntityCollection::average(std::function<Vec(int m)> value
         sumw += w;
     }
     return std::make_pair(sumvw, sumw);
+}
+
+////////////////////////////////////////////////////////////////////
+
+Vec EntityCollection::averageValue(std::function<Vec(int)> value, std::function<double(int)> weight)
+{
+    auto numEntities = _entities.size();
+    if (numEntities == 0) return Vec();
+    if (numEntities == 1) return value(_entities.cbegin()->first);
+
+    Vec sumvw;
+    double sumw;
+    std::tie(sumvw, sumw) = average(value, weight);
+    return sumw > 0. ? sumvw / sumw : Vec();
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/EntityCollection.hpp
+++ b/SKIRT/utils/EntityCollection.hpp
@@ -83,6 +83,17 @@ public:
         \f$\sum_m \omega(m)\,w_m\f$. */
     std::pair<double, double> average(std::function<double(int m)> value, std::function<double(int m)> weight);
 
+    /** This function returns the weighted average of a given scalar field \f$f(m)\f$ with given
+        external weight \f$\omega(m)\f$ over all entities in the collection. The arguments
+        respectively specify the scalar field \f$f(m)\f$ and the corresponding external weight
+        \f$\omega(m)\f$. These functions should return the field value respectively the external
+        weight corresponding to a given entity index.
+
+        The function combines the external weights with the weights stored internally for each
+        entity in the collection. Specifically, it calculates \f$\sum_m f(m)\,\omega(m)\,w_m /
+        \sum_m \omega(m)\,w_m\f$. */
+    double averageValue(std::function<double(int m)> value, std::function<double(int m)> weight);
+
     /** This function returns the nominator and denominator for the weighted average of a given
         vector field \f${\bf{f}}(m)\f$ with given external weight \f$\omega(m)\f$ over all entities
         in the collection. The arguments respectively specify the vector field \f${\bf{f}}(m)\f$
@@ -93,6 +104,17 @@ public:
         entity in the collection. Specifically, it calculates \f$\sum_m
         {\bf{f}}(m)\,\omega(m)\,w_m\f$ and \f$\sum_m \omega(m)\,w_m\f$. */
     std::pair<Vec, double> average(std::function<Vec(int m)> value, std::function<double(int m)> weight);
+
+    /** This function returns the weighted average of a given vector field \f${\bf{f}}(m)\f$ with
+        given external weight \f$\omega(m)\f$ over all entities in the collection. The arguments
+        respectively specify the vector field \f${\bf{f}}(m)\f$ and the corresponding external
+        weight \f$\omega(m)\f$. These functions should return the field value respectively the
+        external weight corresponding to a given entity index.
+
+        The function combines the external weights with the weights stored internally for each
+        entity in the collection. Specifically, it calculates \f$\sum_m {\bf{f}}(m)\,\omega(m)\,w_m
+        / \sum_m \omega(m)\,w_m\f$. */
+    Vec averageValue(std::function<Vec(int m)> value, std::function<double(int m)> weight);
 
     // ------- Data members -------
 


### PR DESCRIPTION
**Motivation**
For an imported medium described by _smoothed particles_, when calculating the medium property values in each spatial grid cell during setup,  medium properties other than the medium density were taken from the particle nearest the sample location, rather than interpolating over all overlapping particles. Moreover, in rare cases, the code would use a particle close to the sample location but not the nearest particle.

**Description**
With this new version, medium properties are sampled from an imported particle medium as follows:
- density is properly interpolated over all overlapping particles, as before.
- metallicity, temperature, bulk velocity, and magnetic field are now also properly interpolated over all overlapping particles using density-weighted averaging.
- any additional parameters requested by a material mix or used for selecting a variable material mix are taken from the particle with the highest mass density at the sample location; this is because it is unknown a priori if and how these parameters should be averaged for interpolation. 

**Tests**
All functional tests work. Those affected by the change were adjusted.
