### PR TITLE
Update format checking to clang-format version 18

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,6 @@
 BasedOnStyle: LLVM
 Language: Cpp
 
-TESTERROR: true
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignEscapedNewlines: DontAlign

--- a/.clang-format
+++ b/.clang-format
@@ -4,6 +4,7 @@
 BasedOnStyle: LLVM
 Language: Cpp
 
+TESTERROR: true
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignEscapedNewlines: DontAlign

--- a/.clang-format
+++ b/.clang-format
@@ -1,95 +1,256 @@
-# clang-format version 9.0.0 style options for SKIRT C++ code
-# see https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormat.html
+# clang-format version 18.1 style options for SKIRT C++ code
+# see https://releases.llvm.org/18.1.4/tools/clang/docs/ClangFormat.html
 
-BasedOnStyle: LLVM
-Language: Cpp
-
+---
+Language:        Cpp
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseColons: false
 AlignEscapedNewlines: DontAlign
-AlignOperands: true
-AlignTrailingComments: true
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
 AllowAllArgumentsOnNextLine: true
-AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: true
+AllowShortCompoundRequirementOnASingleLine: true
 AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
 BinPackArguments: true
 BinPackParameters: true
-BreakBeforeBinaryOperators: NonAssignment
-BreakBeforeBraces: Custom
+BitFieldColonSpacing: Both
 BraceWrapping:
-  AfterCaseLabel: true
-  AfterClass: true
-  AfterControlStatement: true
-  AfterEnum: false
-  AfterFunction: true
-  AfterNamespace: true
-  AfterStruct: true
-  AfterUnion: true
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       false
   AfterExternBlock: true
-  BeforeCatch: true
-  BeforeElse: true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
   BeforeLambdaBody: false
-  IndentBraces: false
+  BeforeWhile:     false
+  IndentBraces:    false
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakArrays:     true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
-ColumnLimit: 120
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: false
-IncludeBlocks: Merge
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Merge
 IncludeCategories:
   - Regex:           '^".*\.hpp"'
     Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^".*\.h"'
     Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^<Windows.h>'
     Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^<.*\.h>'
     Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^<.*>'
     Priority:        4
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
 IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
 IndentPPDirectives: AfterHash
-IndentWidth: 4
+IndentRequiresClause: true
+IndentWidth:     4
 IndentWrappedFunctionNames: false
+InsertBraces:    false
 InsertNewlineAtEOF: true
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtEOF: false
 LambdaBodyIndentation: Signature
-MacroBlockBegin: "^(ITEM_CONCRETE)|(ITEM_ABSTRACT)|(ENUM_DEF)$"
-MacroBlockEnd: "^(ITEM_END)|(ENUM_END)$"
+LineEnding:      DeriveLF
+MacroBlockBegin: '^(ITEM_CONCRETE)|(ITEM_ABSTRACT)|(ENUM_DEF)$'
+MacroBlockEnd:   '^(ITEM_END)|(ENUM_END)$'
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
-ReflowComments: false
-SortIncludes: true
-SortUsingDeclarations: true
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  false
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
 SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyParentheses: false
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
 SpacesBeforeTrailingComments: 2
-Standard: Cpp11
-UseTab: Never
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
 ...
+

--- a/.clang-format
+++ b/.clang-format
@@ -55,7 +55,6 @@ AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
@@ -105,7 +104,6 @@ DerivePointerAlignment: false
 DisableFormat:   false
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
-ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: false
 ForEachMacros:
   - foreach
@@ -237,7 +235,7 @@ SpacesInParensOptions:
   InEmptyParentheses: false
   Other:           false
 SpacesInSquareBrackets: false
-Standard:        Latest
+Standard:        c++14
 StatementAttributeLikeMacros:
   - Q_EMIT
 StatementMacros:

--- a/.clang-format
+++ b/.clang-format
@@ -70,7 +70,6 @@ IndentWidth: 4
 IndentWrappedFunctionNames: false
 InsertNewlineAtEOF: true
 KeepEmptyLinesAtTheStartOfBlocks: true
-KeepEmptyLinesAtEOF: false
 LambdaBodyIndentation: Signature
 MacroBlockBegin: "^(ITEM_CONCRETE)|(ITEM_ABSTRACT)|(ENUM_DEF)$"
 MacroBlockEnd: "^(ITEM_END)|(ENUM_END)$"

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -2,7 +2,7 @@
 #
 # The workflow fails if one or more of the .hpp or .cpp files in the repository
 # are not properly formatted according to the rules in the .clang-format file
-# located in the root of the repository directory, using clang-format version 16.
+# located in the root of the repository directory, using clang-format version 18.
 # In that case, the log file provides a list of improperly formatted files.
 # Source files with other extensions (including .h, .c, .hh, .cc) are NOT tested
 # to allow for differently formatted third-party code.
@@ -19,16 +19,19 @@ jobs:
     # job name, displayed in the action log
     name: Check source code formatting
     # run this job on a Github-provided runner with Ubuntu 24.04
-    # because it has clang-format-16 installed
+    # because it has clang-format-18 installed
     runs-on: ubuntu-24.04
     # steps that make up this job
     steps:
     # checkout using a recent version of the checkout action
     - name: Checkout
       uses: actions/checkout@v3
-    # run clang-format on all .hpp and .cpp files
+    # run clang-format on all .hpp and .cpp files, writing any errors to a text file
     - name: Autoformat
-      run: find . \( -name '*.hpp' -or -name '*.cpp' \) -exec clang-format-16 -style=file -i {} \;
+      run: find . \( -name '*.hpp' -or -name '*.cpp' \) -exec clang-format-18 -style=file -i {} 2> formaterror.txt \;
+    # remove the error file if it is empty
+    - name: RemoveEmptyError
+      run: bash -c "if ! [ -s formaterror.txt ] ; then rm -f formaterror.txt ; fi"
     # fail the workflow if anything changed to the repository
     - name: Verify
       run: git diff --stat --no-ext-diff --exit-code

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -31,9 +31,7 @@ jobs:
       run: |
         find . \( -name '*.hpp' -or -name '*.cpp' \) -exec clang-format-18 -style=file -i {} 2> formaterror.txt \;
         cat formaterror.txt
-    # remove the error file if it is empty
-    - name: RemoveEmptyError
-      run: bash -c "if ! [ -s formaterror.txt ] ; then rm -f formaterror.txt ; fi"
+        bash -c "if [ -s formaterror.txt ] ; then exit 1 ; fi"
     # fail the workflow if anything changed to the repository
     - name: Verify
       run: git diff --stat --no-ext-diff --exit-code

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -28,7 +28,9 @@ jobs:
       uses: actions/checkout@v3
     # run clang-format on all .hpp and .cpp files, writing any errors to a text file
     - name: Autoformat
-      run: find . \( -name '*.hpp' -or -name '*.cpp' \) -exec clang-format-18 -style=file -i {} 2> formaterror.txt \;
+      run: |
+        find . \( -name '*.hpp' -or -name '*.cpp' \) -exec clang-format-18 -style=file -i {} 2> formaterror.txt \;
+        cat formaterror.txt
     # remove the error file if it is empty
     - name: RemoveEmptyError
       run: bash -c "if ! [ -s formaterror.txt ] ; then rm -f formaterror.txt ; fi"

--- a/SKIRT/core/AdaptiveMeshGeometry.cpp
+++ b/SKIRT/core/AdaptiveMeshGeometry.cpp
@@ -8,7 +8,7 @@
 
 ////////////////////////////////////////////////////////////////////
 
-Snapshot* AdaptiveMeshGeometry::createAndOpenSnapshot()
+Snapshot*       AdaptiveMeshGeometry::createAndOpenSnapshot()
 {
     // create and open the snapshot
     _adaptiveMeshSnapshot = new AdaptiveMeshSnapshot;

--- a/SKIRT/core/AdaptiveMeshGeometry.cpp
+++ b/SKIRT/core/AdaptiveMeshGeometry.cpp
@@ -8,7 +8,7 @@
 
 ////////////////////////////////////////////////////////////////////
 
-Snapshot*       AdaptiveMeshGeometry::createAndOpenSnapshot()
+Snapshot* AdaptiveMeshGeometry::createAndOpenSnapshot()
 {
     // create and open the snapshot
     _adaptiveMeshSnapshot = new AdaptiveMeshSnapshot;

--- a/SKIRT/core/MultiParallel.cpp
+++ b/SKIRT/core/MultiParallel.cpp
@@ -103,6 +103,7 @@ void MultiParallel::run(int threadIndex)
         try
         {
             while (!_terminate && doSomeWork())
+
                 ;
         }
         catch (FatalError& error)

--- a/formatSourceCode.sh
+++ b/formatSourceCode.sh
@@ -6,57 +6,34 @@
 # Execute this script with "git" as default directory to
 # automatically reformat all C++ code in the SKIRT project
 #
-# Requires clang-format version 16.0 to be installed
-# in the default path, in the home directory, or inside Xcode.
+# Requires clang-format version 18.1 to be installed
+# in the default path.
 #
 
 # --------------------------------------------------------------------
 
-# Look for clang-format or clang-format-16 in various places;
-# exit with an error if we don't find it
-CLANGFORMATPATH="$(which clang-format-16)"
+# Look for clang-format-18 or clang-format
+CLANGFORMATPATH="$(which clang-format-18)"
 if [ "$CLANGFORMATPATH" == "" ]
 then
     CLANGFORMATPATH="$(which clang-format)"
 fi
-if [ "$CLANGFORMATPATH" == "" ]
-then
-    CANDIDATEPATH="$HOME/clang/bin/clang-format-16"
-    if [[ -x $CANDIDATEPATH ]]
-    then
-        CLANGFORMATPATH=$CANDIDATEPATH
-    fi
-fi
-if [ "$CLANGFORMATPATH" == "" ]
-then
-    CANDIDATEPATH="$HOME/clang/bin/clang-format"
-    if [[ -x $CANDIDATEPATH ]]
-    then
-        CLANGFORMATPATH=$CANDIDATEPATH
-    fi
-fi
-if [ "$CLANGFORMATPATH" == "" ]
-then
-    CANDIDATEPATH="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-format"
-    if [[ -x $CANDIDATEPATH ]]
-    then
-        CLANGFORMATPATH=$CANDIDATEPATH
-    fi
-fi
+
+# Exit with an error if we don't find it
 if [ "$CLANGFORMATPATH" == "" ]
 then
     echo
-    echo Fatal error: there is no clang-format in the default path or in ~/clang/bin/
+    echo Fatal error: there is no clang-format in the default path
     echo
     exit
 fi
 
 # Verify the clang-format version
 CLANGFORMATVERSION=$($CLANGFORMATPATH -version)
-if ! [[ $CLANGFORMATVERSION == *"16.0."* ]]
+if ! [[ $CLANGFORMATVERSION == *"18.1."* ]]
 then
     echo
-    echo Fatal error: $CLANGFORMATPATH is not version 16.0 but
+    echo Fatal error: $CLANGFORMATPATH is not version 18.1 but
     echo $CLANGFORMATVERSION
     echo
     exit
@@ -72,6 +49,14 @@ then
 fi
 
 # Format all .hpp and .cpp files, which skips third-party source code because it has a different filename extension
-echo Using $CLANGFORMATPATH...
-find . \( -name '*.hpp' -or -name '*.cpp' \) -exec $CLANGFORMATPATH -style=file -i {} \;
+# We use xargs so that multiple invocation can run in parallel
+echo Using $CLANGFORMATPATH -- $CLANGFORMATVERSION...
+find . \( -name '*.hpp' -or -name '*.cpp' \) -print0 | xargs -0L1 -P0 $CLANGFORMATPATH -style=file -i 2> formaterror.txt
+
+# If the error file is nonempty, show its contents before removing it
+if [ -s formaterror.txt ]
+then
+    cat formaterror.txt
+fi
+rm -f formaterror.txt
 echo Done

--- a/formatSourceCode.sh
+++ b/formatSourceCode.sh
@@ -49,7 +49,7 @@ then
 fi
 
 # Format all .hpp and .cpp files, which skips third-party source code because it has a different filename extension
-# We use xargs so that multiple invocation can run in parallel
+# (we use xargs so that multiple invocations of clang-format can run in parallel)
 echo Using $CLANGFORMATPATH -- $CLANGFORMATVERSION...
 find . \( -name '*.hpp' -or -name '*.cpp' \) -print0 | xargs -0L1 -P0 $CLANGFORMATPATH -style=file -i 2> formaterror.txt
 
@@ -57,6 +57,9 @@ find . \( -name '*.hpp' -or -name '*.cpp' \) -print0 | xargs -0L1 -P0 $CLANGFORM
 if [ -s formaterror.txt ]
 then
     cat formaterror.txt
+    rm -f formaterror.txt
+    echo Failed!
+else
+    rm -f formaterror.txt
+    echo Done
 fi
-rm -f formaterror.txt
-echo Done


### PR DESCRIPTION
**Motivation**
It has become hard to find and install `clang-format` version 9. However, the previous attempt in pull request #227 for updating the `clang-format` version was flawed. Please disregard any information in that pull request.

**Description**
With this pull-request the SKIRT repository is updated to use `clang-format` version 18.1. This is the most recent version that can be easily installed on Ubuntu 24.04 and with some effort on macOS as well.

Specifically:
- The `formatSourceCode.sh` shell script and the GitHub format checking workflow now use `clang-format` version 18.1.
- The `formatSourceCode.sh` shell script now performs the formatting on multiple cores in parallel. 
- The Github format checking workflow now fails in case clang-format fails (e.g. because of an unsupported option).
- The SKIRT source code is updated to the slightly different formatting results.

**Action required for developers**
Developers who wish to contribute to the repository should install `clang-format` version 18.1 on their system **and** include its path in the `PATH` environment variable.
- On Ubuntu, this should be easy using the apt package manager.
- On macOS, the tool must be built from source code using an install tool such as port or brew. The `clang-format` tool included with Xcode is _not_ lined up with official LLVM versions. 
