### PR TITLE
Adjust source code formatting of empty lines

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -156,7 +156,7 @@ IntegerLiteralSeparator:
   HexMinDigits:    0
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtTheStartOfBlocks: false
 KeepEmptyLinesAtEOF: false
 LambdaBodyIndentation: Signature
 LineEnding:      DeriveLF

--- a/.clang-format
+++ b/.clang-format
@@ -103,7 +103,7 @@ Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat:   false
 EmptyLineAfterAccessModifier: Never
-EmptyLineBeforeAccessModifier: LogicalBlock
+EmptyLineBeforeAccessModifier: Always
 FixNamespaceComments: false
 ForEachMacros:
   - foreach

--- a/SKIRT/core/AxPowerLawRedistributeGeometryDecorator.hpp
+++ b/SKIRT/core/AxPowerLawRedistributeGeometryDecorator.hpp
@@ -49,6 +49,7 @@ protected:
     void setupSelfAfter() override;
 
     //======================== Other Functions =======================
+
 public:
     /** The dimension of the geometry after applying the decorator can only change spherical
         geometries into axially symmetric, otherwise it doesn't change the dimension. */

--- a/SKIRT/core/DistantInstrument.hpp
+++ b/SKIRT/core/DistantInstrument.hpp
@@ -113,8 +113,8 @@ public:
 
     //======================== Data Members ========================
 
-    // data members derived from the discoverable properties during setup
 private:
+    // data members derived from the discoverable properties during setup
     Direction _bfkobs;
     Direction _bfky;
 };

--- a/SKIRT/core/MonteCarloSimulation.cpp
+++ b/SKIRT/core/MonteCarloSimulation.cpp
@@ -181,6 +181,7 @@ namespace
     class DustAbsorptionConvergence
     {
         double _prevLabsseco{0.};  // remembers the absorbed luminosity in the previous iteration
+
     public:
         // this function determines and logs the total absorbed luminosity and related percentages
         // it returns true if secondary emission can be considered to be converged, false otherwise

--- a/SKIRT/core/OligoWavelengthDistribution.hpp
+++ b/SKIRT/core/OligoWavelengthDistribution.hpp
@@ -34,7 +34,6 @@ class OligoWavelengthGrid;
     information from this object. */
 class OligoWavelengthDistribution : public WavelengthDistribution
 {
-
     //============= Construction - Setup - Destruction =============
 
 public:

--- a/SKIRT/core/OligoWavelengthGrid.hpp
+++ b/SKIRT/core/OligoWavelengthGrid.hpp
@@ -20,7 +20,6 @@
     specified wavelengths is not important; they will be sorted anyway. */
 class OligoWavelengthGrid : public DisjointWavelengthGrid
 {
-
     //============= Construction - Setup - Destruction =============
 
 public:

--- a/SKIRT/core/SphePowerLawRedistributeGeometryDecorator.hpp
+++ b/SKIRT/core/SphePowerLawRedistributeGeometryDecorator.hpp
@@ -31,6 +31,7 @@ class SphePowerLawRedistributeGeometryDecorator : public RedistributeGeometryDec
     ITEM_END()
 
     //======================== Other Functions =======================
+
 public:
     /** The dimension of the geometry after applying the decorator cannot change and is thus the
         dimension of the original geometry. */

--- a/SKIRT/core/SpheroidalGraphiteGrainComposition.hpp
+++ b/SKIRT/core/SpheroidalGraphiteGrainComposition.hpp
@@ -41,7 +41,6 @@
     through an enum. */
 class SpheroidalGraphiteGrainComposition : public PolarizedGraphiteGrainComposition
 {
-
     ENUM_DEF(TableType, Builtin, OneTable, TwoTables)
         ENUM_VAL(TableType, Builtin, "builtin resources")
         ENUM_VAL(TableType, OneTable, "single custom table")

--- a/SKIRT/core/SpheroidalSilicateGrainComposition.hpp
+++ b/SKIRT/core/SpheroidalSilicateGrainComposition.hpp
@@ -40,7 +40,6 @@
     through an enum. */
 class SpheroidalSilicateGrainComposition : public PolarizedSilicateGrainComposition
 {
-
     ENUM_DEF(TableType, Builtin, OneTable, TwoTables)
         ENUM_VAL(TableType, Builtin, "builtin resources")
         ENUM_VAL(TableType, OneTable, "single custom table")

--- a/SKIRT/core/TetraMeshSpatialGrid.cpp
+++ b/SKIRT/core/TetraMeshSpatialGrid.cpp
@@ -614,7 +614,6 @@ void TetraMeshSpatialGrid::storeTetrahedra(const tetgenio& final, bool storeVert
     _tetrahedra.reserve(_numCells);  // no default constructor for Tetra
     for (int i = 0; i < _numCells; i++)
     {
-
         // vertices
         FourIndices vertexIndices;
         for (int c = 0; c < 4; c++)

--- a/SKIRT/utils/PhotonPacket.hpp
+++ b/SKIRT/utils/PhotonPacket.hpp
@@ -290,8 +290,10 @@ public:
     private:
         friend class PhotonPacket;
         int _h;  // the index of the medium component to which this information record belongs
+
     public:
         ScatteringInfo(int h) : _h{h} {}  // cannot be private because we use emplace_back to construct
+
     public:
         bool valid{false};   // true if this record holds valid values
         bool dipole{false};  // true if scattering as a dipole, false if scattering isotropically

--- a/SKIRT/utils/SpatialGridPath.hpp
+++ b/SKIRT/utils/SpatialGridPath.hpp
@@ -97,6 +97,7 @@ public:
         double _s;            // cumulative distance until cell exit
         double _tauExtOrSca;  // cumulative extinction or scattering optical depth at cell exit
         double _tauAbs;       // cumulative absorption optical depth at cell exit or zero
+
     public:
         Segment(int m, double ds, double s) : _m(m), _ds(ds), _s(s), _tauExtOrSca{0.}, _tauAbs{0.} {}
         int m() const { return _m; }
@@ -178,6 +179,7 @@ public:
     double interactionOpticalDepth() const { return _interactionOpticalDepth; }
 
     // ------- Data members -------
+
 private:
     Position _bfr;
     Direction _bfk;

--- a/SMILE/fundamentals/System.cpp
+++ b/SMILE/fundamentals/System.cpp
@@ -707,7 +707,6 @@ void System::releaseMemoryMap(string path)
         // actually release the memory map only when count has reached zero
         if (!record.count)
         {
-
 #if defined(_WIN64)
             UnmapViewOfFile(record.start);
             CloseHandle(record.maphandle);

--- a/SMILE/fundamentals/System.hpp
+++ b/SMILE/fundamentals/System.hpp
@@ -23,7 +23,6 @@
     destructor, all public functions in this class are static and thread-safe. */
 class System final
 {
-
     // ================== Initialization ==================
 
 private:

--- a/SMILE/shapes/ConvexPolygon.hpp
+++ b/SMILE/shapes/ConvexPolygon.hpp
@@ -21,6 +21,7 @@
 class ConvexPolygon
 {
     // ================== Constants ==================
+
 public:
     /** The maximum number of points that can be held by a polygon object. */
     constexpr static size_t maxPoints = 8;

--- a/SMILE/shapes/ShapeCanvas.cpp
+++ b/SMILE/shapes/ShapeCanvas.cpp
@@ -26,6 +26,7 @@ class ShapeCanvas::GraphicsStateCanvas
     Canvas _canvas;                 // regular canvas
     GraphicsState _cgs;             // current graphics state
     vector<GraphicsState> _gstack;  // graphics state stack
+
 public:
     GraphicsStateCanvas(size_t numPixels) : _canvas(numPixels) {}
     void pushState() { _gstack.push_back(_cgs); }


### PR DESCRIPTION
**Description**
This update tells clang-format to:
  - always put an empty line before an access modifier
  - remove empty lines at the start of a {} block

**Motivation**
Use the new features of clang-format version 18 to further clean up the code.
