### PR TITLE
Add bias to `Snapshot` and Use in `ImportedSource`

### DIFF
--- a/SKIRT/core/AdaptiveMeshSource.hpp
+++ b/SKIRT/core/AdaptiveMeshSource.hpp
@@ -31,11 +31,12 @@
     \f$v_y\f$, \f$v_z\f$ bulk velocity components of the source population represented by the cell.
     If additionally the \em importVelocityDispersion option is enabled, the next column specifies
     the velocity dispersion \f$\sigma_v\f$, adjusting the velocity for each photon packet launch
-    with a random offset sampled from a spherically symmetric Gaussian distribution. If the 
+    with a random offset sampled from a spherically symmetric Gaussian distribution. If the
     \em importCurrentMass option is enabled, the next column provides the current mass of the
     particle, \f$M_\mathrm{curr}\f$. This mass is currently only used for probing the input model.
     If the \em importBias option is enabled, the next column specifies the bias parameter, \f$b\f$,
-    which is used to bias the photon sampling for each particle.
+    which is used to bias the photon sampling for each cell (see the documentation of the
+    ImportedSource class).
 
     The remaining columns specify the parameters required by the configured %SED family to select
     and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining

--- a/SKIRT/core/AdaptiveMeshSource.hpp
+++ b/SKIRT/core/AdaptiveMeshSource.hpp
@@ -24,14 +24,18 @@
     AdaptiveMeshSource instance, including the selected %SEDFamily.
 
     \f[ [ v_x\,(\mathrm{km/s}) \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) \quad [
-    \sigma_v\,(\mathrm{km/s}) ] ] \quad [M_\mathrm{curr}\,(\mathrm{M}_\odot)] \quad \dots
-    \text{SED family parameters}\dots \f]
+    \sigma_v\,(\mathrm{km/s}) ] ] \quad [M_\mathrm{curr}\,(\mathrm{M}_\odot)] \quad b\,(1) \quad
+    \dots \text{SED family parameters}\dots \f]
 
     If the \em importVelocity option is enabled, the first three columns specify the \f$v_x\f$,
     \f$v_y\f$, \f$v_z\f$ bulk velocity components of the source population represented by the cell.
     If additionally the \em importVelocityDispersion option is enabled, the next column specifies
     the velocity dispersion \f$\sigma_v\f$, adjusting the velocity for each photon packet launch
-    with a random offset sampled from a spherically symmetric Gaussian distribution.
+    with a random offset sampled from a spherically symmetric Gaussian distribution. If the 
+    \em importCurrentMass option is enabled, the next column provides the current mass of the
+    particle, \f$M_\mathrm{curr}\f$. This mass is currently only used for probing the input model.
+    If the \em importBias option is enabled, the next column specifies the bias parameter, \f$b\f$,
+    which is used to bias the photon sampling for each particle.
 
     The remaining columns specify the parameters required by the configured %SED family to select
     and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining

--- a/SKIRT/core/CellSource.hpp
+++ b/SKIRT/core/CellSource.hpp
@@ -25,8 +25,9 @@
     \f[ x_\mathrm{min}\,(\mathrm{pc}) \quad y_\mathrm{min}\,(\mathrm{pc}) \quad
     z_\mathrm{min}\,(\mathrm{pc}) \quad x_\mathrm{max}\,(\mathrm{pc}) \quad
     y_\mathrm{max}\,(\mathrm{pc}) \quad z_\mathrm{max}\,(\mathrm{pc}) \quad [ v_x\,(\mathrm{km/s})
-    \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) \quad [ \sigma_v\,(\mathrm{km/s}) ] ]
-    \quad [M_\mathrm{curr}\,(\mathrm{M}_\odot)] \quad \dots \text{SED family parameters}\dots \f]
+    \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) \quad [ \sigma_v\,(\mathrm{km/s}) ]
+    \quad [M_\mathrm{curr}\,(\mathrm{M}_\odot)] \quad b\,(1) \quad \dots \text{SED family parameters}
+    \dots \f]
 
     The first six columns specify the coordinates of the lower-left and upper-right corners of the
     cell. If the \em importVelocity option is enabled, the next three columns specify the
@@ -34,6 +35,10 @@
     by the cell. If additionally the \em importVelocityDispersion option is enabled, the next
     column specifies the velocity dispersion \f$\sigma_v\f$, adjusting the velocity for each photon
     packet launch with a random offset sampled from a spherically symmetric Gaussian distribution.
+    If the \em importCurrentMass option is enabled, the next column provides the current mass of
+    the cell, \f$M_\mathrm{curr}\f$. This mass is currently only used for probing the input model.
+    If the \em importBias option is enabled, the next column specifies the bias parameter, \f$b\f$,
+    which is used to bias the photon sampling for each particle.
 
     The remaining columns specify the parameters required by the configured %SED family to select
     and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining

--- a/SKIRT/core/CellSource.hpp
+++ b/SKIRT/core/CellSource.hpp
@@ -38,7 +38,8 @@
     If the \em importCurrentMass option is enabled, the next column provides the current mass of
     the cell, \f$M_\mathrm{curr}\f$. This mass is currently only used for probing the input model.
     If the \em importBias option is enabled, the next column specifies the bias parameter, \f$b\f$,
-    which is used to bias the photon sampling for each particle.
+    which is used to bias the photon sampling for each cell (see the documentation of the
+    ImportedSource class).
 
     The remaining columns specify the parameters required by the configured %SED family to select
     and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining

--- a/SKIRT/core/ImportedSource.cpp
+++ b/SKIRT/core/ImportedSource.cpp
@@ -6,7 +6,6 @@
 #include "ImportedSource.hpp"
 #include "Band.hpp"
 #include "Configuration.hpp"
-#include "Constants.hpp"
 #include "FatalError.hpp"
 #include "Log.hpp"
 #include "NR.hpp"

--- a/SKIRT/core/ImportedSource.cpp
+++ b/SKIRT/core/ImportedSource.cpp
@@ -70,6 +70,7 @@ void ImportedSource::setupSelfAfter()
         if (_importVelocityDispersion) _snapshot->importVelocityDispersion();
     }
     if (_importCurrentMass) _snapshot->importCurrentMass();
+    if (_importBias) _snapshot->importBias();
     _snapshot->importParameters(_sedFamily->parameterInfo());
 
     // notify about building search data structures if needed
@@ -223,7 +224,7 @@ void ImportedSource::prepareForLaunch(double sourceBias, size_t firstIndex, size
     if (!M) return;
 
     // calculate the launch weight for each entity, normalized to unity
-    _Wv = (1 - sourceBias) * _Lv + sourceBias / M;
+    _Wv = (1 - sourceBias) * _Lv + sourceBias / M; // adjust this formule using the bias
 
     // determine the first history index for each entity
     _Iv.resize(M + 1);

--- a/SKIRT/core/ImportedSource.hpp
+++ b/SKIRT/core/ImportedSource.hpp
@@ -69,6 +69,11 @@ class ImportedSource : public Source
         ATTRIBUTE_DISPLAYED_IF(importCurrentMass, "Level3")
         ATTRIBUTE_INSERT(importCurrentMass, "importCurrentMass:CurrentMass")
 
+        PROPERTY_BOOL(importBias, "import biases for each entity")
+        ATTRIBUTE_DEFAULT_VALUE(importBias, "false")
+        ATTRIBUTE_DISPLAYED_IF(importBias, "Level3")
+        // ATTRIBUTE_INSERT(importBias, "?") // what does INSERT do?
+
         PROPERTY_STRING(useColumns, "a list of names corresponding to columns in the file to be imported")
         ATTRIBUTE_DEFAULT_VALUE(useColumns, "")
         ATTRIBUTE_REQUIRED_IF(useColumns, "false")

--- a/SKIRT/core/ImportedSource.hpp
+++ b/SKIRT/core/ImportedSource.hpp
@@ -72,7 +72,6 @@ class ImportedSource : public Source
         PROPERTY_BOOL(importBias, "import biases for each entity")
         ATTRIBUTE_DEFAULT_VALUE(importBias, "false")
         ATTRIBUTE_DISPLAYED_IF(importBias, "Level3")
-        // ATTRIBUTE_INSERT(importBias, "?") // what does INSERT do?
 
         PROPERTY_STRING(useColumns, "a list of names corresponding to columns in the file to be imported")
         ATTRIBUTE_DEFAULT_VALUE(useColumns, "")
@@ -234,6 +233,8 @@ private:
 
     // intialized by prepareForLaunch()
     Array _Wv;           // the relative launch weight for each entity (normalized to unity)
+    Array _bv;           // the bias for each entity (normalized to unity)
+    Array _Lbv;          // the bias multiplied by luminosity for each entity (normalized to unity)
     vector<size_t> _Iv;  // first history index allocated to each entity (with extra entry at the end)
 };
 

--- a/SKIRT/core/ImportedSource.hpp
+++ b/SKIRT/core/ImportedSource.hpp
@@ -34,16 +34,39 @@ class Snapshot;
     spatial and spectral information for an entity yields its contribution to the imported
     radiation source.
 
-    The input file may include a separate column listing the current mass. When this option is
-    enabled, the provided current mass can be used for probing the input model. This is relevant
-    because %SED families usually do not request the current mass as a parameter (they often use
-    the initial mass instead, or do not include direct mass information at all).
+    The input file may include additional columns as configured by the \em importXXX options
+    offered by this base class. Most importantly, it may include a bulk velocity vector with an
+    optional velocity dispersion for each entity. When this option is enabled, the appropriate
+    Doppler shift is taken into account when launching photon packets. Apart from the anisotropy
+    resulting from this optional Doppler shift, the radiation emitted by this primary source is
+    always isotropic. It is also always unpolarized.
 
-    The input file may also include a bulk velocity vector with an optional velocity dispersion for
-    each entity. When this option is enabled, the appropriate Doppler shift is taken into account
-    when launching photon packets. Apart from the anisotropy resulting from this optional Doppler
-    shift, the radiation emitted by this primary source is always isotropic. It is also always
-    unpolarized. */
+    Furthermore, the input file may include a separate column listing the current mass. When this
+    option is enabled, the provided current mass can be used for probing the input model. This is
+    relevant because %SED families usually do not request the current mass as a parameter (they
+    often use the initial mass instead, or do not include direct mass information at all).
+
+    <em>%Source biasing</em>
+
+    Finally, the input file may include a column specifying a source bias weight for the
+    corresponding entity. These bias weights adjust the (relative) number of photon packets
+    launched from each entity. This can be used to increase sampling in regions of interest, for
+    example to reduce Monte Carlo noise in the low-luminosity outskirts of a galaxy model.
+    Specifically, the number of photon packets \f$N_m\f$ allocated to entity \f$m\f$ is given by
+
+    \f[ N_m =  N_s \left[ (1-\xi) \frac{b_m L_m}{\sum b_m L_m} + \xi \frac{b_m}{\sum b_m} \right] \f]
+
+    where \f$N_s\f$ is the total number of photon packets to be launched by this source, \f$b_m\f$
+    is imported bias weight for entity \f$m\f$, \f$L_m\f$ is the luminosity of entity \f$m\f$, and
+    \f$\xi\f$ is the value of the \em sourceBias property offered by the SourceSystem class.
+    If the \em importBias option for this source is disabled (the default), all bias weights are
+    taken to have a value of \f$b_m=1\f$. The above formule then reduces to
+
+    \f[ N_m =  N_s \left[ (1-\xi) \frac{L_m}{L} + \xi \frac{1}{M} \right] \f]
+
+    where \f$L\f$ is the total luminosity for this source and \f$M\f$ is the total number of
+    entities in this source. In all cases, the value of \f$\xi\f$ shifts between luminosity-weighted
+    (\f$\xi=0\f$) and entity-weighted (\f$\xi=1\f$) or any combination thereof. */
 class ImportedSource : public Source
 {
     ITEM_ABSTRACT(ImportedSource, Source, "a primary source imported from snapshot data")
@@ -69,7 +92,7 @@ class ImportedSource : public Source
         ATTRIBUTE_DISPLAYED_IF(importCurrentMass, "Level3")
         ATTRIBUTE_INSERT(importCurrentMass, "importCurrentMass:CurrentMass")
 
-        PROPERTY_BOOL(importBias, "import biases for each entity")
+        PROPERTY_BOOL(importBias, "import a per-particle/cell source bias weight")
         ATTRIBUTE_DEFAULT_VALUE(importBias, "false")
         ATTRIBUTE_DISPLAYED_IF(importBias, "Level3")
 
@@ -169,22 +192,14 @@ public:
     double meanSpecificLuminosity(const Band* band, int m) const;
 
     /** This function performs some preparations for launching photon packets. It is called in
-         serial mode before each segment of photon packet launches, providing the history indices
-         mapped by the source system to this particular source. See the description of the
-         SourceSystem class for more background information.
+        serial mode before each segment of photon packet launches, providing the history indices
+        mapped by the source system to this particular source. See the description of the
+        SourceSystem class for more background information.
 
-         This function distributes the provided range of history indices over the individual
-         entities imported by this source, creating a map for use when actually launching the
-         photon packets. The number of photon packets allocated to each entity is determined as
-         follows:
-
-         \f[ N_m = \left[ (1-\xi) \frac{L_m}{L} + \xi \frac{1}{M} \right] N_s \f]
-
-         where \f$N_s\f$ is the total number of photon packets to be launched by this source,
-         \f$N_m\f$ is the number of photon packets to be launched by entity \f$m\f$, \f$L_m\f$ is
-         the luminosity of source \f$m\f$, \f$L\f$ is the total luminosity for this source, \f$M\f$
-         is the number of entities in this source, and \f$\xi\f$ is the \em emissionBias property
-         value of the source system. */
+        This function distributes the provided range of history indices over the individual
+        entities imported by this source, creating a map for use when actually launching the photon
+        packets. The number of photon packets allocated to each entity is determined following the
+        scheme described in the header documentation of this class. */
     void prepareForLaunch(double sourceBias, size_t firstIndex, size_t numIndices) override;
 
     /** This function causes the photon packet \em pp to be launched from the source using the

--- a/SKIRT/core/ParticleSnapshot.cpp
+++ b/SKIRT/core/ParticleSnapshot.cpp
@@ -315,13 +315,16 @@ void ParticleSnapshot::readAndClose()
     // if the user configured a mass-density policy, we skip zero-mass particles
     int numTempIgnored = 0;
     int numMassIgnored = 0;
+    int numBiasIgnored = 0;
     Array row;
     while (infile()->readRow(row))
     {
         if (useTemperatureCutoff() && row[temperatureIndex()] > maxTemperature())
             numTempIgnored++;
-        else if (hasMassDensityPolicy() && row[massIndex()] == 0)
+        else if (hasMassDensityPolicy() && row[massIndex()] == 0.)
             numMassIgnored++;
+        else if (hasBias() && row[biasIndex()] == 0.)
+            numBiasIgnored++;
         else
             _propv.push_back(row);
     }
@@ -339,6 +342,7 @@ void ParticleSnapshot::readAndClose()
         if (numTempIgnored)
             log()->info("  Number of high-temperature particles ignored: " + std::to_string(numTempIgnored));
         if (numMassIgnored) log()->info("  Number of zero-mass particles ignored: " + std::to_string(numMassIgnored));
+        if (numBiasIgnored) log()->info("  Number of zero-bias particles ignored: " + std::to_string(numBiasIgnored));
         log()->info("  Number of particles retained: " + std::to_string(_propv.size()));
     }
 

--- a/SKIRT/core/ParticleSnapshot.cpp
+++ b/SKIRT/core/ParticleSnapshot.cpp
@@ -333,7 +333,7 @@ void ParticleSnapshot::readAndClose()
     Snapshot::readAndClose();
 
     // log the number of particles
-    if (!numTempIgnored && !numMassIgnored)
+    if (!numTempIgnored && !numMassIgnored && !numBiasIgnored)
     {
         log()->info("  Number of particles: " + std::to_string(_propv.size()));
     }

--- a/SKIRT/core/ParticleSource.hpp
+++ b/SKIRT/core/ParticleSource.hpp
@@ -37,7 +37,7 @@
     is enabled, the next column provides the current mass of the particle, \f$M_\mathrm{curr}\f$.
     This mass is currently only used for probing the input model. If the \em importBias option is
     enabled, the next column specifies the bias parameter, \f$b\f$, which is used to bias the
-    photon sampling for each particle.
+    photon sampling for each particle (see the documentation of the ImportedSource class).
 
     The remaining columns specify the parameters required by the configured %SED family to select
     and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining

--- a/SKIRT/core/ParticleSource.hpp
+++ b/SKIRT/core/ParticleSource.hpp
@@ -24,8 +24,8 @@
 
     \f[ x\,(\mathrm{pc}) \quad y\,(\mathrm{pc}) \quad z\,(\mathrm{pc}) \quad h\,(\mathrm{pc}) \quad
     [ v_x\,(\mathrm{km/s}) \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) \quad [
-    \sigma_v\,(\mathrm{km/s}) ] ] \quad [M_\mathrm{curr}\,(\mathrm{M}_\odot)] \quad \dots
-    \text{SED family parameters}\dots \f]
+    \sigma_v\,(\mathrm{km/s}) ] \quad [M_\mathrm{curr}\,(\mathrm{M}_\odot)] \quad b\,(1) \quad
+    \dots \text{SED family parameters}\dots \f]
 
     The first three columns are the \f$x\f$, \f$y\f$ and \f$z\f$ coordinates of the particle, and
     the fourth column is the particle smoothing length \f$h\f$. If the \em importVelocity option is
@@ -33,7 +33,11 @@
     components of the source population represented by the particle. If additionally the \em
     importVelocityDispersion option is enabled, the next column specifies the velocity dispersion
     \f$\sigma_v\f$, adjusting the velocity for each photon packet launch with a random offset
-    sampled from a spherically symmetric Gaussian distribution.
+    sampled from a spherically symmetric Gaussian distribution. If the \em importCurrentMass option
+    is enabled, the next column provides the current mass of the particle, \f$M_\mathrm{curr}\f$.
+    This mass is currently only used for probing the input model. If the \em importBias option is
+    enabled, the next column specifies the bias parameter, \f$b\f$, which is used to bias the
+    photon sampling for each particle.
 
     The remaining columns specify the parameters required by the configured %SED family to select
     and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining

--- a/SKIRT/core/Snapshot.cpp
+++ b/SKIRT/core/Snapshot.cpp
@@ -171,6 +171,12 @@ void Snapshot::importMagneticField()
     _infile->addColumn("magnetic field z", "magneticfield", "uG");
 }
 
+void Snapshot::importBias()
+{
+    _biasIndex = _nextIndex++;
+    _infile->addColumn("bias");
+}
+
 ////////////////////////////////////////////////////////////////////
 
 void Snapshot::importParameters(const vector<SnapshotParameter>& parameters)
@@ -326,6 +332,13 @@ Vec Snapshot::magneticField(Position bfr) const
     thread_local EntityCollection entities;  // can be reused for all queries in a given execution thread
     getEntities(entities, bfr);
     return entities.averageValue([this](int m) { return magneticField(m); }, [this](int m) { return currentMass(m); });
+}
+
+////////////////////////////////////////////////////////////////////
+
+double Snapshot::bias(int m) const
+{
+    return properties(m)[biasIndex()];
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/Snapshot.hpp
+++ b/SKIRT/core/Snapshot.hpp
@@ -182,6 +182,9 @@ public:
         components (x,y,z). The default unit is \f$\mu \mathrm{G}\f$. */
     void importMagneticField();
 
+    /** This function configures the snapshot to import a bias for each entity in the snapshot. */
+    void importBias();
+
     /** This function configures the snapshot to import a sequence of parameters as described by
         the specified list of SnapshotParameter metadata objects. */
     void importParameters(const vector<SnapshotParameter>& parameters);
@@ -263,6 +266,10 @@ protected:
     /** This function returns the column index of the first magnetic field field, or -1 if this is
         not being imported, for use by subclasses. */
     int magneticFieldIndex() const { return _magneticFieldIndex; }
+
+    /** This function returns the column index of the bias field, or -1 if this is not being
+        imported, for use by subclasses. */
+    int biasIndex() const { return _biasIndex; }
 
     /** This function returns the column index of the first field in the parameter list, or -1 if
         this is not being imported, for use by subclasses. */
@@ -478,6 +485,14 @@ public:
         undefined. */
     Vec magneticField(Position bfr) const;
 
+    /** This function returns true if the bias is being imported, and false otherwise. */
+    bool hasBias() const { return _biasIndex >= 0; }
+
+    /** This function returns the bias of the entity with index \f$0\le m \le N_\mathrm{ent}-1\f$.
+        If the bias is not being imported, or the index is out of range, the behavior is undefined.
+        */
+    double bias(int m) const;
+
     /** This function returns true if parameters are being imported (i.e. if the number of imported
          parameters is nonzero), and false otherwise. */
     bool hasParameters() const { return _numParameters > 0; }
@@ -538,6 +553,7 @@ private:
     int _velocityIndex{-1};
     int _velocityDispersionIndex{-1};
     int _magneticFieldIndex{-1};
+    int _biasIndex{-1};
     int _parametersIndex{-1};
     int _numParameters{0};
 

--- a/SKIRT/core/VoronoiMeshSource.hpp
+++ b/SKIRT/core/VoronoiMeshSource.hpp
@@ -32,11 +32,12 @@
     components of the source population represented by the cell corresponding to the site. If
     additionally the \em importVelocityDispersion option is enabled, the next column specifies the
     velocity dispersion \f$\sigma_v\f$, adjusting the velocity for each photon packet launch with a
-    random offset sampled from a spherically symmetric Gaussian distribution. If the 
+    random offset sampled from a spherically symmetric Gaussian distribution. If the
     \em importCurrentMass option is enabled, the next column provides the current mass of the
     particle, \f$M_\mathrm{curr}\f$. This mass is currently only used for probing the input model.
     If the \em importBias option is enabled, the next column specifies the bias parameter, \f$b\f$,
-    which is used to bias the photon sampling for each particle.
+    which is used to bias the photon sampling for each cell (see the documentation of the
+    ImportedSource class).
 
     The remaining columns specify the parameters required by the configured %SED family to select
     and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining

--- a/SKIRT/core/VoronoiMeshSource.hpp
+++ b/SKIRT/core/VoronoiMeshSource.hpp
@@ -23,7 +23,8 @@
 
     \f[ x\,(\mathrm{pc}) \quad y\,(\mathrm{pc}) \quad z\,(\mathrm{pc}) \quad [ v_x\,(\mathrm{km/s})
     \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) \quad [ \sigma_v\,(\mathrm{km/s}) ] ]
-    \quad [M_\mathrm{curr}\,(\mathrm{M}_\odot)] \quad \dots \text{SED family parameters}\dots \f]
+    \quad [M_\mathrm{curr}\,(\mathrm{M}_\odot)] \quad b\,(1) \quad \dots \text{SED family parameters}
+    \dots \f]
 
     The first three columns are the \f$x\f$, \f$y\f$ and \f$z\f$ coordinates of the Voronoi site
     (i.e. the location defining a particular Voronoi cell). If the \em importVelocity option is
@@ -31,7 +32,11 @@
     components of the source population represented by the cell corresponding to the site. If
     additionally the \em importVelocityDispersion option is enabled, the next column specifies the
     velocity dispersion \f$\sigma_v\f$, adjusting the velocity for each photon packet launch with a
-    random offset sampled from a spherically symmetric Gaussian distribution.
+    random offset sampled from a spherically symmetric Gaussian distribution. If the 
+    \em importCurrentMass option is enabled, the next column provides the current mass of the
+    particle, \f$M_\mathrm{curr}\f$. This mass is currently only used for probing the input model.
+    If the \em importBias option is enabled, the next column specifies the bias parameter, \f$b\f$,
+    which is used to bias the photon sampling for each particle.
 
     The remaining columns specify the parameters required by the configured %SED family to select
     and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining


### PR DESCRIPTION
**Description**
The `Snapshot` class now supports importing a bias column. This feature is utilized by the `ImportedSource` class to adjust photon counts across its entities, enabling users to prioritize photon launches from specific entities. However this bias may be used by any `Snapshot` in the future.

**Motivation**
Regions with low signal-to-noise ratios are challenging to improve without significantly increasing the number of photons launched. This update provides users with the ability to bias photon counts, allowing them to, for instance, assign higher biases to particles in certain regions. This results in more photons being launched from these regions, improving signal-to-noise.

**Tests**
All existing tests passed, and new tests were added to validate the bias functionality. Manual checks confirmed correct photon counts and luminosities. However, no tests were performed for the `AdaptiveMeshSource`.

**Context**
Documentation was updated to include details about the bias functionality in all classes inheriting from `ImportedSources`. Additionally, documentation for the current mass parameter, which is available to all `ImportedSources`, was also added. A note clarifies that this column is only used for probing. If this documentation feels out of place, it can be removed as needed.