### PR TITLE
Move the code for searching particles/cells into a separate utility class 

### DIFF
--- a/SKIRT/core/CellSnapshot.cpp
+++ b/SKIRT/core/CellSnapshot.cpp
@@ -13,215 +13,11 @@
 
 ////////////////////////////////////////////////////////////////////
 
-namespace
+Box CellSnapshot::boxForCell(int m) const
 {
-    // returns a Box object corresponding to the six elements in the given properties array starting at the given index
-    Box box(const Array& prop, int i)
-    {
-        return Box(prop[i], prop[i + 1], prop[i + 2], prop[i + 3], prop[i + 4], prop[i + 5]);
-    }
-
-    // builds a smart grid in the specified spatial direction (box+0=x, box+1=y, box+2=z) and with the specified size,
-    // and stores it in output parameter "grid", along with the minimum and maximum coordinate enclosing the cells
-    void makegrid(const vector<Array>& propv, int dir, int gridsize, Array& grid, double& cmin, double& cmax)
-    {
-        int n = propv.size();
-
-        // find the spatial range of the cells in the specified direction
-        cmin = +std::numeric_limits<double>::infinity();
-        cmax = -std::numeric_limits<double>::infinity();
-        for (const Array& prop : propv)
-        {
-            cmin = min(cmin, prop[dir]);
-            cmax = max(cmax, prop[dir + 3]);
-        }
-
-        // determine the cell distribution by binning at a decent resolution
-        int nbins = gridsize * 100;
-        double binwidth = (cmax - cmin) / nbins;
-        vector<int> bins(nbins);
-        for (const Array& prop : propv)
-        {
-            double center = 0.5 * (prop[dir] + prop[dir + 3]);
-            bins[static_cast<int>((center - cmin) / binwidth)] += 1;
-        }
-
-        // determine grid separation points based on the cumulative distribution
-        grid.resize(gridsize + 1);
-        grid[0] = -std::numeric_limits<double>::infinity();
-        int percell = n / gridsize;  // target number of particles per cell
-        int cumul = 0;               // cumulative number of particles in processed bins
-        int gridindex = 1;           // index of the next grid separation point to be filled
-        for (int binindex = 0; binindex < nbins; binindex++)
-        {
-            cumul += bins[binindex];
-            if (cumul > percell * gridindex)
-            {
-                grid[gridindex] = cmin + (binindex + 1) * binwidth;
-                gridindex += 1;
-                if (gridindex >= gridsize) break;
-            }
-        }
-        grid[gridsize] = std::numeric_limits<double>::infinity();
-    }
-
-    // returns the linear index for element (i,j,k) in a p*p*p table
-    inline int index(int p, int i, int j, int k)
-    {
-        return ((i * p) + j) * p + k;
-    }
-}
-
-////////////////////////////////////////////////////////////////////
-
-// This is a helper class for organizing cuboidal cells in a smart grid, so that
-// it is easy to retrieve the first cell that overlaps a given point in space.
-// The Box object on which this class is based specifies a cuboid guaranteed to
-// enclose all cells in the grid.
-class CellSnapshot::CellGrid : public Box
-{
-    // data members initialized during construction
-    const vector<Array>& _propv;   // reference to the original list of cells
-    int _i;                        // the box index in the properties list of each cell
-    int _p;                        // number of grid cells in each spatial direction
-    Array _xgrid, _ygrid, _zgrid;  // the m+1 grid separation points for each spatial direction
-    vector<vector<int>> _listv;    // the m*m*m lists of indices for cells overlapping each grid cell
-    int _pmin, _pmax, _ptotal;     // minimum, maximum nr of cells in list; total nr of cells in listv
-
-public:
-    // The constructor creates a cuboidal grid of the specified number of grid cells in each
-    // spatial direction, and for each of the grid cells it builds a list of all cells
-    // overlapping the grid cell. In an attempt to distribute the cells evenly over the
-    // grid cells, the sizes of the grid cells in each spatial direction are chosen so that
-    // the cell centers are evenly distributed over the grid cells.
-    CellGrid(const vector<Array>& propv, int boxindex, int gridsize) : _propv(propv), _i(boxindex), _p(gridsize)
-    {
-        // build the grids in each spatial direction
-        double xmin, ymin, zmin, xmax, ymax, zmax;
-        makegrid(propv, boxindex + 0, gridsize, _xgrid, xmin, xmax);
-        makegrid(propv, boxindex + 1, gridsize, _ygrid, ymin, ymax);
-        makegrid(propv, boxindex + 2, gridsize, _zgrid, zmin, zmax);
-        setExtent(xmin, ymin, zmin, xmax, ymax, zmax);
-
-        // make room for p*p*p grid cells
-        _listv.resize(gridsize * gridsize * gridsize);
-
-        // add each cell to the list for every grid cell that it overlaps
-        int n = propv.size();
-        for (int m = 0; m != n; ++m)
-        {
-            Box cell = box(propv[m], boxindex);
-
-            // find indices for first and last grid cell overlapped by cell, in each spatial direction
-            int i1 = NR::locateClip(_xgrid, cell.xmin());
-            int i2 = NR::locateClip(_xgrid, cell.xmax());
-            int j1 = NR::locateClip(_ygrid, cell.ymin());
-            int j2 = NR::locateClip(_ygrid, cell.ymax());
-            int k1 = NR::locateClip(_zgrid, cell.zmin());
-            int k2 = NR::locateClip(_zgrid, cell.zmax());
-
-            // add the cell to all grid cells in that 3D range
-            for (int i = i1; i <= i2; i++)
-                for (int j = j1; j <= j2; j++)
-                    for (int k = k1; k <= k2; k++)
-                    {
-                        _listv[index(gridsize, i, j, k)].push_back(m);
-                    }
-        }
-
-        // calculate statistics
-        _pmin = n;
-        _pmax = 0;
-        _ptotal = 0;
-        for (int index = 0; index < gridsize * gridsize * gridsize; index++)
-        {
-            int size = _listv[index].size();
-            _pmin = min(_pmin, size);
-            _pmax = max(_pmax, size);
-            _ptotal += size;
-        }
-    }
-
-    // This function returns the smallest number of cells overlapping a single grid cell.
-    int minCellRefsPerCell() const { return _pmin; }
-
-    // This function returns the largest number of cells overlapping a single grid cell.
-    int maxCellRefsPerCell() const { return _pmax; }
-
-    // This function returns the total number of cell references for all cells in the grid.
-    int totalCellRefs() const { return _ptotal; }
-
-    // This function returns the index (in the list originally passed to the constructor)
-    // of the first cell in the list that overlaps the specified position,
-    // or -1 if none of the cells in the list overlap the specified position.
-    int cellIndexFor(Position r) const
-    {
-        // locate the grid cell containing the specified position
-        int i = NR::locateClip(_xgrid, r.x());
-        int j = NR::locateClip(_ygrid, r.y());
-        int k = NR::locateClip(_zgrid, r.z());
-
-        // search the list of cells for that grid cell
-        for (int m : _listv[index(_p, i, j, k)])
-        {
-            if (box(_propv[m], _i).contains(r)) return m;
-        }
-        return -1;
-    }
-
-    // This function replaces the contents of the specified entity collection by the set of cells
-    // that overlap the path with specified starting point and direction.
-    // The weight of a cell is given by the length of the path segment inside the cell.
-    void getEntities(EntityCollection& entities, Position bfr, Direction bfk) const
-    {
-        // use the values in these variables only after an intersection call that returns true
-        double smin, smax;
-
-        // initialize the output collection
-        entities.clear();
-
-        // verify that the path intersects the domain
-        if (extent().intersects(bfr, bfk, smin, smax))
-        {
-            // find the indices for first and last grid cell, in each spatial direction,
-            // overlapped by the bounding box of the path's intersection with the domain
-            Box pathbox(bfr + smin * bfk, bfr + smax * bfk);
-            int i1 = NR::locateClip(_xgrid, pathbox.xmin());
-            int i2 = NR::locateClip(_xgrid, pathbox.xmax());
-            int j1 = NR::locateClip(_ygrid, pathbox.ymin());
-            int j2 = NR::locateClip(_ygrid, pathbox.ymax());
-            int k1 = NR::locateClip(_zgrid, pathbox.zmin());
-            int k2 = NR::locateClip(_zgrid, pathbox.zmax());
-            if (i1 > i2) std::swap(i1, i2);  // fix reversed coords for negative bfk components
-            if (j1 > j2) std::swap(j1, j2);
-            if (k1 > k2) std::swap(k1, k2);
-
-            // loop over all grid cells in that 3D range
-            for (int i = i1; i <= i2; i++)
-                for (int j = j1; j <= j2; j++)
-                    for (int k = k1; k <= k2; k++)
-                    {
-                        // if the path intersects the grid cell
-                        Box gridcellbox(_xgrid[i], _ygrid[j], _zgrid[k], _xgrid[i + 1], _ygrid[j + 1], _zgrid[k + 1]);
-                        if (gridcellbox.intersects(bfr, bfk, smin, smax))
-                        {
-                            // loop over all cells in this grid cell
-                            for (int m : _listv[index(_p, i, j, k)])
-                            {
-                                // if the path intersects the cell, add the cell to the output collection
-                                if (box(_propv[m], _i).intersects(bfr, bfk, smin, smax)) entities.add(m, smax - smin);
-                            }
-                        }
-                    }
-        }
-    }
-};
-
-////////////////////////////////////////////////////////////////////
-
-CellSnapshot::~CellSnapshot()
-{
-    delete _grid;
+    const auto& prop = _propv[m];
+    int i = boxIndex();
+    return Box(prop[i], prop[i + 1], prop[i + 2], prop[i + 3], prop[i + 4], prop[i + 5]);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -264,14 +60,14 @@ void CellSnapshot::readAndClose()
             if (maxT && prop[temperatureIndex()] > maxT)
                 numIgnored++;
             else
-                originalMass = max(0., massIndex() >= 0 ? prop[massIndex()]
-                                                        : prop[densityIndex()] * box(prop, boxIndex()).volume());
+                originalMass =
+                    max(0., massIndex() >= 0 ? prop[massIndex()] : prop[densityIndex()] * boxForCell(m).volume());
 
             double metallicMass = originalMass * (useMetallicity() ? prop[metallicityIndex()] : 1.);
             double effectiveMass = metallicMass * multiplier();
 
             Mv[m] = effectiveMass;
-            _rhov[m] = effectiveMass / box(prop, boxIndex()).volume();
+            _rhov[m] = effectiveMass / boxForCell(m).volume();
 
             totalOriginalMass += originalMass;
             totalMetallicMass += metallicMass;
@@ -288,17 +84,20 @@ void CellSnapshot::readAndClose()
         if (n) NR::cdf(_cumrhov, Mv);
     }
 
-    // if needed, construct a 3D-grid over the domain, and create a list of cells that overlap each grid cell
+    // if needed, construct a a search structure for the cells
     if (hasMassDensityPolicy() || needGetEntities())
     {
-        int gridsize = max(20, static_cast<int>(pow(_propv.size(), 1. / 3.) / 5));
-        string size = std::to_string(gridsize);
-        log()->info("Constructing intermediate " + size + "x" + size + "x" + size + " grid for cells...");
-        _grid = new CellGrid(_propv, boxIndex(), gridsize);
-        log()->info("  Smallest number of cells per grid cell: " + std::to_string(_grid->minCellRefsPerCell()));
-        log()->info("  Largest  number of cells per grid cell: " + std::to_string(_grid->maxCellRefsPerCell()));
-        log()->info("  Average  number of cells per grid cell: "
-                    + StringUtils::toString(_grid->totalCellRefs() / double(gridsize * gridsize * gridsize), 'f', 1));
+        log()->info("Constructing search grid for cells...");
+        auto bounds = [this](int m) { return boxForCell(m); };
+        auto intersects = [this](int m, const Box& box) { return box.intersects(boxForCell(m)); };
+        _search.loadEntities(_propv.size(), bounds, intersects);
+
+        string size = std::to_string(_search.numBlocks());
+        log()->info("  Number of blocks in search grid: " + size + " x " + size + " x " + size);
+        log()->info("  Smallest number of cells per block: " + std::to_string(_search.minEntitiesPerBlock()));
+        log()->info("  Largest  number of cells per block: " + std::to_string(_search.maxEntitiesPerBlock()));
+        log()->info("  Average  number of cells per block: "
+                    + StringUtils::toString(_search.avgEntitiesPerBlock(), 'f', 1));
     }
 }
 
@@ -309,8 +108,8 @@ Box CellSnapshot::extent() const
     // if there are no cells, return an empty box
     if (_propv.empty()) return Box();
 
-    // if there is a cell grid, ask it to return the extent (it is already calculated)
-    if (_grid) return _grid->extent();
+    // if there is a search structure, ask it to return the extent (it is already calculated)
+    if (_search.numBlocks()) return _search.extent();
 
     // otherwise find the spatial range of the cells
     double xmin = +std::numeric_limits<double>::infinity();
@@ -342,7 +141,7 @@ int CellSnapshot::numEntities() const
 
 double CellSnapshot::volume(int m) const
 {
-    return box(_propv[m], boxIndex()).volume();
+    return boxForCell(m).volume();
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -356,7 +155,8 @@ double CellSnapshot::density(int m) const
 
 double CellSnapshot::density(Position bfr) const
 {
-    int m = _grid ? _grid->cellIndexFor(bfr) : -1;
+    auto contains = [this, bfr](int m) { return boxForCell(m).contains(bfr); };
+    int m = _search.firstEntity(bfr, contains);
     return m >= 0 ? _rhov[m] : 0.;
 }
 
@@ -371,14 +171,14 @@ double CellSnapshot::mass() const
 
 Position CellSnapshot::position(int m) const
 {
-    return Position(box(_propv[m], boxIndex()).center());
+    return Position(boxForCell(m).center());
 }
 
 ////////////////////////////////////////////////////////////////////
 
 Position CellSnapshot::generatePosition(int m) const
 {
-    return random()->position(box(_propv[m], boxIndex()));
+    return random()->position(boxForCell(m));
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -405,14 +205,19 @@ const Array& CellSnapshot::properties(int m) const
 
 void CellSnapshot::getEntities(EntityCollection& entities, Position bfr) const
 {
-    entities.addSingle(_grid->cellIndexFor(bfr));
+    auto contains = [this, bfr](int m) { return boxForCell(m).contains(bfr); };
+    entities.addSingle(_search.firstEntity(bfr, contains));
 }
 
 ////////////////////////////////////////////////////////////////////
 
 void CellSnapshot::getEntities(EntityCollection& entities, Position bfr, Direction bfk) const
 {
-    _grid->getEntities(entities, bfr, bfk);
+    auto weight = [this, bfr, bfk](int m) {
+        double smin, smax;
+        return boxForCell(m).intersects(bfr, bfk, smin, smax) ? smax - smin : 0.;
+    };
+    _search.getEntities(entities, bfr, bfk, weight);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/CellSnapshot.cpp
+++ b/SKIRT/core/CellSnapshot.cpp
@@ -87,7 +87,7 @@ void CellSnapshot::readAndClose()
     // if needed, construct a a search structure for the cells
     if (hasMassDensityPolicy() || needGetEntities())
     {
-        log()->info("Constructing search grid for cells...");
+        log()->info("Constructing search grid for " + std::to_string(_propv.size()) + " cells...");
         auto bounds = [this](int m) { return boxForCell(m); };
         auto intersects = [this](int m, const Box& box) { return box.intersects(boxForCell(m)); };
         _search.loadEntities(_propv.size(), bounds, intersects);

--- a/SKIRT/core/CellSnapshot.cpp
+++ b/SKIRT/core/CellSnapshot.cpp
@@ -92,8 +92,8 @@ void CellSnapshot::readAndClose()
         auto intersects = [this](int m, const Box& box) { return box.intersects(boxForCell(m)); };
         _search.loadEntities(_propv.size(), bounds, intersects);
 
-        string size = std::to_string(_search.numBlocks());
-        log()->info("  Number of blocks in search grid: " + size + " x " + size + " x " + size);
+        int nb = _search.numBlocks();
+        log()->info("  Number of blocks in grid: " + std::to_string(nb * nb * nb) + " (" + std::to_string(nb) + "^3)");
         log()->info("  Smallest number of cells per block: " + std::to_string(_search.minEntitiesPerBlock()));
         log()->info("  Largest  number of cells per block: " + std::to_string(_search.maxEntitiesPerBlock()));
         log()->info("  Average  number of cells per block: "

--- a/SKIRT/core/CellSnapshot.cpp
+++ b/SKIRT/core/CellSnapshot.cpp
@@ -84,7 +84,7 @@ void CellSnapshot::readAndClose()
         if (n) NR::cdf(_cumrhov, Mv);
     }
 
-    // if needed, construct a a search structure for the cells
+    // if needed, construct a search structure for the cells
     if (hasMassDensityPolicy() || needGetEntities())
     {
         log()->info("Constructing search grid for " + std::to_string(_propv.size()) + " cells...");

--- a/SKIRT/core/CellSnapshot.hpp
+++ b/SKIRT/core/CellSnapshot.hpp
@@ -6,6 +6,7 @@
 #ifndef CELLSNAPSHOT_HPP
 #define CELLSNAPSHOT_HPP
 
+#include "BoxSearch.hpp"
 #include "Snapshot.hpp"
 
 ////////////////////////////////////////////////////////////////////
@@ -35,10 +36,6 @@
 class CellSnapshot : public Snapshot
 {
     //================= Construction - Destruction =================
-
-public:
-    /** The destructor deletes the search data structure, if it was constructed. */
-    ~CellSnapshot();
 
     //========== Reading ==========
 
@@ -123,6 +120,13 @@ public:
         data structures were not created, invoking this function causes undefined behavior. */
     void getEntities(EntityCollection& entities, Position bfr, Direction bfk) const override;
 
+    //=================== Private helper functions =====================
+
+private:
+    /** This function returns the bounding box representing the cell with the given index. If the
+        index is out of range, the behavior is undefined. */
+    Box boxForCell(int m) const;
+
     //======================== Data Members ========================
 
 private:
@@ -130,13 +134,10 @@ private:
     vector<Array> _propv;  // cell properties as imported
 
     // data members initialized after reading the input file if a density policy has been set
-    Array _rhov;       // density for each cell (not normalized)
-    Array _cumrhov;    // normalized cumulative density distribution for cells
-    double _mass{0.};  // total effective mass
-
-    // data members initialized after reading the input file if a density policy has been set
-    class CellGrid;
-    CellGrid* _grid{nullptr};  // smart grid for locating the cell at a given location
+    Array _rhov;        // density for each cell (not normalized)
+    Array _cumrhov;     // normalized cumulative density distribution for cells
+    double _mass{0.};   // total effective mass
+    BoxSearch _search;  // search structure for locating cells
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -395,7 +395,7 @@ void MediumSystem::setupSelfAfter()
     // calculate the initial aggregate state, if needed
     _state.calculateAggregate();
 
-    log->info("Done calculating cell densities");
+    log->info("Done calculating medium properties");
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ParticleSnapshot.cpp
+++ b/SKIRT/core/ParticleSnapshot.cpp
@@ -177,8 +177,8 @@ void ParticleSnapshot::readAndClose()
         auto intersects = [this](int m, const Box& box) { return box.intersects(_pv[m].center(), _pv[m].radius()); };
         _search.loadEntities(_pv.size(), bounds, intersects);
 
-        string size = std::to_string(_search.numBlocks());
-        log()->info("  Number of blocks in search grid: " + size + " x " + size + " x " + size);
+        int nb = _search.numBlocks();
+        log()->info("  Number of blocks in grid: " + std::to_string(nb * nb * nb) + " (" + std::to_string(nb) + "^3)");
         log()->info("  Smallest number of particles per block: " + std::to_string(_search.minEntitiesPerBlock()));
         log()->info("  Largest  number of particles per block: " + std::to_string(_search.maxEntitiesPerBlock()));
         log()->info("  Average  number of particles per block: "

--- a/SKIRT/core/ParticleSnapshot.cpp
+++ b/SKIRT/core/ParticleSnapshot.cpp
@@ -24,7 +24,7 @@ class ParticleSnapshot::Particle
 public:
     /** The constructor arguments specify the particle attributes: particle index, coordinates of
         the center, smoothing length, and effective mass. */
-    Particle(double x, double y, double z, double h, double M) : _x{x}, _y{y}, _z{z}, _h{h}, _M{M} {}
+    Particle(double x, double y, double z, double h, double M) : _x(x), _y(y), _z(z), _h(h), _M(M) {}
 
     /** This function returns the coordinates of the center of the particle. */
     Vec center() const { return Vec(_x, _y, _z); }

--- a/SKIRT/core/ParticleSnapshot.cpp
+++ b/SKIRT/core/ParticleSnapshot.cpp
@@ -14,31 +14,26 @@
 
 ////////////////////////////////////////////////////////////////////
 
-/** Particle is an almost trivial helper class for working with smoothed particles, usually
+/** Particle is a simple helper class for working with smoothed particles, usually
     imported from a smoothed particle hydrodynamical (SPH) simulation. A Particle object
     holds the particle's center position, smoothing length, and effective mass (after any
     multipliers have been applied). Isolating these properties in a simple object allows efficient
-    storage and retrieval, for example when organizing smoothed particles in a search grid. */
+    storage and retrieval, for example when organizing smoothed particles in a search structure. */
 class ParticleSnapshot::Particle
 {
 public:
     /** The constructor arguments specify the particle attributes: particle index, coordinates of
         the center, smoothing length, and effective mass. */
-    Particle(int m, double x, double y, double z, double h, double M) : _r{x, y, z}, _h(h), _M(M), _m(m) {}
-
-    /** This function returns the index of the particle. */
-    int index() const { return _m; }
+    Particle(double x, double y, double z, double h, double M) : _x{x}, _y{y}, _z{z}, _h{h}, _M{M} {}
 
     /** This function returns the coordinates of the center of the particle. */
-    Vec center() const { return Vec(_r[0], _r[1], _r[2]); }
-
-    /** This function returns the x, y, or z-coordinate of the center of the particle, depending on
-        the value of \em dir: 1->x, 2->y, 3->z. For any other value of \em dir the behavior is
-        undefined. */
-    double center(int dir) const { return _r[dir - 1]; }
+    Vec center() const { return Vec(_x, _y, _z); }
 
     /** This function returns the smoothing length of the particle. */
     double radius() const { return _h; }
+
+    /** This function returns the bounding box of the particle. */
+    Box bounds() const { return Box(_x - _h, _y - _h, _z - _h, _x + _h, _y + _h, _z + _h); }
 
     /** This function returns the mass of the particle. */
     double mass() const { return _M; }
@@ -64,235 +59,9 @@ public:
 
 private:
     // data members received as constructor arguments
-    double _r[3];  // center coordinates
-    double _h;     // smoothing length
-    double _M;     // total mass
-    int _m;        // index
-};
-
-////////////////////////////////////////////////////////////////////
-
-/** ParticleGrid is a helper class for organizing Particle instances in a smart
-    grid, so that it is easy to retrieve a list of all particles that may overlap a particular
-    point in space. The Box object on which this class is based specifies a cuboid guaranteed to
-    enclose all particles in the grid. */
-class ParticleSnapshot::ParticleGrid : public Box
-{
-private:
-    // returns the linear index for cell (i,j,k) in a m*m*m table
-    static inline int index(int m, int i, int j, int k) { return ((i * m) + j) * m + k; }
-
-    // builds a smart grid in the specified spatial direction (1=x, 2=y, 3=z) and with the specified size,
-    // and stores it in output parameter "grid", along with the minimum and maximum coordinate enclosing the particles
-    static void makegrid(const vector<Particle>& pv, int dir, int gridsize, Array& grid, double& cmin, double& cmax)
-    {
-        int n = pv.size();
-
-        // find the spatial range of the particles in the specified direction
-        cmin = +std::numeric_limits<double>::infinity();
-        cmax = -std::numeric_limits<double>::infinity();
-        for (int p = 0; p < n; p++)
-        {
-            cmin = min(cmin, pv[p].center(dir) - pv[p].radius());
-            cmax = max(cmax, pv[p].center(dir) + pv[p].radius());
-        }
-
-        // guard against point sources (h=0) that are all lined up along this coordinate
-        if (cmin == cmax)
-        {
-            double eps = 1e-12 * (cmin ? abs(cmin) : 1.);
-            cmin -= eps;
-            cmax += eps;
-        }
-
-        // determine the particle distribution by binning at a decent resolution
-        int nbins = gridsize * 100;
-        double binwidth = (cmax - cmin) / nbins;
-        vector<int> bins(nbins);
-        for (int p = 0; p < n; p++) bins[int((pv[p].center(dir) - cmin) / binwidth)] += 1;
-
-        // determine grid separation points based on the cumulative distribution
-        grid.resize(gridsize + 1);
-        grid[0] = -std::numeric_limits<double>::infinity();
-        int percell = n / gridsize;  // target number of particles per cell
-        int cumul = 0;               // cumulative number of particles in processed bins
-        int gridindex = 1;           // index of the next grid separation point to be filled
-        for (int binindex = 0; binindex < nbins; binindex++)
-        {
-            cumul += bins[binindex];
-            if (cumul > percell * gridindex)
-            {
-                grid[gridindex] = cmin + (binindex + 1) * binwidth;
-                gridindex += 1;
-                if (gridindex >= gridsize) break;
-            }
-        }
-        grid[gridsize] = std::numeric_limits<double>::infinity();
-    }
-
-public:
-    /** The constructor creates a cuboidal grid of the specified number of grid cells in each
-        spatial direction, and for each of the cells it builds a list of all particles (partially
-        or fully) overlapping the cell. In an attempt to distribute the particles evenly over the
-        cells, the sizes of the grid cells in each spatial direction are chosen so that the
-        particle centers are evenly distributed over the cells. The internal particle lists store
-        pointers to the particle objects contained in the provided list \em pv, so that list
-        must not be modified or deallocated as long as this grid instance exists. */
-    ParticleGrid(const vector<Particle>& pv, int gridsize) : _m(gridsize)
-    {
-        // build the grids in each spatial direction
-        double xmin, ymin, zmin, xmax, ymax, zmax;
-        makegrid(pv, 1, gridsize, _xgrid, xmin, xmax);
-        makegrid(pv, 2, gridsize, _ygrid, ymin, ymax);
-        makegrid(pv, 3, gridsize, _zgrid, zmin, zmax);
-        setExtent(xmin, ymin, zmin, xmax, ymax, zmax);
-
-        // make room for m*m*m cells
-        _listv.resize(gridsize * gridsize * gridsize);
-
-        // add each particle to the list for every cell that it overlaps
-        int n = pv.size();
-        for (int p = 0; p < n; p++)
-        {
-            Vec rc = pv[p].center();
-            double h = pv[p].radius();
-
-            // find indices for first and last cell possibly overlapped by particle, in each spatial direction
-            int i1 = NR::locateClip(_xgrid, rc.x() - h);
-            int i2 = NR::locateClip(_xgrid, rc.x() + h);
-            int j1 = NR::locateClip(_ygrid, rc.y() - h);
-            int j2 = NR::locateClip(_ygrid, rc.y() + h);
-            int k1 = NR::locateClip(_zgrid, rc.z() - h);
-            int k2 = NR::locateClip(_zgrid, rc.z() + h);
-
-            // loop over all cells in that 3D range
-            for (int i = i1; i <= i2; i++)
-                for (int j = j1; j <= j2; j++)
-                    for (int k = k1; k <= k2; k++)
-                    {
-                        // add the particle to the list if it indeed overlaps the cell
-                        Box cell(_xgrid[i], _ygrid[j], _zgrid[k], _xgrid[i + 1], _ygrid[j + 1], _zgrid[k + 1]);
-                        if (cell.intersects(rc, h)) _listv[index(gridsize, i, j, k)].push_back(&pv[p]);
-                    }
-        }
-
-        // calculate statistics
-        _pmin = n;
-        _pmax = 0;
-        _ptotal = 0;
-        for (int index = 0; index < gridsize * gridsize * gridsize; index++)
-        {
-            int size = _listv[index].size();
-            _pmin = min(_pmin, size);
-            _pmax = max(_pmax, size);
-            _ptotal += size;
-        }
-    }
-
-    /** This function returns the smallest number of particles overlapping a single cell. */
-    int minParticlesPerCell() const { return _pmin; }
-
-    /** This function returns the largest number of particles overlapping a single cell. */
-    int maxParticlesPerCell() const { return _pmax; }
-
-    /** This function returns the total number of particle references for all cells in the grid. */
-    int totalParticles() const { return _ptotal; }
-
-    /** This function returns a list of all particles that may overlap the specified position. It
-        locates the cell containing the specified position and returns the list of particles
-        overlapping that cell. Thus the list may include particles that don't actually overlap the
-        specified position. The objective of this class is to make this function very fast, while
-        limiting the number of unnecessary particles in the returned list. */
-    const vector<const Particle*>& particlesFor(Vec r) const
-    {
-        int i = NR::locateClip(_xgrid, r.x());
-        int j = NR::locateClip(_ygrid, r.y());
-        int k = NR::locateClip(_zgrid, r.z());
-        return _listv[index(_m, i, j, k)];
-    }
-
-    /** This function replaces the contents of the specified entity collection by the set of
-        particles with a smoothing kernel that overlaps the specified point \f${\bf{r}}\f$. The
-        weight corresponding to each particle is set to the particle's smoothing kernel value at
-        the given point. If the given point does not overlap any particle, the collection will be
-        empty. */
-    void getEntities(EntityCollection& entities, Vec bfr, const SmoothingKernel* kernel) const
-    {
-        entities.clear();
-        for (const Particle* particle : particlesFor(bfr))
-        {
-            double h = particle->radius();
-            double u = (bfr - particle->center()).norm() / h;
-            // if the point is inside the particle, add the particle to the output collection
-            if (u <= 1.)
-            {
-                double w = kernel->density(u);
-                entities.add(particle->index(), w);
-            }
-        }
-    }
-
-    /** This function replaces the contents of the specified entity collection by the set of
-        particles with a smoothing kernel that overlaps the specified path with starting point
-        \f${\bf{r}}\f$ and direction \f${\bf{k}}\f$. The weight of each particle is given by the
-        effective length seen by the path as it crosses the particle's smoothing kernel. If the
-        path does not overlap any particle, the collection will be empty. */
-    void getEntities(EntityCollection& entities, Vec bfr, Vec bfk, const SmoothingKernel* kernel) const
-    {
-        // use the values in these variables only after a box/path intersection call that returns true
-        double smin, smax;
-
-        // initialize the output collection
-        entities.clear();
-
-        // verify that the path intersects the domain
-        if (extent().intersects(bfr, bfk, smin, smax))
-        {
-            // find the indices for first and last grid cell, in each spatial direction,
-            // overlapped by the bounding box of the path's intersection with the domain
-            Box pathbox(bfr + smin * bfk, bfr + smax * bfk);
-            int i1 = NR::locateClip(_xgrid, pathbox.xmin());
-            int i2 = NR::locateClip(_xgrid, pathbox.xmax());
-            int j1 = NR::locateClip(_ygrid, pathbox.ymin());
-            int j2 = NR::locateClip(_ygrid, pathbox.ymax());
-            int k1 = NR::locateClip(_zgrid, pathbox.zmin());
-            int k2 = NR::locateClip(_zgrid, pathbox.zmax());
-            if (i1 > i2) std::swap(i1, i2);  // fix reversed coords for negative bfk components
-            if (j1 > j2) std::swap(j1, j2);
-            if (k1 > k2) std::swap(k1, k2);
-
-            // loop over all grid cells in that 3D range
-            for (int i = i1; i <= i2; i++)
-                for (int j = j1; j <= j2; j++)
-                    for (int k = k1; k <= k2; k++)
-                    {
-                        // if the path intersects the grid cell
-                        Box gridcellbox(_xgrid[i], _ygrid[j], _zgrid[k], _xgrid[i + 1], _ygrid[j + 1], _zgrid[k + 1]);
-                        if (gridcellbox.intersects(bfr, bfk, smin, smax))
-                        {
-                            // loop over all particles in this grid cell
-                            for (const Particle* particle : _listv[index(_m, i, j, k)])
-                            {
-                                double h = particle->radius();
-                                double q = particle->impact(bfr, bfk) / h;
-
-                                // if the path intersects the particle, add the particle to the output collection
-                                if (q < 1.)
-                                {
-                                    double w = kernel->columnDensity(q) * h;
-                                    entities.add(particle->index(), w);
-                                }
-                            }
-                        }
-                    }
-        }
-    }
-
-private:
-    int _m;                                  // number of grid cells in each spatial direction
-    Array _xgrid, _ygrid, _zgrid;            // the m+1 grid separation points for each spatial direction
-    vector<vector<const Particle*>> _listv;  // the m*m*m lists of particles overlapping each grid cell
-    int _pmin, _pmax, _ptotal;               // minimum, maximum nr of particles in list; total nr of particles in listv
+    double _x, _y, _z;  // center coordinates
+    double _h;          // smoothing length
+    double _M;          // total mass
 };
 
 ////////////////////////////////////////////////////////////////////
@@ -301,10 +70,7 @@ ParticleSnapshot::ParticleSnapshot() {}
 
 ////////////////////////////////////////////////////////////////////
 
-ParticleSnapshot::~ParticleSnapshot()
-{
-    delete _grid;
-}
+ParticleSnapshot::~ParticleSnapshot() {}
 
 ////////////////////////////////////////////////////////////////////
 
@@ -349,7 +115,7 @@ void ParticleSnapshot::readAndClose()
     // if a mass density policy has been set, calculate masses and densities for all cells
     if (hasMassDensityPolicy())
     {
-        // build a list of compact smoothed particle objects that we can organize in a grid
+        // build a list of compact smoothed particle objects that we can organize in a search structure
         double totalOriginalMass = 0;
         double totalMetallicMass = 0;
         double totalEffectiveMass = 0;
@@ -363,7 +129,7 @@ void ParticleSnapshot::readAndClose()
             double metallicMass = originalMass * (useMetallicity() ? prop[metallicityIndex()] : 1.);
             double effectiveMass = metallicMass * multiplier();
 
-            _pv.emplace_back(m, prop[positionIndex() + 0], prop[positionIndex() + 1], prop[positionIndex() + 2],
+            _pv.emplace_back(prop[positionIndex() + 0], prop[positionIndex() + 1], prop[positionIndex() + 2],
                              prop[sizeIndex()], effectiveMass);
 
             totalOriginalMass += originalMass;
@@ -390,7 +156,7 @@ void ParticleSnapshot::readAndClose()
         if (!_pv.empty()) NR::cdf(_cumrhov, _pv.size(), [this](int i) { return _pv[i].mass(); });
     }
 
-    // if needed, build a list of compact particles without masses that we can organize in a grid
+    // if needed, build a list of compact particles without masses that we can organize in a search structure
     if (!hasMassDensityPolicy() && needGetEntities())
     {
         int numParticles = _propv.size();
@@ -398,22 +164,25 @@ void ParticleSnapshot::readAndClose()
         for (int m = 0; m != numParticles; ++m)
         {
             const Array& prop = _propv[m];
-            _pv.emplace_back(m, prop[positionIndex() + 0], prop[positionIndex() + 1], prop[positionIndex() + 2],
+            _pv.emplace_back(prop[positionIndex() + 0], prop[positionIndex() + 1], prop[positionIndex() + 2],
                              prop[sizeIndex()], 0.);
         }
     }
 
-    // if needed, construct a 3D-grid over the domain, and create a list of particles that overlap each grid cell
+    // if needed, construct a search structure for the particles
     if (hasMassDensityPolicy() || needGetEntities())
     {
-        int gridsize = max(20, static_cast<int>(pow(_pv.size(), 1. / 3.) / 5));
-        string size = std::to_string(gridsize);
-        log()->info("Constructing intermediate " + size + "x" + size + "x" + size + " grid for particles...");
-        _grid = new ParticleGrid(_pv, gridsize);
-        log()->info("  Smallest number of particles per cell: " + std::to_string(_grid->minParticlesPerCell()));
-        log()->info("  Largest  number of particles per cell: " + std::to_string(_grid->maxParticlesPerCell()));
-        log()->info("  Average  number of particles per cell: "
-                    + StringUtils::toString(_grid->totalParticles() / double(gridsize * gridsize * gridsize), 'f', 1));
+        log()->info("Constructing search grid for particles...");
+        auto bounds = [this](int m) { return _pv[m].bounds(); };
+        auto intersects = [this](int m, const Box& box) { return box.intersects(_pv[m].center(), _pv[m].radius()); };
+        _search.loadEntities(_pv.size(), bounds, intersects);
+
+        string size = std::to_string(_search.numBlocks());
+        log()->info("  Number of blocks in search grid: " + size + " x " + size + " x " + size);
+        log()->info("  Smallest number of particles per block: " + std::to_string(_search.minEntitiesPerBlock()));
+        log()->info("  Largest  number of particles per block: " + std::to_string(_search.maxEntitiesPerBlock()));
+        log()->info("  Average  number of particles per block: "
+                    + StringUtils::toString(_search.avgEntitiesPerBlock(), 'f', 1));
     }
 }
 
@@ -431,8 +200,8 @@ Box ParticleSnapshot::extent() const
     // if there are no particles, return an empty box
     if (_propv.empty()) return Box();
 
-    // if there is a particle grid, ask it to return the extent (it is already calculated)
-    if (_grid) return _grid->extent();
+    // if there is a search structure, ask it to return the extent (it is already calculated)
+    if (_search.numBlocks()) return _search.extent();
 
     // otherwise find the spatial range of the particles assuming a finite support kernel
     double xmin = +std::numeric_limits<double>::infinity();
@@ -478,14 +247,11 @@ double ParticleSnapshot::density(int m) const
 
 double ParticleSnapshot::density(Position bfr) const
 {
-    double sum = 0.;
-    if (_grid)
-        for (const Particle* p : _grid->particlesFor(bfr))
-        {
-            double h = p->radius();
-            double u = (bfr - p->center()).norm() / h;
-            sum += _kernel->density(u) * p->density();
-        }
+    auto density = [this, bfr](int m) {
+        double u = (bfr - _pv[m].center()).norm() / _pv[m].radius();
+        return _kernel->density(u) * _pv[m].density();
+    };
+    double sum = _search.accumulate(bfr, density);
     return sum > 0. ? sum : 0.;  // guard against negative densities
 }
 
@@ -542,14 +308,23 @@ const Array& ParticleSnapshot::properties(int m) const
 
 void ParticleSnapshot::getEntities(EntityCollection& entities, Position bfr) const
 {
-    _grid->getEntities(entities, bfr, _kernel);
+    auto weight = [this, bfr](int m) {
+        double u = (bfr - _pv[m].center()).norm() / _pv[m].radius();
+        return _kernel->density(u);
+    };
+    _search.getEntities(entities, bfr, weight);
 }
 
 ////////////////////////////////////////////////////////////////////
 
 void ParticleSnapshot::getEntities(EntityCollection& entities, Position bfr, Direction bfk) const
 {
-    _grid->getEntities(entities, bfr, bfk, _kernel);
+    auto weight = [this, bfr, bfk](int m) {
+        double h = _pv[m].radius();
+        double q = _pv[m].impact(bfr, bfk) / h;
+        return _kernel->columnDensity(q) * h;
+    };
+    _search.getEntities(entities, bfr, bfk, weight);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ParticleSnapshot.cpp
+++ b/SKIRT/core/ParticleSnapshot.cpp
@@ -172,7 +172,7 @@ void ParticleSnapshot::readAndClose()
     // if needed, construct a search structure for the particles
     if (hasMassDensityPolicy() || needGetEntities())
     {
-        log()->info("Constructing search grid for particles...");
+        log()->info("Constructing search grid for " + std::to_string(_pv.size()) + " particles...");
         auto bounds = [this](int m) { return _pv[m].bounds(); };
         auto intersects = [this](int m, const Box& box) { return box.intersects(_pv[m].center(), _pv[m].radius()); };
         _search.loadEntities(_pv.size(), bounds, intersects);

--- a/SKIRT/core/ParticleSnapshot.hpp
+++ b/SKIRT/core/ParticleSnapshot.hpp
@@ -7,6 +7,7 @@
 #define PARTICLESNAPSHOT_HPP
 
 #include "Array.hpp"
+#include "BoxSearch.hpp"
 #include "Snapshot.hpp"
 class SmoothingKernel;
 
@@ -28,10 +29,11 @@ class ParticleSnapshot : public Snapshot
 
 public:
     /** The default constructor initializes the snapshot in an invalid state; it is provided here
-        so that we don't need to expose the inplemetation of the private Particle class. */
+        so that we don't need to expose the implementation of the private Particle class. */
     ParticleSnapshot();
 
-    /** The destructor deletes the smoothed particle grid, if it was constructed. */
+    /** The destructor is provided here so that we don't need to expose the implementation of the
+        private Particle class. */
     ~ParticleSnapshot();
 
     //========== Reading ==========
@@ -130,7 +132,6 @@ public:
 private:
     // private classes
     class Particle;
-    class ParticleGrid;
 
     // data members initialized during configuration
     const SmoothingKernel* _kernel{nullptr};
@@ -139,10 +140,10 @@ private:
     vector<Array> _propv;  // particle properties as imported
 
     // data members initialized when reading the input file, but only if a density policy has been set
-    vector<Particle> _pv;          // compact particle objects in the same order
-    ParticleGrid* _grid{nullptr};  // smart grid for locating smoothed particles
-    Array _cumrhov;                // cumulative density distribution for particles
-    double _mass{0.};              // total effective mass
+    vector<Particle> _pv;  // compact particle objects in the same order
+    BoxSearch _search;     // search structure for locating particles
+    Array _cumrhov;        // cumulative density distribution for particles
+    double _mass{0.};      // total effective mass
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ParticleSnapshot.hpp
+++ b/SKIRT/core/ParticleSnapshot.hpp
@@ -28,12 +28,13 @@ class ParticleSnapshot : public Snapshot
     //================= Construction - Destruction =================
 
 public:
-    /** The default constructor initializes the snapshot in an invalid state; it is provided here
-        so that we don't need to expose the implementation of the private Particle class. */
+    /** The default constructor initializes the snapshot in an invalid state0. It is provided and
+        implemented in the .cpp file so that we don't need to expose the declaration of the private
+        Particle class. */
     ParticleSnapshot();
 
-    /** The destructor is provided here so that we don't need to expose the implementation of the
-        private Particle class. */
+    /** The destructor is provided and implemented in the .cpp file so that we don't need to expose
+        the declaration of the private Particle class. */
     ~ParticleSnapshot();
 
     //========== Reading ==========

--- a/SKIRT/core/ParticleSnapshot.hpp
+++ b/SKIRT/core/ParticleSnapshot.hpp
@@ -6,7 +6,6 @@
 #ifndef PARTICLESNAPSHOT_HPP
 #define PARTICLESNAPSHOT_HPP
 
-#include "Array.hpp"
 #include "BoxSearch.hpp"
 #include "Snapshot.hpp"
 class SmoothingKernel;
@@ -21,7 +20,7 @@ class SmoothingKernel;
     particles in the snapshot.
 
     If the snapshot configuration requires the ability to determine the density at a given spatial
-    position, a lot of effort is made to accelerate the density interpolation over a potentially
+    position, an effort is made to accelerate the density interpolation over a potentially
     large number of smoothed particles. */
 class ParticleSnapshot : public Snapshot
 {
@@ -131,9 +130,6 @@ public:
     //======================== Data Members ========================
 
 private:
-    // private classes
-    class Particle;
-
     // data members initialized during configuration
     const SmoothingKernel* _kernel{nullptr};
 
@@ -141,10 +137,11 @@ private:
     vector<Array> _propv;  // particle properties as imported
 
     // data members initialized when reading the input file, but only if a density policy has been set
+    class Particle;
     vector<Particle> _pv;  // compact particle objects in the same order
-    BoxSearch _search;     // search structure for locating particles
     Array _cumrhov;        // cumulative density distribution for particles
     double _mass{0.};      // total effective mass
+    BoxSearch _search;     // search structure for locating particles
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/TetraMeshSpatialGrid.cpp
+++ b/SKIRT/core/TetraMeshSpatialGrid.cpp
@@ -547,7 +547,7 @@ void TetraMeshSpatialGrid::storeTetrahedra(const tetgenio& final, bool storeVert
 
 void TetraMeshSpatialGrid::buildSearch()
 {
-    _log->info("Constructing search grid for tetrahedra...");
+    _log->info("Constructing search grid for " + std::to_string(_tetrahedra.size()) + " tetrahedra...");
     auto bounds = [this](int m) { return _tetrahedra[m].extent(); };
     auto intersects = [this](int m, const Box& box) { return box.intersects(_tetrahedra[m].extent()); };
     _search.loadEntities(_tetrahedra.size(), bounds, intersects);

--- a/SKIRT/core/TetraMeshSpatialGrid.cpp
+++ b/SKIRT/core/TetraMeshSpatialGrid.cpp
@@ -5,6 +5,7 @@
 
 #include "TetraMeshSpatialGrid.hpp"
 #include "FatalError.hpp"
+#include "Log.hpp"
 #include "MediumSystem.hpp"
 #include "NR.hpp"
 #include "Random.hpp"
@@ -17,12 +18,6 @@
 
 namespace
 {
-    // returns the linear index for element (i,j,k) in a p*p*p table
-    inline int blockIndex(int p, int i, int j, int k)
-    {
-        return ((i * p) + j) * p + k;
-    }
-
     // sample random positions from the given media components with the given relative weigths
     vector<Vec> sampleMedia(const vector<Medium*>& media, const vector<double>& weights, const Box& extent,
                             int numSites)
@@ -234,140 +229,9 @@ const Box& TetraMeshSpatialGrid::Tetra::extent() const
     return _extent;
 }
 
-//////////////////////////////////////////////////////////////////////
-
-class TetraMeshSpatialGrid::BlockGrid
-{
-    const vector<Tetra>& _tetrahedra;  // reference to list of all tetrahedra
-    int _gridsize;                     // number of grid blocks in each spatial direction
-    Array _xgrid, _ygrid, _zgrid;      // the m+1 grid separation points for each spatial direction
-    vector<vector<int>> _listv;        // the m*m*m lists of indices for cells overlapping each grid block
-    int _pmin, _pmax;                  // statistics of the minimum and maximum number of cells per block
-
-public:
-    // The constructor creates a cuboidal grid of the specified number of grid blocks in each
-    // spatial direction, and for each of the grid blocks it builds a list of all cells that may
-    // overlap the grid block. In an attempt to distribute the cells evenly over the
-    // grid blocks, the sizes of the grid blocks in each spatial direction are chosen so that
-    // the cell centers are evenly distributed over the grid blocks.
-    BlockGrid(const vector<Tetra>& tetrahedra, Box extent, int gridsize) : _tetrahedra(tetrahedra), _gridsize(gridsize)
-    {
-        // build the grids in each spatial direction
-        makegrid(0, gridsize, _xgrid, extent.xmin(), extent.xmax());
-        makegrid(1, gridsize, _ygrid, extent.ymin(), extent.ymax());
-        makegrid(2, gridsize, _zgrid, extent.zmin(), extent.zmax());
-
-        // make room for p*p*p grid blocks
-        _listv.resize(gridsize * gridsize * gridsize);
-
-        // add each cell to the list for every grid block that its bounding box overlaps
-        int n = _tetrahedra.size();
-        for (int m = 0; m != n; ++m)
-        {
-            Box boundingBox = _tetrahedra[m].extent();
-
-            // find indices for first and last grid block overlapped by bounding box, in each spatial direction
-            int i1 = NR::locateClip(_xgrid, boundingBox.xmin());
-            int i2 = NR::locateClip(_xgrid, boundingBox.xmax());
-            int j1 = NR::locateClip(_ygrid, boundingBox.ymin());
-            int j2 = NR::locateClip(_ygrid, boundingBox.ymax());
-            int k1 = NR::locateClip(_zgrid, boundingBox.zmin());
-            int k2 = NR::locateClip(_zgrid, boundingBox.zmax());
-
-            // add the cell to all grid blocks in that 3D range
-            for (int i = i1; i <= i2; i++)
-                for (int j = j1; j <= j2; j++)
-                    for (int k = k1; k <= k2; k++)
-                    {
-                        _listv[blockIndex(gridsize, i, j, k)].push_back(m);
-                    }
-        }
-
-        // calculate statistics
-        _pmin = n;
-        _pmax = 0;
-        for (int index = 0; index < gridsize * gridsize * gridsize; index++)
-        {
-            int size = _listv[index].size();
-            _pmin = min(_pmin, size);
-            _pmax = max(_pmax, size);
-        }
-    }
-
-    // This function determines the grid separation points along a specified axis (x, y, or z)
-    // to ensure that the cells are evenly distributed across the grid blocks. It does this by
-    // binning the tetrahedra centers at a high resolution and then calculating the cumulative
-    // distribution to set the grid separation points.
-    void makegrid(int axis, int gridsize, Array& grid, double cmin, double cmax)
-    {
-        int n = _tetrahedra.size();
-
-        // determine the block distribution by binning at a decent resolution
-        int nbins = gridsize * 100;
-        double binwidth = (cmax - cmin) / nbins;
-        vector<int> bins(nbins);
-        for (const Tetra& tetra : _tetrahedra)
-        {
-            double center = 0.;
-            switch (axis)
-            {
-                case 0: center = tetra.centroid().x(); break;
-                case 1: center = tetra.centroid().y(); break;
-                case 2: center = tetra.centroid().z(); break;
-            }
-            bins[static_cast<int>((center - cmin) / binwidth)] += 1;
-        }
-
-        // determine grid separation points based on the cumulative distribution
-        grid.resize(gridsize + 1);
-        grid[0] = -std::numeric_limits<double>::infinity();
-        int perblock = n / gridsize;  // target number of centroids per block
-        int cumul = 0;                // cumulative number of centroids in processed bins
-        int gridindex = 1;            // index of the next grid separation point to be filled
-        for (int binindex = 0; binindex < nbins; binindex++)
-        {
-            cumul += bins[binindex];
-            if (cumul > perblock * gridindex)
-            {
-                grid[gridindex] = cmin + (binindex + 1) * binwidth;
-                gridindex += 1;
-                if (gridindex >= gridsize) break;
-            }
-        }
-        grid[gridsize] = std::numeric_limits<double>::infinity();
-    }
-
-    // This function returns the smallest number of cells overlapping a single grid block.
-    int minCellRefsPerBlock() const { return _pmin; }
-
-    // This function returns the largest number of cells overlapping a single grid block.
-    int maxCellRefsPerBlock() const { return _pmax; }
-
-    // This function returns the index (in the list originally passed to the constructor)
-    // of the first cell in the list that actually overlaps the specified position,
-    // or -1 if none of the cells in the list overlap the specified position.
-    int cellIndexFor(Position r) const
-    {
-        // locate the grid block containing the specified position
-        int i = NR::locateClip(_xgrid, r.x());
-        int j = NR::locateClip(_ygrid, r.y());
-        int k = NR::locateClip(_zgrid, r.z());
-
-        // search the list of cells for that grid block
-        for (int m : _listv[blockIndex(_gridsize, i, j, k)])
-        {
-            if (_tetrahedra[m].contains(r)) return m;
-        }
-        return -1;
-    }
-};
-
 ////////////////////////////////////////////////////////////////////
 
-TetraMeshSpatialGrid::~TetraMeshSpatialGrid()
-{
-    delete _blocks;
-}
+TetraMeshSpatialGrid::~TetraMeshSpatialGrid() {}
 
 //////////////////////////////////////////////////////////////////////
 
@@ -687,14 +551,17 @@ void TetraMeshSpatialGrid::storeTetrahedra(const tetgenio& final, bool storeVert
 
 void TetraMeshSpatialGrid::buildSearch()
 {
-    int gridsize = max(20, static_cast<int>(pow(_tetrahedra.size(), 1. / 3.) / 5));
-    string size = std::to_string(gridsize);
-    _log->info("Constructing intermediate " + size + "x" + size + "x" + size + " BlockGrid for tetrahedra...");
-    _blocks = new BlockGrid(_tetrahedra, extent(), gridsize);
-    _log->info("  Smallest number of tetrahedra per grid block: " + std::to_string(_blocks->minCellRefsPerBlock()));
-    _log->info("  Largest  number of tetrahedra per grid block: " + std::to_string(_blocks->maxCellRefsPerBlock()));
-    _log->info("  Average  number of tetrahedra per grid block: "
-               + StringUtils::toString(_numCells / double(gridsize * gridsize * gridsize), 'f', 1));
+    _log->info("Constructing search grid for tetrahedra...");
+    auto bounds = [this](int m) { return _tetrahedra[m].extent(); };
+    auto intersects = [this](int m, const Box& box) { return box.intersects(_tetrahedra[m].extent()); };
+    _search.loadEntities(_tetrahedra.size(), bounds, intersects);
+
+    string size = std::to_string(_search.numBlocks());
+    _log->info("  Number of blocks in search grid: " + size + " x " + size + " x " + size);
+    _log->info("  Smallest number of tetrahedra per block: " + std::to_string(_search.minEntitiesPerBlock()));
+    _log->info("  Largest  number of tetrahedra per block: " + std::to_string(_search.maxEntitiesPerBlock()));
+    _log->info("  Average  number of tetrahedra per block: "
+               + StringUtils::toString(_search.avgEntitiesPerBlock(), 'f', 1));
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -722,7 +589,8 @@ double TetraMeshSpatialGrid::diagonal(int m) const
 
 int TetraMeshSpatialGrid::cellIndex(Position bfr) const
 {
-    return _blocks->cellIndexFor(bfr);
+    auto contains = [this, bfr](int m) { return _tetrahedra[m].extent().contains(bfr); };
+    return _search.firstEntity(bfr, contains);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/TetraMeshSpatialGrid.cpp
+++ b/SKIRT/core/TetraMeshSpatialGrid.cpp
@@ -552,8 +552,8 @@ void TetraMeshSpatialGrid::buildSearch()
     auto intersects = [this](int m, const Box& box) { return box.intersects(_tetrahedra[m].extent()); };
     _search.loadEntities(_tetrahedra.size(), bounds, intersects);
 
-    string size = std::to_string(_search.numBlocks());
-    _log->info("  Number of blocks in search grid: " + size + " x " + size + " x " + size);
+    int nb = _search.numBlocks();
+    _log->info("  Number of blocks in grid: " + std::to_string(nb * nb * nb) + " (" + std::to_string(nb) + "^3)");
     _log->info("  Smallest number of tetrahedra per block: " + std::to_string(_search.minEntitiesPerBlock()));
     _log->info("  Largest  number of tetrahedra per block: " + std::to_string(_search.maxEntitiesPerBlock()));
     _log->info("  Average  number of tetrahedra per block: "

--- a/SKIRT/core/TetraMeshSpatialGrid.cpp
+++ b/SKIRT/core/TetraMeshSpatialGrid.cpp
@@ -229,10 +229,6 @@ const Box& TetraMeshSpatialGrid::Tetra::extent() const
     return _extent;
 }
 
-////////////////////////////////////////////////////////////////////
-
-TetraMeshSpatialGrid::~TetraMeshSpatialGrid() {}
-
 //////////////////////////////////////////////////////////////////////
 
 void TetraMeshSpatialGrid::setupSelfBefore()

--- a/SKIRT/core/TetraMeshSpatialGrid.cpp
+++ b/SKIRT/core/TetraMeshSpatialGrid.cpp
@@ -585,8 +585,11 @@ double TetraMeshSpatialGrid::diagonal(int m) const
 
 int TetraMeshSpatialGrid::cellIndex(Position bfr) const
 {
-    auto contains = [this, bfr](int m) { return _tetrahedra[m].contains(bfr); };
-    return _search.firstEntity(bfr, contains);
+    for (int m : _search.entitiesFor(bfr))
+    {
+        if (_tetrahedra[m].contains(bfr)) return m;
+    }
+    return -1;
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/TetraMeshSpatialGrid.cpp
+++ b/SKIRT/core/TetraMeshSpatialGrid.cpp
@@ -585,7 +585,7 @@ double TetraMeshSpatialGrid::diagonal(int m) const
 
 int TetraMeshSpatialGrid::cellIndex(Position bfr) const
 {
-    auto contains = [this, bfr](int m) { return _tetrahedra[m].extent().contains(bfr); };
+    auto contains = [this, bfr](int m) { return _tetrahedra[m].contains(bfr); };
     return _search.firstEntity(bfr, contains);
 }
 

--- a/SKIRT/core/TetraMeshSpatialGrid.hpp
+++ b/SKIRT/core/TetraMeshSpatialGrid.hpp
@@ -6,11 +6,11 @@
 #ifndef TETRAMESHSPATIALGRID_HPP
 #define TETRAMESHSPATIALGRID_HPP
 
+#include "BoxSearch.hpp"
 #include "BoxSpatialGrid.hpp"
-#include "Log.hpp"
 #include "PathSegmentGenerator.hpp"
 #include <array>
-
+class Log;
 class tetgenio;
 
 //////////////////////////////////////////////////////////////////////
@@ -187,10 +187,6 @@ private:
     //==================== Private construction ====================
 
 private:
-    /** This private helper class organizes the cells into cuboidal blocks in a smart grid, such
-        that it is easy to retrieve all cells inside a certain block given a position. */
-    class BlockGrid;
-
     /** This private function removes vertices that are outside the domain or too close to other vertices. */
     void removeInvalid();
 
@@ -219,8 +215,7 @@ private:
         it finishes transferring the data. */
     void storeTetrahedra(const tetgenio& final, bool storeVertices);
 
-    /** This private function builds the search data structure for the tetrahedral mesh.
-        See the private BlockGrid class for more information. */
+    /** This private function builds the search data structure for the tetrahedral mesh. */
     void buildSearch();
 
     //======================= Interrogation =======================
@@ -236,9 +231,9 @@ public:
         tetrahedron, it takes the square root of the average of the squared edge lengths. */
     double diagonal(int m) const override;
 
-    /** This function returns the index of the cell that contains the position \f${\bf{r}}\f$.
-        The function uses the data structure stored in the \em BlockGrid to accelerate the
-        search. If no cell is found to contain this position, the function returns -1. */
+    /** This function returns the index of the cell that contains the position \f${\bf{r}}\f$. It
+        uses a search data structure to accelerate the search. If no cell is found to contain this
+        position, the function returns -1. */
     int cellIndex(Position bfr) const override;
 
     /** This function returns the centroid of the tetrahedron with index \f$m\f$. */
@@ -313,13 +308,13 @@ private:
     double _eps{0.};  // small fraction of extent
 
     // data members describing the tetrahedralization
-    int _numCells;     // total number of tetrahedra
-    int _numVertices;  // total number of vertices
+    int _numCells{0};     // total number of tetrahedra
+    int _numVertices{0};  // total number of vertices
     vector<Tetra> _tetrahedra;
     vector<Vec> _vertices;
 
     // smart grid that organizes the tetrahedra into blocks
-    BlockGrid* _blocks{nullptr};
+    BoxSearch _search;  // search structure for locating cells
 
     // allow our path segment generator to access our private data members
     class MySegmentGenerator;

--- a/SKIRT/core/TetraMeshSpatialGrid.hpp
+++ b/SKIRT/core/TetraMeshSpatialGrid.hpp
@@ -92,10 +92,6 @@ class TetraMeshSpatialGrid : public BoxSpatialGrid
 
     //============= Construction - Setup - Destruction =============
 
-public:
-    /** This destructor releases the BlockGrid search structure. */
-    ~TetraMeshSpatialGrid();
-
 protected:
     /** This function verifies that the attributes are correctly set, generates or retrieves
         vertex positions based on the configured policy, builds (and optionally refines) the

--- a/SKIRT/utils/Box.hpp
+++ b/SKIRT/utils/Box.hpp
@@ -203,6 +203,18 @@ public:
         The function employs the algorithm due to Jim Arvo described in "Graphics Gems" (1990). */
     bool intersects(Vec rc, double r) const;
 
+    /** This function extends the receiving box so that it contains both the specified and the
+        original box. */
+    inline void extend(const Box& box)
+    {
+        _xmin = std::min(_xmin, box.xmin());
+        _ymin = std::min(_ymin, box.ymin());
+        _zmin = std::min(_zmin, box.zmin());
+        _xmax = std::max(_xmax, box.xmax());
+        _ymax = std::max(_ymax, box.ymax());
+        _zmax = std::max(_zmax, box.zmax());
+    }
+
 protected:
     /** This function replaces the extent of the box with the newly specified values. This function
         is intended for use in derived classes only. */

--- a/SKIRT/utils/BoxSearch.cpp
+++ b/SKIRT/utils/BoxSearch.cpp
@@ -212,40 +212,43 @@ BoxSearch::EntityGeneratorForRay BoxSearch::entitiesFor(Vec bfr, Vec bfk) const
 {
     EntityGeneratorForRay entities;
 
-    double smin, smax;
-    if (_extent.intersects(bfr, bfk, smin, smax))
+    if (_numBlocks)
     {
-        // find the indices for first and last block, in each spatial direction,
-        // overlapped by the bounding box of the ray's intersection with the domain
-        Box ray(bfr + smin * bfk, bfr + smax * bfk);
-        int i1 = NR::locateClip(_xgrid, ray.xmin());
-        int i2 = NR::locateClip(_xgrid, ray.xmax());
-        int j1 = NR::locateClip(_ygrid, ray.ymin());
-        int j2 = NR::locateClip(_ygrid, ray.ymax());
-        int k1 = NR::locateClip(_zgrid, ray.zmin());
-        int k2 = NR::locateClip(_zgrid, ray.zmax());
+        double smin, smax;
+        if (_extent.intersects(bfr, bfk, smin, smax))
+        {
+            // find the indices for first and last block, in each spatial direction,
+            // overlapped by the bounding box of the ray's intersection with the domain
+            Box ray(bfr + smin * bfk, bfr + smax * bfk);
+            int i1 = NR::locateClip(_xgrid, ray.xmin());
+            int i2 = NR::locateClip(_xgrid, ray.xmax());
+            int j1 = NR::locateClip(_ygrid, ray.ymin());
+            int j2 = NR::locateClip(_ygrid, ray.ymax());
+            int k1 = NR::locateClip(_zgrid, ray.zmin());
+            int k2 = NR::locateClip(_zgrid, ray.zmax());
 
-        // fix reversed coords for negative bfk components
-        if (i1 > i2) std::swap(i1, i2);
-        if (j1 > j2) std::swap(j1, j2);
-        if (k1 > k2) std::swap(k1, k2);
+            // fix reversed coords for negative bfk components
+            if (i1 > i2) std::swap(i1, i2);
+            if (j1 > j2) std::swap(j1, j2);
+            if (k1 > k2) std::swap(k1, k2);
 
-        // loop over all blocks in that 3D range
-        for (int i = i1; i <= i2; i++)
-            for (int j = j1; j <= j2; j++)
-                for (int k = k1; k <= k2; k++)
-                {
-                    // if the path intersects the block
-                    Box block(_xgrid[i], _ygrid[j], _zgrid[k], _xgrid[i + 1], _ygrid[j + 1], _zgrid[k + 1]);
-                    if (block.intersects(bfr, bfk, smin, smax))
+            // loop over all blocks in that 3D range
+            for (int i = i1; i <= i2; i++)
+                for (int j = j1; j <= j2; j++)
+                    for (int k = k1; k <= k2; k++)
                     {
-                        // add all entities overlapping that block to the output list
-                        for (int m : _listv[blockIndex(i, j, k)])
+                        // if the path intersects the block
+                        Box block(_xgrid[i], _ygrid[j], _zgrid[k], _xgrid[i + 1], _ygrid[j + 1], _zgrid[k + 1]);
+                        if (block.intersects(bfr, bfk, smin, smax))
                         {
-                            entities.insert(m);
+                            // add all entities overlapping that block to the output list
+                            for (int m : _listv[blockIndex(i, j, k)])
+                            {
+                                entities.insert(m);
+                            }
                         }
                     }
-                }
+        }
     }
     return entities;
 }

--- a/SKIRT/utils/BoxSearch.cpp
+++ b/SKIRT/utils/BoxSearch.cpp
@@ -210,7 +210,7 @@ BoxSearch::EntityGeneratorForPosition BoxSearch::entitiesFor(Vec bfr) const
 
 BoxSearch::EntityGeneratorForRay BoxSearch::entitiesFor(Vec bfr, Vec bfk) const
 {
-    vector<int> entities;
+    EntityGeneratorForRay entities;
 
     double smin, smax;
     if (_extent.intersects(bfr, bfk, smin, smax))
@@ -242,7 +242,7 @@ BoxSearch::EntityGeneratorForRay BoxSearch::entitiesFor(Vec bfr, Vec bfk) const
                         // add all entities overlapping that block to the output list
                         for (int m : _listv[blockIndex(i, j, k)])
                         {
-                            entities.push_back(m);
+                            entities.insert(m);
                         }
                     }
                 }

--- a/SKIRT/utils/BoxSearch.cpp
+++ b/SKIRT/utils/BoxSearch.cpp
@@ -91,9 +91,8 @@ void BoxSearch::loadEntities(int numEntities, std::function<Box(int)> bounds,
     _extent = boxv[0];
     for (const auto& box : boxv) _extent.extend(box);
 
-    // determine the number of blocks in each spatial direction;
-    // the floor of 20 is exceeded only for more than a million entities
-    _numBlocks = max(20, static_cast<int>(std::cbrt(numEntities) / 5.));
+    // determine the number of blocks in each spatial direction
+    _numBlocks = max(10, static_cast<int>(std::cbrt(numEntities)));
 
     // build the grids in each spatial direction
     makegrid(_xgrid, boxv, 1, _numBlocks, _extent.xmin(), _extent.xmax());

--- a/SKIRT/utils/BoxSearch.cpp
+++ b/SKIRT/utils/BoxSearch.cpp
@@ -41,12 +41,14 @@ namespace
             bins[static_cast<int>((center - cmin) / binwidth)] += 1;
         }
 
+        // set target number of entities per block (in floating point because this works better for small numbers)
+        double perblock = static_cast<double>(boxv.size()) / gridsize;
+
         // determine grid separation points based on the cumulative distribution
         grid.resize(gridsize + 1);
         grid[0] = -std::numeric_limits<double>::infinity();
-        int perblock = boxv.size() / gridsize;  // target number of entities per block
-        int cumul = 0;                          // cumulative number of entities in processed bins
-        int gridindex = 1;                      // index of the next grid separation point to be filled
+        int cumul = 0;      // cumulative number of entities in processed bins
+        int gridindex = 1;  // index of the next grid separation point to be filled
         for (int binindex = 0; binindex < nbins; binindex++)
         {
             cumul += bins[binindex];

--- a/SKIRT/utils/BoxSearch.cpp
+++ b/SKIRT/utils/BoxSearch.cpp
@@ -1,0 +1,263 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "BoxSearch.hpp"
+#include "EntityCollection.hpp"
+#include "NR.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // This function determines the grid block separation points along a specified axis 1->x, 2->y, 3->z
+    // to ensure that the entities are evenly distributed across the grid blocks.
+    // It does this by binning the bounding box centers at a high resolution and then calculating
+    // the cumulative distribution to set the grid separation points.
+    void makegrid(Array& grid, const vector<Box>& boxv, int axis, int gridsize, double cmin, double cmax)
+    {
+        // guard against degenerate zero-width entities that are all lined up along this coordinate
+        if (cmin == cmax)
+        {
+            double eps = 1e-12 * (cmin ? abs(cmin) : 1.);
+            cmin -= eps;
+            cmax += eps;
+        }
+
+        // determine the entity center distribution by binning at a decent resolution
+        int nbins = gridsize * 100;
+        double binwidth = (cmax - cmin) / nbins;
+        vector<int> bins(nbins);
+        for (const auto& box : boxv)
+        {
+            double center = 0.;
+            switch (axis)
+            {
+                case 1: center = box.center().x(); break;
+                case 2: center = box.center().y(); break;
+                case 3: center = box.center().z(); break;
+            }
+            bins[static_cast<int>((center - cmin) / binwidth)] += 1;
+        }
+
+        // determine grid separation points based on the cumulative distribution
+        grid.resize(gridsize + 1);
+        grid[0] = -std::numeric_limits<double>::infinity();
+        int perblock = boxv.size() / gridsize;  // target number of entities per block
+        int cumul = 0;                          // cumulative number of entities in processed bins
+        int gridindex = 1;                      // index of the next grid separation point to be filled
+        for (int binindex = 0; binindex < nbins; binindex++)
+        {
+            cumul += bins[binindex];
+            if (cumul > perblock * gridindex)
+            {
+                grid[gridindex] = cmin + (binindex + 1) * binwidth;
+                gridindex += 1;
+                if (gridindex >= gridsize) break;
+            }
+        }
+        grid[gridsize] = std::numeric_limits<double>::infinity();
+    }
+}
+
+////////////////////////////////////////////////////////////////////
+
+BoxSearch::BoxSearch() {}
+
+////////////////////////////////////////////////////////////////////
+
+void BoxSearch::loadEntities(int numEntities, std::function<Box(int)> bounds,
+                             std::function<bool(int, const Box&)> intersects)
+{
+    // abort if there are no entities
+    if (numEntities <= 0)
+    {
+        _extent = Box();
+        _numBlocks = 0;
+        _minEntitiesPerBlock = 0;
+        _maxEntitiesPerBlock = 0;
+        _avgEntitiesPerBlock = 0;
+        return;
+    }
+
+    // cache the bounding boxes because we need them a few times
+    vector<Box> boxv;
+    boxv.reserve(numEntities);
+    for (int m = 0; m != numEntities; ++m) boxv.emplace_back(bounds(m));
+
+    // calculate the extent of the search domain
+    _extent = boxv[0];
+    for (const auto& box : boxv) _extent.extend(box);
+
+    // determine the number of blocks in each spatial direction;
+    // the floor of 20 is exceeded only for more than a million entities
+    _numBlocks = max(20, static_cast<int>(std::cbrt(numEntities) / 5.));
+
+    // build the grids in each spatial direction
+    makegrid(_xgrid, boxv, 1, _numBlocks, _extent.xmin(), _extent.xmax());
+    makegrid(_ygrid, boxv, 2, _numBlocks, _extent.ymin(), _extent.ymax());
+    makegrid(_zgrid, boxv, 3, _numBlocks, _extent.zmin(), _extent.zmax());
+
+    // construct an empty entity list for each of the nb*nb*nb blocks
+    _listv.clear();  // remove any pre-existing lists
+    _listv.resize(_numBlocks * _numBlocks * _numBlocks);
+
+    // add each entity to the list for every block that its bounding box overlaps
+    for (int m = 0; m != numEntities; ++m)
+    {
+        const auto& box = boxv[m];
+
+        // find indices for first and last grid block overlapped by bounding box, in each spatial direction
+        int i1 = NR::locateClip(_xgrid, box.xmin());
+        int i2 = NR::locateClip(_xgrid, box.xmax());
+        int j1 = NR::locateClip(_ygrid, box.ymin());
+        int j2 = NR::locateClip(_ygrid, box.ymax());
+        int k1 = NR::locateClip(_zgrid, box.zmin());
+        int k2 = NR::locateClip(_zgrid, box.zmax());
+
+        // loop over all blocks in that 3D range
+        for (int i = i1; i <= i2; i++)
+            for (int j = j1; j <= j2; j++)
+                for (int k = k1; k <= k2; k++)
+                {
+                    // add the entity to the list if it indeed overlaps the block
+                    Box block(_xgrid[i], _ygrid[j], _zgrid[k], _xgrid[i + 1], _ygrid[j + 1], _zgrid[k + 1]);
+                    if (intersects(m, block)) _listv[blockIndex(i, j, k)].push_back(m);
+                }
+    }
+
+    // calculate statistics
+    _minEntitiesPerBlock = numEntities;
+    _maxEntitiesPerBlock = 0;
+    int totalEntityReferences = 0;
+    for (const auto& list : _listv)
+    {
+        int size = list.size();
+        _minEntitiesPerBlock = min(_minEntitiesPerBlock, size);
+        _maxEntitiesPerBlock = max(_maxEntitiesPerBlock, size);
+        totalEntityReferences += size;
+    }
+    _avgEntitiesPerBlock = static_cast<double>(totalEntityReferences) / _listv.size();
+}
+
+////////////////////////////////////////////////////////////////////
+
+const Box& BoxSearch::extent() const
+{
+    return _extent;
+}
+
+////////////////////////////////////////////////////////////////////
+
+int BoxSearch::numBlocks() const
+{
+    return _numBlocks;
+}
+
+////////////////////////////////////////////////////////////////////
+
+int BoxSearch::minEntitiesPerBlock() const
+{
+    return _minEntitiesPerBlock;
+}
+
+////////////////////////////////////////////////////////////////////
+
+int BoxSearch::maxEntitiesPerBlock() const
+{
+    return _maxEntitiesPerBlock;
+}
+
+////////////////////////////////////////////////////////////////////
+
+int BoxSearch::avgEntitiesPerBlock() const
+{
+    return _avgEntitiesPerBlock;
+}
+
+////////////////////////////////////////////////////////////////////
+
+int BoxSearch::firstEntityContaining(Vec bfr, std::function<bool(int)> contains) const
+{
+    if (!_numBlocks) return -1;
+
+    // get the indices for the block containing the position
+    int i = NR::locateClip(_xgrid, bfr.x());
+    int j = NR::locateClip(_ygrid, bfr.y());
+    int k = NR::locateClip(_zgrid, bfr.z());
+
+    // loop over all entities overlapping that block; return the first one that contains the position
+    for (int m : _listv[blockIndex(i, j, k)])
+    {
+        if (contains(m)) return m;
+    }
+
+    // there is no entity containing the position
+    return -1;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void BoxSearch::getEntities(EntityCollection& entities, Vec bfr, std::function<double(int)> weight) const
+{
+    entities.clear();
+    if (!_numBlocks) return;
+
+    // get the indices for the block containing the position
+    int i = NR::locateClip(_xgrid, bfr.x());
+    int j = NR::locateClip(_ygrid, bfr.y());
+    int k = NR::locateClip(_zgrid, bfr.z());
+
+    // add all entities overlapping that block to the collection with their respective weight
+    for (int m : _listv[blockIndex(i, j, k)])
+    {
+        entities.add(m, weight(m));
+    }
+}
+
+////////////////////////////////////////////////////////////////////
+
+void BoxSearch::getEntities(EntityCollection& entities, Position bfr, Direction bfk,
+                            std::function<double(int)> weight) const
+{
+    entities.clear();
+    if (!_numBlocks) return;
+
+    // verify that the path intersects the domain
+    double smin, smax;
+    if (_extent.intersects(bfr, bfk, smin, smax))
+    {
+        // find the indices for first and last block, in each spatial direction,
+        // overlapped by the bounding box of the path's intersection with the domain
+        Box pathbox(bfr + smin * bfk, bfr + smax * bfk);
+        int i1 = NR::locateClip(_xgrid, pathbox.xmin());
+        int i2 = NR::locateClip(_xgrid, pathbox.xmax());
+        int j1 = NR::locateClip(_ygrid, pathbox.ymin());
+        int j2 = NR::locateClip(_ygrid, pathbox.ymax());
+        int k1 = NR::locateClip(_zgrid, pathbox.zmin());
+        int k2 = NR::locateClip(_zgrid, pathbox.zmax());
+        if (i1 > i2) std::swap(i1, i2);  // fix reversed coords for negative bfk components
+        if (j1 > j2) std::swap(j1, j2);
+        if (k1 > k2) std::swap(k1, k2);
+
+        // loop over all blocks in that 3D range
+        for (int i = i1; i <= i2; i++)
+            for (int j = j1; j <= j2; j++)
+                for (int k = k1; k <= k2; k++)
+                {
+                    // if the path intersects the block
+                    Box block(_xgrid[i], _ygrid[j], _zgrid[k], _xgrid[i + 1], _ygrid[j + 1], _zgrid[k + 1]);
+                    if (block.intersects(bfr, bfk, smin, smax))
+                    {
+                        // add all entities overlapping that block to the collection with their respective weight
+                        for (int m : _listv[blockIndex(i, j, k)])
+                        {
+                            entities.add(m, weight(m));
+                        }
+                    }
+                }
+    }
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/BoxSearch.hpp
+++ b/SKIRT/utils/BoxSearch.hpp
@@ -15,16 +15,24 @@ class EntityCollection;
 
 //////////////////////////////////////////////////////////////////////
 
-/** BoxSearch is a helper class for organizing spatial objects in a data structure that allows
+/** BoxSearch is a utility class for organizing spatial objects in a data structure that allows
     efficient retrieval of all objects that overlap a given point or ray. The class actually works
     with the bounding boxes of the objects being held, and leaves more detailed tests for
     containment or intersection to the client code.
 
-    The spatial objects held by a BoxSearch instance are called entities. They are identified by
-    a unique index \f$m\f$ ranging from 0 to \f$M-1\f$, where \f$M\f$ is the number of managed
-    entities.
+    The spatial objects held by a BoxSearch instance are called entities. They are identified by a
+    unique index \f$m\f$ ranging from 0 to \f$M-1\f$, where \f$M\f$ is the number of managed
+    entities. All entities are handed to the BoxSearch instance in one go, so that they can be
+    "bulk-loaded" into the search structure.
 
-    To be completed. */
+    The current implementation proceeds as follows. First, a regular Cartesian grid is contructed
+    that partitions 3D space into \f$N_b^3\f$ blocks, where \f$N_b\f$ depends on the number of
+    entities with a floor of \f$N_b=20\f$ up to 1 million entities. Each block is then assigned a
+    list of indices for all entities that possibly intersect with the block. In an attempt to
+    balance the list lengths, the block separation points in each coordinate direction are chosen
+    so that the entity bounding box centers are approximately evently distributed over the blocks
+    in that direction. Locating the block containing a given query position then boils down to
+    three binary searches (one in each direction). */
 class BoxSearch
 {
     // ------- Constructing and loading -------

--- a/SKIRT/utils/BoxSearch.hpp
+++ b/SKIRT/utils/BoxSearch.hpp
@@ -8,6 +8,7 @@
 
 #include "Array.hpp"
 #include "Box.hpp"
+#include <unordered_set>
 
 //////////////////////////////////////////////////////////////////////
 
@@ -95,8 +96,8 @@ private:
 
     /** This typedef defines the generator return type of the entitiesFor function for a ray.
         It represents an iterable sequence of integers. We use a private typedef to hide the actual
-        type, which in the current implementation is simply a copy of a standard vector. */
-    using EntityGeneratorForRay = vector<int>;
+        type, which in the current implementation is simply a copy of a standard unordered set. */
+    using EntityGeneratorForRay = std::unordered_set<int>;
 
     // ------- Querying -------
 
@@ -110,8 +111,8 @@ public:
     EntityGeneratorForPosition entitiesFor(Vec bfr) const;
 
     /** This function returns an iterable sequence of indices \f$m\f$ of all entities that may
-        overlap the specified ray (starting point and direction). The sequence is unordered, may
-        contain duplicates, or may be empty.
+        overlap the specified ray (starting point and direction), in arbitrary order. The sequence
+        may be empty.
 
         The function guarantees that the sequence includes all entities whose bounding box overlaps
         the ray. On the other hand, the sequence may contain entities whose bounding box does \em

--- a/SKIRT/utils/BoxSearch.hpp
+++ b/SKIRT/utils/BoxSearch.hpp
@@ -58,7 +58,7 @@ public:
     const Box& extent() const;
 
     /** This function returns the number of blocks in the search structure for each spatial
-        dimension. */
+        dimension, or zero if no entities have been loaded. */
     int numBlocks() const;
 
     /** This function returns the smallest number of entity references in a search block. */
@@ -68,7 +68,7 @@ public:
     int maxEntitiesPerBlock() const;
 
     /** This function returns the average number of entity references in a search block. */
-    int avgEntitiesPerBlock() const;
+    double avgEntitiesPerBlock() const;
 
     // ------- Querying -------
 
@@ -86,7 +86,20 @@ public:
 
         Note that the callback function may be called for entities whose bounding box does \em not
         overlap the position; in that case it should return false. */
-    int firstEntityContaining(Vec bfr, std::function<bool(int m)> contains) const;
+    int firstEntity(Vec bfr, std::function<bool(int m)> contains) const;
+
+    /** This function accumulates the weights returned by the callback function for all entities
+        that overlap the specified position, and returns the sum. If there are no such entities,
+        the function returns zero.
+
+        The callback function must return the weight in the entity with given index for the
+        position passed to the main function, or zero if the entity does not contain the position.
+        The callback function will be invoked with a sequence of indices in arbitrary order but
+        without duplicates.
+
+        Note that the callback function may be called for entities whose bounding box does \em not
+        overlap the position; in that case it should return zero. */
+    double accumulate(Vec bfr, std::function<double(int m)> weight) const;
 
     /** This function replaces the contents of the specified entity collection by the set of
         entities that overlap the specified position with a nonzero weight. If there are no such
@@ -94,10 +107,8 @@ public:
 
         The callback function must return the weight in the entity with given index for the
         position passed to the main function, or zero if the entity does not contain the position.
-        The callback function will be invoked with a sequence of indices in arbitrary order and
-        possibly with duplicates. For a given index, the callback function must always return the
-        same value. Even if the callback function is invoked multiple times for the same index, the
-        corresponding entity will be added to the entity collection just once.
+        The callback function will be invoked with a sequence of indices in arbitrary order but
+        without duplicates.
 
         Note that the callback function may be called for entities whose bounding box does \em not
         overlap the position; in that case it should return zero. */
@@ -122,8 +133,13 @@ public:
     // ------- Private helper functions -------
 
 private:
-    /** This function returns the linear index for element (i,j,k) in the block list table. */
-    int blockIndex(int i, int j, int k) const { return ((i * _numBlocks) + j) * _numBlocks + k; }
+    /** This function returns the linear index in the block list vector for the block with indices
+        (i,j,k) in the three spatial directions. */
+    int blockIndex(int i, int j, int k) const;
+
+    /** This function returns the linear index in the block list vector for the block containing
+        the given position. */
+    int blockIndex(Vec bfr) const;
 
     // ------- Data members -------
 

--- a/SKIRT/utils/BoxSearch.hpp
+++ b/SKIRT/utils/BoxSearch.hpp
@@ -1,0 +1,145 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef BOXSEARCH_HPP
+#define BOXSEARCH_HPP
+
+#include "Array.hpp"
+#include "Box.hpp"
+#include "Direction.hpp"
+#include "Position.hpp"
+#include <functional>
+class EntityCollection;
+
+//////////////////////////////////////////////////////////////////////
+
+/** BoxSearch is a helper class for organizing spatial objects in a data structure that allows
+    efficient retrieval of all objects that overlap a given point or ray. The class actually works
+    with the bounding boxes of the objects being held, and leaves more detailed tests for
+    containment or intersection to the client code.
+
+    The spatial objects held by a BoxSearch instance are called entities. They are identified by
+    a unique index \f$m\f$ ranging from 0 to \f$M-1\f$, where \f$M\f$ is the number of managed
+    entities.
+
+    To be completed. */
+class BoxSearch
+{
+    // ------- Constructing and loading -------
+
+public:
+    /** The constructor creates a trivial BoxSearch instance holding no entities. Any queries
+        will come up empty. */
+    BoxSearch();
+
+    /** This function loads the specified number of entities \f$M\f$ into the search structure,
+        using the information returned by the provided callback functions. Any entities held
+        prevously are removed and replaced by the new ones.
+
+        The \em bounds callback function returns the bounding box of the entity with the given
+        index. The \em intersects callback function returns true if the entity with the given index
+        possibly intersects the specified box, and false otherwise. A relaxed intersection test
+        such as testing against the bounding box is allowed but a stricter intersection test will
+        result in more efficient retrieval queries.
+
+        The callback functions are invoked one or more times for indices \f$m\f$ ranging from 0 to
+        \f$M-1\f$, in arbitrary order. For given values of their argument(s), the callback
+        functions must always return the same value. */
+    void loadEntities(int numEntities, std::function<Box(int m)> bounds,
+                      std::function<bool(int m, const Box& box)> intersects);
+
+    // ------- Getting properties and statistics -------
+
+public:
+    /** This function returns the extent of the search domain, i.e. the union of all entity
+        bounding boxes. */
+    const Box& extent() const;
+
+    /** This function returns the number of blocks in the search structure for each spatial
+        dimension. */
+    int numBlocks() const;
+
+    /** This function returns the smallest number of entity references in a search block. */
+    int minEntitiesPerBlock() const;
+
+    /** This function returns the largest number of entity references in a search block. */
+    int maxEntitiesPerBlock() const;
+
+    /** This function returns the average number of entity references in a search block. */
+    int avgEntitiesPerBlock() const;
+
+    // ------- Querying -------
+
+public:
+    /** This function returns the index \f$m\f$ of the first entity containing the specified
+        position, or -1 if there is no such entity. The callback function must return true if the
+        entity with given index contains the position passed to the main function, and false
+        otherwise. It is called zero or more times with the following guarantees: (1) all entities
+        whose bounding box overlaps the position are included in the invocation sequence, and (2)
+        the indices of consecutive invocations are sorted in increasing order.
+
+        The first index for which the callback function returns true is returned to the caller of
+        the main function. In case multiple entities overlap the position, because of the second
+        guarantee, the entity with the smallest index is always returned.
+
+        Note that the callback function may be called for entities whose bounding box does \em not
+        overlap the position; in that case it should return false. */
+    int firstEntityContaining(Vec bfr, std::function<bool(int m)> contains) const;
+
+    /** This function replaces the contents of the specified entity collection by the set of
+        entities that overlap the specified position with a nonzero weight. If there are no such
+        entities, the collection will be empty.
+
+        The callback function must return the weight in the entity with given index for the
+        position passed to the main function, or zero if the entity does not contain the position.
+        The callback function will be invoked with a sequence of indices in arbitrary order and
+        possibly with duplicates. For a given index, the callback function must always return the
+        same value. Even if the callback function is invoked multiple times for the same index, the
+        corresponding entity will be added to the entity collection just once.
+
+        Note that the callback function may be called for entities whose bounding box does \em not
+        overlap the position; in that case it should return zero. */
+    void getEntities(EntityCollection& entities, Vec bfr, std::function<double(int m)> weight) const;
+
+    /** This function replaces the contents of the specified entity collection by the set of
+        entities that overlap the specified ray (starting point and direction) with a nonzero
+        weight. If there are no such entities, the collection will be empty.
+
+        The callback function must return the weight in the entity with given index for the ray
+        passed to the main function, or zero if the entity does not intersect the ray. The callback
+        function will be invoked with a sequence of indices in arbitrary order and possibly with
+        duplicates. For a given index, the callback function must always return the same value.
+        Even if the callback function is invoked multiple times for the same index, the
+        corresponding entity will be added to the entity collection just once.
+
+        Note that the callback function may be called for entities whose bounding box does \em not
+        overlap the position; in that case it should return zero. */
+    void getEntities(EntityCollection& entities, Position bfr, Direction bfk,
+                     std::function<double(int m)> weight) const;
+
+    // ------- Private helper functions -------
+
+private:
+    /** This function returns the linear index for element (i,j,k) in the block list table. */
+    int blockIndex(int i, int j, int k) const { return ((i * _numBlocks) + j) * _numBlocks + k; }
+
+    // ------- Data members -------
+
+private:
+    // search structure
+    Box _extent;                   // the extent of the search domain, i.e. the union of all bounding boxes
+    int _numBlocks{0};             // the number of grid blocks nb in each direction
+    Array _xgrid, _ygrid, _zgrid;  // the nb+1 grid separation points for each spatial direction
+    vector<vector<int>> _listv;    // the nb*nb*nb lists of indices for entities overlapping each block
+
+    // statistics
+    int _minEntitiesPerBlock{0};
+    int _maxEntitiesPerBlock{0};
+    double _avgEntitiesPerBlock{0};
+};
+
+//////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/utils/BoxSearch.hpp
+++ b/SKIRT/utils/BoxSearch.hpp
@@ -26,12 +26,12 @@
 
     The current implementation proceeds as follows. First, a regular Cartesian grid is contructed
     that partitions 3D space into \f$N_b^3\f$ blocks, where \f$N_b\f$ depends on the number of
-    entities with a floor of \f$N_b=20\f$ up to 1 million entities. Each block is then assigned a
-    list of indices for all entities that possibly intersect with the block. In an attempt to
-    balance the list lengths, the block separation points in each coordinate direction are chosen
-    so that the entity bounding box centers are approximately evently distributed over the blocks
-    in that direction. Locating the block containing a given query position then boils down to
-    three binary searches (one in each direction).
+    entities. Each block is then assigned a list of indices for all entities that possibly
+    intersect with the block. In an attempt to balance the list lengths, the block separation
+    points in each coordinate direction are chosen so that the entity bounding box centers are
+    approximately evently distributed over the blocks in that direction. Locating the block
+    containing a given query position then boils down to three binary searches (one in each
+    direction).
 
     For performance reasons, the query functions use a template argument type instead of the
     appropriate std::function<> type declaration, which means they must be implemented inline in


### PR DESCRIPTION
**Description**
The classes `ParticleSnapshot`, `CellSnapshot`, and `TetraMeshSpatialGrid` each contained a customized variation of the code for creating and using a search data structure that can efficiently find particles/cells overlapping a given position or ray (half-line). With this update, this code has been unified, streamlined and moved into a separate utility class called `BoxSearch`.

**Motivation**
Reducing code duplication benefits maintainability. Moreover, this functionality is now easily available for other (future) classes that may need it. 

**Tests**
All functional tests work unchanged (binary compatible). Search performance for the tested larger models is similar to that in the previous version of the code.
