### PR TITLE
precalculate luminosities in `ImportedSourceLuminosityProbe`

### DIFF
--- a/SKIRT/core/ImportedSourceLuminosityProbe.cpp
+++ b/SKIRT/core/ImportedSourceLuminosityProbe.cpp
@@ -134,13 +134,15 @@ void ImportedSourceLuminosityProbe::probeImportedSources(const vector<const Impo
                         {
                             switch (style)
                             {
+                                case Style::Sample:
+                                    throw FATALERROR("convolve option is not compatible with style Sample");
+                                    break;
                                 case Style::Average:
                                     storedLuminosities(ell, h, m) = sources[h]->meanSpecificLuminosity(bin[ell], m);
                                     break;
                                 case Style::Convolve:
                                     storedLuminosities(ell, h, m) = sources[h]->meanSpecificLuminosity(band[ell], m);
                                     break;
-                                default: break;
                             }
                         }
                         log->infoIfElapsed(progress, currentChunkSize);

--- a/SKIRT/core/ImportedSourceLuminosityProbe.cpp
+++ b/SKIRT/core/ImportedSourceLuminosityProbe.cpp
@@ -116,7 +116,7 @@ void ImportedSourceLuminosityProbe::probeImportedSources(const vector<const Impo
     // depending on the value of the path argument (to avoid duplicating a lot of code):
     //  - a luminosity volume density value at a given position or along a given path
     //  - a surface brightness value along a given path
-    auto valueAtPositionOrAlongPath = [&sources, &snapshots, numWaves, style, &wave, &bin, &band, &cvol, &csrf,
+    auto valueAtPositionOrAlongPath = [&sources, &snapshots, numWaves, style, &wave, &bin, &cvol, &csrf,
                                        &convolvedLuminosities](bool path, Position bfr, Direction bfk) {
         // allocate an entity collection that can be reused for all queries in a given execution thread
         thread_local EntityCollection entities;

--- a/SKIRT/core/ImportedSourceLuminosityProbe.cpp
+++ b/SKIRT/core/ImportedSourceLuminosityProbe.cpp
@@ -12,6 +12,7 @@
 #include "FatalError.hpp"
 #include "ImportedSource.hpp"
 #include "Indices.hpp"
+#include "Log.hpp"
 #include "Parallel.hpp"
 #include "ParallelFactory.hpp"
 #include "ProbeFormBridge.hpp"
@@ -20,6 +21,14 @@
 #include "StringUtils.hpp"
 #include "TextOutFile.hpp"
 #include "Units.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+namespace
+{
+    // maximum number of luminosity calculations between two invocations of infoIfElapsed()
+    const size_t logProgressChunkSize = 10000;
+}
 
 ////////////////////////////////////////////////////////////////////
 
@@ -97,27 +106,49 @@ void ImportedSourceLuminosityProbe::probeImportedSources(const vector<const Impo
     };
 
     // when convolving, precompute the luminosities for all entities
-    ArrayTable<3> convolvedLuminosities;  // indexed on wavelength band, source, entity
-    if (style == Style::Convolve)
+    ArrayTable<3> storedLuminosities;  // indexed on wavelength, source, entity
+    if (convolve())
     {
         auto parallel = find<ParallelFactory>()->parallelDistributed();
+        auto log = find<Log>();
+        string progress = typeAndName() + " calculated convolved luminosities: ";
 
         int numSources = sources.size();
-        convolvedLuminosities.resize(numWaves, numSources, 1);  // last index has variable size
-        for (int ell = 0; ell != numWaves; ++ell)
+        storedLuminosities.resize(numWaves, numSources, 1);  // last index has variable size
+        for (int h = 0; h != numSources; ++h)
         {
-            for (int h = 0; h != numSources; ++h)
+            int numEntities = snapshots[h]->numEntities();
+            log->infoSetElapsed(numEntities * numWaves);
+
+            for (int ell = 0; ell != numWaves; ++ell)
             {
-                int numEntities = snapshots[h]->numEntities();
-                convolvedLuminosities(ell, h).resize(numEntities);
+                storedLuminosities(ell, h).resize(numEntities);
 
                 // calculate the convolved luminosities in parallel
-                parallel->call(numEntities, [&convolvedLuminosities, &sources, &band, ell, h](size_t firstEntity,
-                                                                                              size_t numEntities) {
-                    for (size_t m = firstEntity; m != firstEntity + numEntities; ++m)
-                        convolvedLuminosities(ell, h, m) = sources[h]->meanSpecificLuminosity(band[ell], m);
+                parallel->call(numEntities, [&storedLuminosities, &sources, &bin, &band, ell, h, style, log,
+                                             progress](size_t firstIndex, size_t numIndices) {
+                    while (numIndices)
+                    {
+                        size_t currentChunkSize = min(logProgressChunkSize, numIndices);
+                        for (size_t m = firstIndex; m != firstIndex + currentChunkSize; ++m)
+                        {
+                            switch (style)
+                            {
+                                case Style::Average:
+                                    storedLuminosities(ell, h, m) = sources[h]->meanSpecificLuminosity(bin[ell], m);
+                                    break;
+                                case Style::Convolve:
+                                    storedLuminosities(ell, h, m) = sources[h]->meanSpecificLuminosity(band[ell], m);
+                                    break;
+                                default: break;
+                            }
+                        }
+                        log->infoIfElapsed(progress, currentChunkSize);
+                        firstIndex += currentChunkSize;
+                        numIndices -= currentChunkSize;
+                    }
                 });
-                ProcessManager::sumToRoot(convolvedLuminosities(ell, h), true);
+                ProcessManager::sumToRoot(storedLuminosities(ell, h), true);
             }
         }
     }
@@ -126,8 +157,8 @@ void ImportedSourceLuminosityProbe::probeImportedSources(const vector<const Impo
     // depending on the value of the path argument (to avoid duplicating a lot of code):
     //  - a luminosity volume density value at a given position or along a given path
     //  - a surface brightness value along a given path
-    auto valueAtPositionOrAlongPath = [&sources, &snapshots, numWaves, style, &wave, &bin, &cvol, &csrf,
-                                       &convolvedLuminosities](bool path, Position bfr, Direction bfk) {
+    auto valueAtPositionOrAlongPath = [&sources, &snapshots, numWaves, style, &wave, &cvol, &csrf,
+                                       &storedLuminosities](bool path, Position bfr, Direction bfk) {
         // allocate an entity collection that can be reused for all queries in a given execution thread
         thread_local EntityCollection entities;
 
@@ -158,8 +189,8 @@ void ImportedSourceLuminosityProbe::probeImportedSources(const vector<const Impo
                     switch (style)
                     {
                         case Style::Sample: luminosity = sources[h]->specificLuminosity(wave[ell], m); break;
-                        case Style::Average: luminosity = sources[h]->meanSpecificLuminosity(bin[ell], m); break;
-                        case Style::Convolve: luminosity = convolvedLuminosities(ell, h, m); break;
+                        case Style::Average: luminosity = storedLuminosities(ell, h, m); break;
+                        case Style::Convolve: luminosity = storedLuminosities(ell, h, m); break;
                     }
 
                     // convert to the proper output value and accumulate into the result array


### PR DESCRIPTION
**Description**
Precompute luminosities for all entities in `ImportedSourceLuminosityProbe` to speed up projection when `convolve=true`.

**Motivation**
The `ImportedSourceLuminosityProbe` is quite slow because it had to convolve the SED with the transmission curve for each entity, repeating this process for each pixel and recalculating the same quantity multiple times. The probe now precomputes this integral for each band and entity and stores it, allowing a fast look-up later. Although it may now compute quantities that are not used, the speed-up is still several 100 times faster for some simulations.

**Tests**
This implementation was validated by comparing projected images with the previous implementation to ensure identical results. Existing test cases already cover this functionality, so no new tests were added.

**Concerns**
Currently, SKIRT does not log anything when it precomputes the luminosities, which might make it seem like the code is stuck during this step. I’m unsure which classes are generally *allowed* to log so I left it out, but this can easily be added.