### PR TITLE
Add import capability in spherical coordinates

### DIFF
--- a/SKIRT/core/Cylinder3DSpatialGrid.hpp
+++ b/SKIRT/core/Cylinder3DSpatialGrid.hpp
@@ -9,6 +9,7 @@
 #include "Array.hpp"
 #include "CylinderSpatialGrid.hpp"
 #include "Mesh.hpp"
+class CylindricalCell;
 
 ////////////////////////////////////////////////////////////////////
 

--- a/SKIRT/core/CylindricalCellSnapshot.cpp
+++ b/SKIRT/core/CylindricalCellSnapshot.cpp
@@ -78,7 +78,7 @@ void CylindricalCellSnapshot::readAndClose()
     // inform the user
     log()->info("  Number of cells: " + std::to_string(_propv.size()));
 
-    // build CylCell objects so we can calculate volume and other geometric properties
+    // build CylindricalCell objects so we can calculate volume and other geometric properties
     _cellv.reserve(_propv.size());
     int bi = boxIndex();
     for (const Array& prop : _propv)

--- a/SKIRT/core/CylindricalCellSnapshot.cpp
+++ b/SKIRT/core/CylindricalCellSnapshot.cpp
@@ -192,7 +192,7 @@ double CylindricalCellSnapshot::mass() const
 
 Position CylindricalCellSnapshot::position(int m) const
 {
-    return Position(_cellv[m].center());
+    return _cellv[m].center();
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/CylindricalCellSnapshot.hpp
+++ b/SKIRT/core/CylindricalCellSnapshot.hpp
@@ -7,7 +7,7 @@
 #define CYLINDRICALCELLSNAPSHOT_HPP
 
 #include "BoxSearch.hpp"
-#include "CylCell.hpp"
+#include "CylindricalCell.hpp"
 #include "Snapshot.hpp"
 
 ////////////////////////////////////////////////////////////////////
@@ -181,8 +181,8 @@ private:
     int _numAutoRevolveBins{0};  // must be 2 or more to enable auto-revolve feature
 
     // data members initialized when reading the input file
-    vector<Array> _propv;    // cell properties as imported
-    vector<CylCell> _cellv;  // imported coordinates converted to a cylindrical cell object
+    vector<Array> _propv;            // cell properties as imported
+    vector<CylindricalCell> _cellv;  // imported coordinates converted to a cylindrical cell object
 
     // data members initialized after reading the input file if a density policy has been set
     Array _rhov;        // density for each cell (not normalized)

--- a/SKIRT/core/CylindricalCellSnapshot.hpp
+++ b/SKIRT/core/CylindricalCellSnapshot.hpp
@@ -30,7 +30,7 @@
 
     - two horizontal planes defined by \f$z_\text{min} \le z_\text{max}\f$.
 
-    \note Because of the limitations on the range of \f$\varphi\f$, a Cylcell cannot straddle the
+    \note Because of the limitations on the range of \f$\varphi\f$, a cell cannot straddle the
     negative x-axis of the Cartesian model coordinate system, and it cannot span more than half of
     the azimuth circle.
 

--- a/SKIRT/core/CylindricalCellSource.hpp
+++ b/SKIRT/core/CylindricalCellSource.hpp
@@ -52,7 +52,7 @@
 class CylindricalCellSource : public ImportedSource
 {
     ITEM_CONCRETE(CylindricalCellSource, ImportedSource, "a primary source imported from cylindrical cell data")
-        ATTRIBUTE_TYPE_DISPLAYED_IF(CylindricalCellMedium, "Level2")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(CylindricalCellSource, "Level2")
 
         PROPERTY_BOOL(autoRevolve, "automatically revolve 2D data to a 3D model")
         ATTRIBUTE_DEFAULT_VALUE(autoRevolve, "false")

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -257,6 +257,7 @@
 #include "StellarSurfaceSource.hpp"
 #include "StellarUnits.hpp"
 #include "SunSED.hpp"
+#include "SymCosMesh.hpp"
 #include "SymLogMesh.hpp"
 #include "SymPowMesh.hpp"
 #include "TTauriDiskGeometry.hpp"
@@ -520,6 +521,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<SymPowMesh>();
     ItemRegistry::add<LogMesh>();
     ItemRegistry::add<SymLogMesh>();
+    ItemRegistry::add<SymCosMesh>();
     ItemRegistry::add<TabulatedMesh>();
     ItemRegistry::add<FileMesh>();
     ItemRegistry::add<ListMesh>();

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -245,6 +245,7 @@
 #include "Sphere3DSpatialGrid.hpp"
 #include "SphericalBackgroundSource.hpp"
 #include "SphericalCellGeometry.hpp"
+#include "SphericalCellSource.hpp"
 #include "SphericalClipGeometryDecorator.hpp"
 #include "SpheroidalGeometryDecorator.hpp"
 #include "SpheroidalGraphiteGrainComposition.hpp"
@@ -331,6 +332,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<ParticleSource>();
     ItemRegistry::add<CellSource>();
     ItemRegistry::add<CylindricalCellSource>();
+    ItemRegistry::add<SphericalCellSource>();
     ItemRegistry::add<MeshSource>();
     ItemRegistry::add<AdaptiveMeshSource>();
     ItemRegistry::add<VoronoiMeshSource>();

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -244,6 +244,7 @@
 #include "Sphere2DSpatialGrid.hpp"
 #include "Sphere3DSpatialGrid.hpp"
 #include "SphericalBackgroundSource.hpp"
+#include "SphericalCellGeometry.hpp"
 #include "SphericalClipGeometryDecorator.hpp"
 #include "SpheroidalGeometryDecorator.hpp"
 #include "SpheroidalGraphiteGrainComposition.hpp"
@@ -455,6 +456,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<ParticleGeometry>();
     ItemRegistry::add<CellGeometry>();
     ItemRegistry::add<CylindricalCellGeometry>();
+    ItemRegistry::add<SphericalCellGeometry>();
     ItemRegistry::add<MeshGeometry>();
     ItemRegistry::add<AdaptiveMeshGeometry>();
     ItemRegistry::add<VoronoiMeshGeometry>();

--- a/SKIRT/core/SimulationItemRegistry.cpp
+++ b/SKIRT/core/SimulationItemRegistry.cpp
@@ -245,6 +245,7 @@
 #include "Sphere3DSpatialGrid.hpp"
 #include "SphericalBackgroundSource.hpp"
 #include "SphericalCellGeometry.hpp"
+#include "SphericalCellMedium.hpp"
 #include "SphericalCellSource.hpp"
 #include "SphericalClipGeometryDecorator.hpp"
 #include "SpheroidalGeometryDecorator.hpp"
@@ -538,6 +539,7 @@ SimulationItemRegistry::SimulationItemRegistry(string version, string format)
     ItemRegistry::add<ParticleMedium>();
     ItemRegistry::add<CellMedium>();
     ItemRegistry::add<CylindricalCellMedium>();
+    ItemRegistry::add<SphericalCellMedium>();
     ItemRegistry::add<MeshMedium>();
     ItemRegistry::add<AdaptiveMeshMedium>();
     ItemRegistry::add<VoronoiMeshMedium>();

--- a/SKIRT/core/Sphere1DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.cpp
@@ -4,6 +4,7 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "Sphere1DSpatialGrid.hpp"
+#include "Cubic.hpp"
 #include "NR.hpp"
 #include "PathSegmentGenerator.hpp"
 #include "Random.hpp"
@@ -42,7 +43,7 @@ double Sphere1DSpatialGrid::volume(int m) const
     if (i < 0 || i >= _Nr)
         return 0.;
     else
-        return 4. / 3. * M_PI * pow3(_rv[i], _rv[i + 1]);
+        return 4. / 3. * M_PI * Cubic::pow3(_rv[i], _rv[i + 1]);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -84,7 +85,7 @@ Position Sphere1DSpatialGrid::randomPositionInCell(int m) const
     else
     {
         Direction bfk = random()->direction();
-        double r = cbrt(pow3(_rv[i]) + pow3(_rv[i], _rv[i + 1]) * random()->uniform());
+        double r = cbrt(Cubic::pow3(_rv[i]) + Cubic::pow3(_rv[i], _rv[i + 1]) * random()->uniform());
         return Position(r, bfk);
     }
 }

--- a/SKIRT/core/Sphere2DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere2DSpatialGrid.cpp
@@ -4,7 +4,7 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "Sphere2DSpatialGrid.hpp"
-#include "FatalError.hpp"
+#include "Cubic.hpp"
 #include "NR.hpp"
 #include "PathSegmentGenerator.hpp"
 #include "Quadratic.hpp"
@@ -49,7 +49,7 @@ double Sphere2DSpatialGrid::volume(int m) const
     double rmin, thetamin, rmax, thetamax;
     if (getCoords(m, rmin, thetamin, rmax, thetamax))
     {
-        return (2. / 3.) * M_PI * pow3(rmin, rmax) * (cos(thetamin) - cos(thetamax));
+        return (2. / 3.) * M_PI * Cubic::pow3(rmin, rmax) * (cos(thetamin) - cos(thetamax));
     }
     return 0.;
 }
@@ -104,7 +104,7 @@ Position Sphere2DSpatialGrid::randomPositionInCell(int m) const
     double rmin, thetamin, rmax, thetamax;
     if (getCoords(m, rmin, thetamin, rmax, thetamax))
     {
-        double r = cbrt(pow3(rmin) + pow3(rmin, rmax) * random()->uniform());
+        double r = cbrt(Cubic::pow3(rmin) + Cubic::pow3(rmin, rmax) * random()->uniform());
         double theta = acos(cos(thetamin) + (cos(thetamax) - cos(thetamin)) * random()->uniform());
         double phi = 2.0 * M_PI * random()->uniform();
         return Position(r, theta, phi, Position::CoordinateSystem::SPHERICAL);

--- a/SKIRT/core/Sphere3DSpatialGrid.cpp
+++ b/SKIRT/core/Sphere3DSpatialGrid.cpp
@@ -4,6 +4,7 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "Sphere3DSpatialGrid.hpp"
+#include "Cubic.hpp"
 #include "FatalError.hpp"
 #include "NR.hpp"
 #include "PathSegmentGenerator.hpp"
@@ -91,7 +92,7 @@ double Sphere3DSpatialGrid::volume(int m) const
     double rmin, thetamin, phimin, rmax, thetamax, phimax;
     if (getCoords(m, rmin, thetamin, phimin, rmax, thetamax, phimax))
     {
-        return (1. / 3.) * pow3(rmin, rmax) * (cos(thetamin) - cos(thetamax)) * (phimax - phimin);
+        return (1. / 3.) * Cubic::pow3(rmin, rmax) * (cos(thetamin) - cos(thetamax)) * (phimax - phimin);
     }
     return 0.;
 }
@@ -147,7 +148,7 @@ Position Sphere3DSpatialGrid::randomPositionInCell(int m) const
     double rmin, thetamin, phimin, rmax, thetamax, phimax;
     if (getCoords(m, rmin, thetamin, phimin, rmax, thetamax, phimax))
     {
-        double r = cbrt(pow3(rmin) + pow3(rmin, rmax) * random()->uniform());
+        double r = cbrt(Cubic::pow3(rmin) + Cubic::pow3(rmin, rmax) * random()->uniform());
         double theta = acos(cos(thetamin) + (cos(thetamax) - cos(thetamin)) * random()->uniform());
         double phi = phimin + (phimax - phimin) * random()->uniform();
         return Position(r, theta, phi, Position::CoordinateSystem::SPHERICAL);

--- a/SKIRT/core/SphereSpatialGrid.hpp
+++ b/SKIRT/core/SphereSpatialGrid.hpp
@@ -45,13 +45,6 @@ public:
     //======================== Helper Functions =======================
 
 protected:
-    /** This function returns \f$x^3\f$. It is intended as a convenience for subclasses. */
-    static double pow3(double x) { return x * x * x; }
-
-    /** This function returns \f$x_1^3 - x_0^3 = (x_1-x_0)(x_1^2 + x_1 x_0 + x_0^2)\f$. It is
-        intended as a convenience for subclasses. */
-    static double pow3(double x0, double x1) { return (x1 - x0) * (x1 * x1 + x1 * x0 + x0 * x0); }
-
     /** This function initializes a polar-inclination grid from the specified mesh, making sure
         that there is exactly one boundary corresponding to the equatorial plane
         (\f$\theta=\pi/2\f$ or equivalently \f$\cos\theta=0\f$). If the mesh does not include such

--- a/SKIRT/core/SphericalCellGeometry.cpp
+++ b/SKIRT/core/SphericalCellGeometry.cpp
@@ -1,0 +1,44 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "SphericalCellGeometry.hpp"
+#include "SphericalCellSnapshot.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+Snapshot* SphericalCellGeometry::createAndOpenSnapshot()
+{
+    // create and open the snapshot
+    auto snapshot = new SphericalCellSnapshot;
+    snapshot->open(this, filename(), "spherical cells");
+
+    // honor custom column reordering
+    snapshot->useColumns(useColumns());
+
+    // configure the cell bounding box columns
+    snapshot->setCoordinateSystem(SphericalCellSnapshot::CoordinateSystem::SPHERICAL);
+    snapshot->importBox();
+    switch (autoRevolve())
+    {
+        case AutoRevolveType::None: break;
+        case AutoRevolveType::Inclination: snapshot->setNumAutoRevolveBins(numInclinationRevolveBins(), 0); break;
+        case AutoRevolveType::Azimuth: snapshot->setNumAutoRevolveBins(0, numAzimuthRevolveBins()); break;
+        case AutoRevolveType::InclinationAndAzimuth:
+            snapshot->setNumAutoRevolveBins(numInclinationRevolveBins(), numAzimuthRevolveBins());
+            break;
+    }
+
+    // configure the mass or density column
+    switch (massType())
+    {
+        case MassType::MassDensity: snapshot->importMassDensity(); break;
+        case MassType::Mass: snapshot->importMass(); break;
+        case MassType::NumberDensity: snapshot->importNumberDensity(); break;
+        case MassType::Number: snapshot->importNumber(); break;
+    }
+    return snapshot;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SphericalCellGeometry.hpp
+++ b/SKIRT/core/SphericalCellGeometry.hpp
@@ -3,35 +3,35 @@
 ////       © Astronomical Observatory, Ghent University         ////
 ///////////////////////////////////////////////////////////////// */
 
-#ifndef CYLINDRICALCELLGEOMETRY_HPP
-#define CYLINDRICALCELLGEOMETRY_HPP
+#ifndef SPHERICALCELLGEOMETRY_HPP
+#define SPHERICALCELLGEOMETRY_HPP
 
 #include "ImportedGeometry.hpp"
 
 ////////////////////////////////////////////////////////////////////
 
-/** A CylindricalCellGeometry instance represents a 3D geometry with a spatial density distribution
-    described by a list of cylindrical cells lined up with the cylindrical coordinate axes; refer
-    to the CylindricalCellSnapshot class for more information. The cell data is usually extracted
-    from a cosmological simulation snapshot, and it must be provided in a column text file
-    formatted as described below. The total mass in the geometry is normalized to unity after
-    importing the data.
+/** A SphericalCellGeometry instance represents a 3D geometry with a spatial density distribution
+    described by a list of spherical cells lined up with the spherical coordinate axes; refer to
+    the SphericalCellSnapshot class for more information. The cell data is usually extracted from a
+    cosmological simulation snapshot, and it must be provided in a column text file formatted as
+    described below. The total mass in the geometry is normalized to unity after importing the
+    data.
 
     Refer to the description of the TextInFile class for information on overall formatting and on
     how to include header lines specifying the units for each column in the input file. In case the
     input file has no unit specifications, the default units mentioned below are used instead. The
     number of columns in the input file depends on the options configured by the user for this
-    CylindricalCellGeometry instance:
+    SphericalCellGeometry instance:
 
-    \f[ R_\mathrm{min}\,(\mathrm{pc}) \quad \varphi_\mathrm{min}\,(\mathrm{deg}) \quad
-    z_\mathrm{min}\,(\mathrm{pc}) \quad R_\mathrm{max}\,(\mathrm{pc}) \quad
-    \varphi_\mathrm{max}\,(\mathrm{deg}) \quad z_\mathrm{max}\,(\mathrm{pc}) \quad \{\,
+    \f[ R_\mathrm{min}\,(\mathrm{pc}) \quad \theta_\mathrm{min}\,(\mathrm{deg}) \quad
+    \varphi_\mathrm{min}\,(\mathrm{deg}) \quad R_\mathrm{max}\,(\mathrm{pc}) \quad
+    \theta_\mathrm{max}\,(\mathrm{deg}) \quad \varphi_\mathrm{max}\,(\mathrm{deg}) \quad \{\,
     \rho\,(\text{M}_\odot\,\text{pc}^{-3}) \;\;|\;\; M\,(\text{M}_\odot) \;\;|\;\;
     n\,(\text{cm}^{-3}) \;\;|\;\; N\,(1) \,\} \quad [Z\,(1)] \quad [T\,(\mathrm{K})] \f]
 
-    The first six columns specify the coordinates of the bordering planes and cylinders of the
-    cell. The \em autoRevolve property controls a feature to automatically revolve 2D data to 3D.
-    See the CylindricalCellSnapshot class for more information.
+    The first six columns specify the coordinates of the bordering surfaces of the cell. The \em
+    autoRevolve property controls a feature to automatically revolve 1D or 2D data to 3D. See the
+    SphericalCellSnapshot class for more information.
 
     Depending on the value of the \em massType option, the seventh column lists the average mass
     density \f$\rho\f$, the integrated mass \f$M\f$, the average number density \f$n\f$, or the
@@ -46,7 +46,7 @@
     temperature, the mass and density of the cell are set to zero, regardless of the mass or
     density specified in the seventh column. If the \em importTemperature option is disabled, or
     the maximum temperature value is set to zero, such a cutoff is not applied. */
-class CylindricalCellGeometry : public ImportedGeometry
+class SphericalCellGeometry : public ImportedGeometry
 {
     /** The enumeration type indicating the type of mass quantity to be imported. */
     ENUM_DEF(MassType, MassDensity, Mass, NumberDensity, Number)
@@ -56,17 +56,31 @@ class CylindricalCellGeometry : public ImportedGeometry
         ENUM_VAL(MassType, Number, "number (volume-integrated number density)")
     ENUM_END()
 
-    ITEM_CONCRETE(CylindricalCellGeometry, ImportedGeometry, "a geometry imported from cylindrical cell data")
-        ATTRIBUTE_TYPE_DISPLAYED_IF(CylindricalCellGeometry, "Level2")
+    /** The enumeration type for selecting the auto-revolve option. */
+    ENUM_DEF(AutoRevolveType, None, Inclination, Azimuth, InclinationAndAzimuth)
+        ENUM_VAL(AutoRevolveType, None, "no auto-revolve")
+        ENUM_VAL(AutoRevolveType, Inclination, "auto-revolve inclination")
+        ENUM_VAL(AutoRevolveType, Azimuth, "auto-revolve azimuth")
+        ENUM_VAL(AutoRevolveType, InclinationAndAzimuth, "auto-revolve both inclination and azimuth")
+    ENUM_END()
 
-        PROPERTY_BOOL(autoRevolve, "automatically revolve 2D data to a 3D model")
-        ATTRIBUTE_DEFAULT_VALUE(autoRevolve, "false")
+    ITEM_CONCRETE(SphericalCellGeometry, ImportedGeometry, "a geometry imported from spherical cell data")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(SphericalCellMedium, "Level2")
 
-        PROPERTY_INT(numAutoRevolveBins, "the number of azimuth bins for auto-revolving 2D data")
-        ATTRIBUTE_RELEVANT_IF(numAutoRevolveBins, "autoRevolve")
-        ATTRIBUTE_MIN_VALUE(numAutoRevolveBins, "2")
-        ATTRIBUTE_MAX_VALUE(numAutoRevolveBins, "1024")
-        ATTRIBUTE_DEFAULT_VALUE(numAutoRevolveBins, "16")
+        PROPERTY_ENUM(autoRevolve, AutoRevolveType, "automatically revolve 1D or 2D data to a 3D model")
+        ATTRIBUTE_DEFAULT_VALUE(autoRevolve, "None")
+
+        PROPERTY_INT(numInclinationRevolveBins, "the number of inclination bins for auto-revolving 1D or 2D data")
+        ATTRIBUTE_RELEVANT_IF(numInclinationRevolveBins, "autoRevolveInclination|autoRevolveInclinationAndAzimuth")
+        ATTRIBUTE_MIN_VALUE(numInclinationRevolveBins, "2")
+        ATTRIBUTE_MAX_VALUE(numInclinationRevolveBins, "1024")
+        ATTRIBUTE_DEFAULT_VALUE(numInclinationRevolveBins, "16")
+
+        PROPERTY_INT(numAzimuthRevolveBins, "the number of azimuth bins for auto-revolving 1D or 2D data")
+        ATTRIBUTE_RELEVANT_IF(numAzimuthRevolveBins, "autoRevolveAzimuth|autoRevolveInclinationAndAzimuth")
+        ATTRIBUTE_MIN_VALUE(numAzimuthRevolveBins, "2")
+        ATTRIBUTE_MAX_VALUE(numAzimuthRevolveBins, "1024")
+        ATTRIBUTE_DEFAULT_VALUE(numAzimuthRevolveBins, "16")
 
         PROPERTY_ENUM(massType, MassType, "the type of mass quantity to be imported")
         ATTRIBUTE_DEFAULT_VALUE(massType, "MassDensity")
@@ -76,7 +90,7 @@ class CylindricalCellGeometry : public ImportedGeometry
     //============= Construction - Setup - Destruction =============
 
 protected:
-    /** This function constructs a new CylindricalCellGeometry object, calls its open() function,
+    /** This function constructs a new SphericalCellGeometry object, calls its open() function,
         configures it to import a mass or density column, and finally returns a pointer to the
         object. Ownership of the Snapshot object is transferred to the caller. */
     Snapshot* createAndOpenSnapshot() override;

--- a/SKIRT/core/SphericalCellGeometry.hpp
+++ b/SKIRT/core/SphericalCellGeometry.hpp
@@ -23,8 +23,8 @@
     number of columns in the input file depends on the options configured by the user for this
     SphericalCellGeometry instance:
 
-    \f[ R_\mathrm{min}\,(\mathrm{pc}) \quad \theta_\mathrm{min}\,(\mathrm{deg}) \quad
-    \varphi_\mathrm{min}\,(\mathrm{deg}) \quad R_\mathrm{max}\,(\mathrm{pc}) \quad
+    \f[ r_\mathrm{min}\,(\mathrm{pc}) \quad \theta_\mathrm{min}\,(\mathrm{deg}) \quad
+    \varphi_\mathrm{min}\,(\mathrm{deg}) \quad r_\mathrm{max}\,(\mathrm{pc}) \quad
     \theta_\mathrm{max}\,(\mathrm{deg}) \quad \varphi_\mathrm{max}\,(\mathrm{deg}) \quad \{\,
     \rho\,(\text{M}_\odot\,\text{pc}^{-3}) \;\;|\;\; M\,(\text{M}_\odot) \;\;|\;\;
     n\,(\text{cm}^{-3}) \;\;|\;\; N\,(1) \,\} \quad [Z\,(1)] \quad [T\,(\mathrm{K})] \f]
@@ -65,7 +65,7 @@ class SphericalCellGeometry : public ImportedGeometry
     ENUM_END()
 
     ITEM_CONCRETE(SphericalCellGeometry, ImportedGeometry, "a geometry imported from spherical cell data")
-        ATTRIBUTE_TYPE_DISPLAYED_IF(SphericalCellMedium, "Level2")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(SphericalCellGeometry, "Level2")
 
         PROPERTY_ENUM(autoRevolve, AutoRevolveType, "automatically revolve 1D or 2D data to a 3D model")
         ATTRIBUTE_DEFAULT_VALUE(autoRevolve, "None")

--- a/SKIRT/core/SphericalCellMedium.cpp
+++ b/SKIRT/core/SphericalCellMedium.cpp
@@ -1,0 +1,44 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "SphericalCellMedium.hpp"
+#include "SphericalCellSnapshot.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+Snapshot* SphericalCellMedium::createAndOpenSnapshot()
+{
+    // create and open the snapshot
+    auto snapshot = new SphericalCellSnapshot;
+    snapshot->open(this, filename(), "spherical cells");
+
+    // honor custom column reordering
+    snapshot->useColumns(useColumns());
+
+    // configure the cell bounding box columns
+    snapshot->setCoordinateSystem(SphericalCellSnapshot::CoordinateSystem::SPHERICAL);
+    snapshot->importBox();
+    switch (autoRevolve())
+    {
+        case AutoRevolveType::None: break;
+        case AutoRevolveType::Inclination: snapshot->setNumAutoRevolveBins(numInclinationRevolveBins(), 0); break;
+        case AutoRevolveType::Azimuth: snapshot->setNumAutoRevolveBins(0, numAzimuthRevolveBins()); break;
+        case AutoRevolveType::InclinationAndAzimuth:
+            snapshot->setNumAutoRevolveBins(numInclinationRevolveBins(), numAzimuthRevolveBins());
+            break;
+    }
+
+    // configure the mass or density column
+    switch (massType())
+    {
+        case MassType::MassDensity: snapshot->importMassDensity(); break;
+        case MassType::Mass: snapshot->importMass(); break;
+        case MassType::NumberDensity: snapshot->importNumberDensity(); break;
+        case MassType::Number: snapshot->importNumber(); break;
+    }
+    return snapshot;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SphericalCellMedium.hpp
+++ b/SKIRT/core/SphericalCellMedium.hpp
@@ -1,0 +1,119 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef SPHERICALCELLMEDIUM_HPP
+#define SPHERICALCELLMEDIUM_HPP
+
+#include "ImportedMedium.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** A SphericalCellMedium instance represents a transfer medium with a spatial density distribution
+    (and, optionally, other properties) described by a list of spherical cells lined up with the
+    spherical coordinate axes; refer to the SphericalCellSnapshot class for more information. The
+    cell data is usually extracted from a cosmological simulation snapshot, and it must be provided
+    in a column text file formatted as described below.
+
+    Refer to the description of the TextInFile class for information on overall formatting and on
+    how to include header lines specifying the units for each column in the input file. In case the
+    input file has no unit specifications, the default units mentioned below are used instead. The
+    number of columns expected in the input file depends on the options configured by the user for
+    this SphericalCellMedium instance:
+
+    \f[ r_\mathrm{min}\,(\mathrm{pc}) \quad \theta_\mathrm{min}\,(\mathrm{deg}) \quad
+    \varphi_\mathrm{min}\,(\mathrm{deg}) \quad r_\mathrm{max}\,(\mathrm{pc}) \quad
+    \theta_\mathrm{max}\,(\mathrm{deg}) \quad \varphi_\mathrm{max}\,(\mathrm{deg}) \quad \{\,
+    \rho\,(\text{M}_\odot\,\text{pc}^{-3}) \;\;|\;\; M\,(\text{M}_\odot) \;\;|\;\;
+    n\,(\text{cm}^{-3}) \;\;|\;\; N\,(1) \,\} \quad [Z\,(1)] \quad [T\,(\mathrm{K})] \f] \f[ [
+    v_x\,(\mathrm{km/s}) \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) ] \quad [
+    B_x\,(\mu\mathrm{G}) \quad B_y\,(\mu\mathrm{G}) \quad B_z\,(\mu\mathrm{G}) ] \quad [
+    \dots\text{mix family params}\dots ] \f]
+
+    The first six columns specify the coordinates of the bordering surfaces of the cell. The \em
+    autoRevolve property controls a feature to automatically revolve 1D or 2D data to 3D. See the
+    SphericalCellSnapshot class for more information.
+
+    Depending on the value of the \em massType option, the seventh column lists the average mass
+    density \f$\rho\f$, the integrated mass \f$M\f$, the average number density \f$n\f$, or the
+    integrated number density \f$N\f$ for the cell.
+
+    If the \em importMetallicity option is enabled, the next column specifies a "metallicity"
+    fraction, which is multiplied with the mass/density column to obtain the actual mass/density of
+    the cell. If the \em importTemperature option is enabled, the next column specifies a
+    temperature. If this temperature is higher than the maximum configured temperature, the mass
+    and density of the cell are set to zero, regardless of the mass or density specified in the
+    seventh column. If the \em importTemperature option is disabled, or the maximum temperature
+    value is set to zero, such a cutoff is not applied.
+
+    If both the \em importMetallicity and \em importTemperature options are enabled, this leads to
+    the following expression for the mass of an imported particle:
+
+    \f[ M_\mathrm{imported} = \begin{cases} f_\mathrm{mass}\,Z\,M & \mathrm{if}\; T<T_\mathrm{max}
+    \;\mathrm{or}\; T_\mathrm{max}=0 \\ 0 & \mathrm{otherwise} \end{cases} \f]
+
+    If the \em importVelocity option is enabled, the subsequent three columns specify the
+    \f$v_R\f$, \f$v_\varphi\f$, \f$v_z\f$ components of the bulk velocity, in spherical
+    coordinates, for the material represented by the cell.
+
+    If the \em importMagneticField option is enabled, the subsequent three columns specify the
+    \f$B_R\f$, \f$B_\varphi\f$, \f$B_z\f$ magnetic field vector components for the cell, in
+    spherical coordinates.
+
+    Finally, if the \em importVariableMixParams option is enabled, the remaining columns specify
+    the parameters used by the configured material mix family to select a particular material mix
+    for the cell. */
+class SphericalCellMedium : public ImportedMedium
+{
+    /** The enumeration type indicating the type of mass quantity to be imported. */
+    ENUM_DEF(MassType, MassDensity, Mass, NumberDensity, Number)
+        ENUM_VAL(MassType, MassDensity, "mass density")
+        ENUM_VAL(MassType, Mass, "mass (volume-integrated)")
+        ENUM_VAL(MassType, NumberDensity, "number density")
+        ENUM_VAL(MassType, Number, "number (volume-integrated)")
+    ENUM_END()
+
+    /** The enumeration type for selecting the auto-revolve option. */
+    ENUM_DEF(AutoRevolveType, None, Inclination, Azimuth, InclinationAndAzimuth)
+        ENUM_VAL(AutoRevolveType, None, "no auto-revolve")
+        ENUM_VAL(AutoRevolveType, Inclination, "auto-revolve inclination")
+        ENUM_VAL(AutoRevolveType, Azimuth, "auto-revolve azimuth")
+        ENUM_VAL(AutoRevolveType, InclinationAndAzimuth, "auto-revolve both inclination and azimuth")
+    ENUM_END()
+
+    ITEM_CONCRETE(SphericalCellMedium, ImportedMedium, "a transfer medium imported from spherical cell data")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(SphericalCellMedium, "Level2")
+
+        PROPERTY_ENUM(autoRevolve, AutoRevolveType, "automatically revolve 1D or 2D data to a 3D model")
+        ATTRIBUTE_DEFAULT_VALUE(autoRevolve, "None")
+
+        PROPERTY_INT(numInclinationRevolveBins, "the number of inclination bins for auto-revolving 1D or 2D data")
+        ATTRIBUTE_RELEVANT_IF(numInclinationRevolveBins, "autoRevolveInclination|autoRevolveInclinationAndAzimuth")
+        ATTRIBUTE_MIN_VALUE(numInclinationRevolveBins, "2")
+        ATTRIBUTE_MAX_VALUE(numInclinationRevolveBins, "1024")
+        ATTRIBUTE_DEFAULT_VALUE(numInclinationRevolveBins, "16")
+
+        PROPERTY_INT(numAzimuthRevolveBins, "the number of azimuth bins for auto-revolving 1D or 2D data")
+        ATTRIBUTE_RELEVANT_IF(numAzimuthRevolveBins, "autoRevolveAzimuth|autoRevolveInclinationAndAzimuth")
+        ATTRIBUTE_MIN_VALUE(numAzimuthRevolveBins, "2")
+        ATTRIBUTE_MAX_VALUE(numAzimuthRevolveBins, "1024")
+        ATTRIBUTE_DEFAULT_VALUE(numAzimuthRevolveBins, "16")
+
+        PROPERTY_ENUM(massType, MassType, "the type of mass quantity to be imported")
+        ATTRIBUTE_DEFAULT_VALUE(massType, "MassDensity")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function constructs a new SphericalCellSnapshot object, calls its open() function,
+        configures it to import a mass or density column, and finally returns a pointer to the
+        object. Ownership of the Snapshot object is transferred to the caller. */
+    Snapshot* createAndOpenSnapshot() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SphericalCellSnapshot.cpp
+++ b/SKIRT/core/SphericalCellSnapshot.cpp
@@ -1,0 +1,268 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "SphericalCellSnapshot.hpp"
+#include "EntityCollection.hpp"
+#include "FatalError.hpp"
+#include "Log.hpp"
+#include "NR.hpp"
+#include "Random.hpp"
+#include "StringUtils.hpp"
+#include "Cubic.hpp"
+#include "TextInFile.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void SphericalCellSnapshot::setNumAutoRevolveBins(int numAzimuthBins, int numInclinationBins)
+{
+    _numAutoAzimuthBins = numAzimuthBins;
+    _numAutoInclinationBins = numInclinationBins;
+}
+
+////////////////////////////////////////////////////////////////////
+
+void SphericalCellSnapshot::readAndClose()
+{
+    // read the snapshot cell info into memory
+    _propv = infile()->readAllRows();
+
+    // close the file
+    close();
+
+    // perform 2D auto-revolve if requested
+    if (_numAutoAzimuthBins >= 2 && _numAutoInclinationBins < 2)
+    {
+        int num2DCells = _propv.size();
+        log()->info("  Auto-revolving " + std::to_string(num2DCells) + " 2D cells using "
+                    + std::to_string(_numAutoAzimuthBins) + " azimuth bins");
+
+        // construct the azimuth grid, and make sure the endpoints are exact
+        Array phiv;
+        NR::buildLinearGrid(phiv, -M_PI, M_PI, _numAutoAzimuthBins);
+        phiv[0] = -M_PI;
+        phiv[_numAutoAzimuthBins] = M_PI;
+
+        // get indices for columns we need during the revolve operation (mass indices might be -1)
+        int iphimin = boxIndex() + 2;
+        int iphimax = boxIndex() + 5;
+        int imass1 = massIndex();
+        int imass2 = initialMassIndex();
+        int imass3 = currentMassIndex();
+
+        // move the original 2D cells to a temporary vector
+        vector<Array> prop2Dv;
+        _propv.swap(prop2Dv);
+        _propv.reserve(num2DCells * _numAutoAzimuthBins);
+
+        // loop over the original 2D cells
+        for (Array& prop : prop2Dv)
+        {
+            // verify that the cell is 2D
+            if (prop[iphimin] || prop[iphimax]) throw FATALERROR("2D cell in input file has nonzero azimuth angle(s)");
+
+            // distribute masses over azimuth bins
+            if (imass1 >= 0) prop[imass1] /= _numAutoAzimuthBins;
+            if (imass2 >= 0) prop[imass2] /= _numAutoAzimuthBins;
+            if (imass3 >= 0) prop[imass3] /= _numAutoAzimuthBins;
+
+            // loop over azimuth bins and add a new 3D cell for each
+            for (int k = 0; k != _numAutoAzimuthBins; ++k)
+            {
+                prop[iphimin] = phiv[k];
+                prop[iphimax] = phiv[k + 1];
+                _propv.emplace_back(prop);
+            }
+        }
+    }
+
+    // inform the user
+    log()->info("  Number of cells: " + std::to_string(_propv.size()));
+
+    // build SphericalCell objects so we can calculate volume and other geometric properties
+    _cellv.reserve(_propv.size());
+    int bi = boxIndex();
+    for (const Array& prop : _propv)
+        _cellv.emplace_back(prop[bi], prop[bi + 1], prop[bi + 2], prop[bi + 3], prop[bi + 4], prop[bi + 5]);
+
+    // if a mass density policy has been set, calculate masses and densities for all cells
+    if (hasMassDensityPolicy()) calculateDensityAndMass(_rhov, _cumrhov, _mass);
+
+    // if applicable, convert velocity and/or magnetic field vectors from spherical to Cartesian coordinates
+    int vi = velocityIndex();
+    int mi = magneticFieldIndex();
+    if (vi >= 0 || mi >= 0)
+    {
+        for (Array& prop : _propv)
+        {
+            // get the central inclination angle of the cell
+            double theta = 0.5 * (prop[bi + 1] + prop[bi + 4]);
+            double sintheta = sin(theta);
+            double costheta = cos(theta);
+
+            // get the central azimuth angle of the cell
+            double phi = 0.5 * (prop[bi + 2] + prop[bi + 5]);
+            double sinphi = sin(phi);
+            double cosphi = cos(phi);
+
+            // convert the velocity vector
+            if (vi >= 0)
+            {
+                double vr = prop[vi];
+                double vtheta = prop[vi + 1];
+                double vphi = prop[vi + 2];
+                prop[vi + 0] = vr * sintheta * cosphi + vtheta * costheta * cosphi - vphi * sinphi;
+                prop[vi + 1] = vr * sintheta * sinphi + vtheta * costheta * sinphi + vphi * cosphi;
+                prop[vi + 2] = vr * costheta - vtheta * sintheta;
+            }
+
+            // convert the magnetic field vector
+            if (mi >= 0)
+            {
+                double Br = prop[mi];
+                double Btheta = prop[mi + 1];
+                double Bphi = prop[mi + 2];
+                prop[mi + 0] = Br * sintheta * cosphi + Btheta * costheta * cosphi - Bphi * sinphi;
+                prop[mi + 1] = Br * sintheta * sinphi + Btheta * costheta * sinphi + Bphi * cosphi;
+                prop[mi + 2] = Br * costheta - Btheta * sintheta;
+            }
+        }
+    }
+
+    // if needed, construct a search structure for the cells
+    if (hasMassDensityPolicy() || needGetEntities())
+    {
+        log()->info("Constructing search grid for " + std::to_string(_propv.size()) + " cells...");
+        auto bounds = [this](int m) { return _cellv[m].boundingBox(); };
+        auto intersects = [this](int m, const Box& box) { return box.intersects(_cellv[m].boundingBox()); };
+        _search.loadEntities(_propv.size(), bounds, intersects);
+
+        int nb = _search.numBlocks();
+        log()->info("  Number of blocks in grid: " + std::to_string(nb * nb * nb) + " (" + std::to_string(nb) + "^3)");
+        log()->info("  Smallest number of cells per block: " + std::to_string(_search.minEntitiesPerBlock()));
+        log()->info("  Largest  number of cells per block: " + std::to_string(_search.maxEntitiesPerBlock()));
+        log()->info("  Average  number of cells per block: "
+                    + StringUtils::toString(_search.avgEntitiesPerBlock(), 'f', 1));
+    }
+}
+
+////////////////////////////////////////////////////////////////////
+
+Box SphericalCellSnapshot::extent() const
+{
+    // if there is a search structure, ask it to return the extent (it is already calculated)
+    if (_search.numBlocks()) return _search.extent();
+
+    // otherwise find the spatial range of the cells
+    Box extent;
+    for (const auto& cell : _cellv) extent.extend(cell.boundingBox());
+    return extent;
+}
+
+////////////////////////////////////////////////////////////////////
+
+int SphericalCellSnapshot::numEntities() const
+{
+    return _propv.size();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double SphericalCellSnapshot::volume(int m) const
+{
+    return _cellv[m].volume();
+}
+
+////////////////////////////////////////////////////////////////////
+
+double SphericalCellSnapshot::density(int m) const
+{
+    return _rhov[m];
+}
+
+////////////////////////////////////////////////////////////////////
+
+double SphericalCellSnapshot::density(Position bfr) const
+{
+    for (int m : _search.entitiesFor(bfr))
+    {
+        if (_cellv[m].contains(bfr)) return _rhov[m];
+    }
+    return 0.;
+}
+
+////////////////////////////////////////////////////////////////////
+
+double SphericalCellSnapshot::mass() const
+{
+    return _mass;
+}
+
+////////////////////////////////////////////////////////////////////
+
+Position SphericalCellSnapshot::position(int m) const
+{
+    return _cellv[m].center();
+}
+
+////////////////////////////////////////////////////////////////////
+
+Position SphericalCellSnapshot::generatePosition(int m) const
+{
+    double rmin, thetamin, phimin, rmax, thetamax, phimax;
+    _cellv[m].extent(rmin, thetamin, phimin, rmax, thetamax, phimax);
+
+    double r = cbrt(Cubic::pow3(rmin) + Cubic::pow3(rmin, rmax) * random()->uniform());
+    double theta = acos(cos(thetamin) + (cos(thetamax) - cos(thetamin)) * random()->uniform());
+    double phi = phimin + (phimax - phimin) * random()->uniform();
+    return Position(r, theta, phi, Position::CoordinateSystem::SPHERICAL);
+}
+
+////////////////////////////////////////////////////////////////////
+
+Position SphericalCellSnapshot::generatePosition() const
+{
+    // if there are no cells, return the origin
+    if (_propv.empty()) return Position();
+
+    // select a cell according to its mass contribution
+    int m = NR::locateClip(_cumrhov, random()->uniform());
+
+    return generatePosition(m);
+}
+
+////////////////////////////////////////////////////////////////////
+
+const Array& SphericalCellSnapshot::properties(int m) const
+{
+    return _propv[m];
+}
+
+////////////////////////////////////////////////////////////////////
+
+void SphericalCellSnapshot::getEntities(EntityCollection& entities, Position bfr) const
+{
+    for (int m : _search.entitiesFor(bfr))
+    {
+        if (_cellv[m].contains(bfr))
+        {
+            entities.addSingle(m);
+            return;
+        }
+    }
+    entities.clear();
+}
+
+////////////////////////////////////////////////////////////////////
+
+void SphericalCellSnapshot::getEntities(EntityCollection& entities, Position bfr, Direction bfk) const
+{
+    entities.clear();
+    for (int m : _search.entitiesFor(bfr, bfk))
+    {
+        entities.add(m, _cellv[m].intersection(bfr, bfk));
+    };
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SphericalCellSnapshot.hpp
+++ b/SKIRT/core/SphericalCellSnapshot.hpp
@@ -32,8 +32,8 @@
 
     \note Because of the limitations on the range of \f$\varphi\f$, a cell cannot straddle the
     negative x-axis of the Cartesian model coordinate system, and it cannot span more than half of
-    the azimuth circle. Also, because of the limitations on the range of \f$\theta\f$, a
-    cell cannot straddle the z-axis of the Cartesian model coordinate system.
+    the azimuth circle. Also, because of the limitations on the range of \f$\theta\f$, a cell
+    cannot straddle the z-axis of the Cartesian model coordinate system.
 
     The intention is for the cells to define a partition of the spatial domain, and usually they
     will, however this is not enforced. When two or more cells overlap at a given position, the
@@ -55,26 +55,28 @@
 
     <em>2D or 1D data</em>
 
-    If the 2D auto-revolve feature is enabled, each line in the text file represents a 2D cell in
-    the meridional plane with \f$\varphi=0\f$. The cells are defined using just the radial and
-    inclination borders. After reading the text file, these 2D cells will automatically be revolved
-    around the z-axis using a user-specified number of \f$\varphi\f$ bins.
+    If the inclination auto-revolve feature is enabled, each line in the text file represents a 2D
+    cell in the equatorial plane, defined using just the \f$r\f$ and \f$\varphi\f$ borders. After
+    reading the text file, these cells will automatically be revolved around the origin using a
+    user-specified number of \f$\theta\f$ bins. To enable this feature, the number of inclination
+    auto-revolve bins must be set to at least 2, and all \f$\theta_\text{min}\f$ and
+    \f$\theta_\text{max}\f$ values in the input file must be zero. A nonzero value in these columns
+    will trigger a fatal error.
 
-    If the 1D auto-revolve feature is enabled, each line in the text file represents a 1D cell
-    along the vertical axis (with \f$\theta=0\f$ and \f$\varphi=0\f$). The cells are defined using
-    just the radial borders. After reading the text file, these 1D cells will automatically be
-    revolved around the origin using a user-specified number of \f$\theta\f$ and \f$\varphi\f$
-    bins.
+    If the azimuth auto-revolve feature is enabled, each line in the text file represents a 2D cell
+    in a meridional plane, defined using just the \f$r\f$ and \f$\theta\f$ borders. After reading
+    the text file, these cells will automatically be revolved around the z-axis using a
+    user-specified number of \f$\varphi\f$ bins. To enable this feature, the number of azimuth
+    auto-revolve bins must be set to at least 2, and all \f$\varphi_\text{min}\f$ and
+    \f$\varphi_\text{max}\f$ values in the input file must be zero. A nonzero value in these
+    columns will trigger a fatal error.
 
-    To enable the 2D auto-revolve feature, the number of azimuth auto-revolve bins must be set to
-    at least 2. To enable the 1D auto-revolve feature, the number of inclination auto-revolve bins
-    must be set to at least 2 as well. Also, for 2D all \f$\varphi_\text{min}\f$ and
-    \f$\varphi_\text{max}\f$ values in the input file must be exactly zero. For 1D, all
-    \f$\theta_\text{min}\f$ and \f$\theta_\text{max}\f$ values in the input file must be exactly
-    zero as well. A nonzero value in these columns will trigger a fatal error.
+    Finally, if both the inclination and azimuth auto-revolve features are enabled, each line in
+    the text file represents a 1D cell along a radial axis, defined using just the \f$r\f$ borders.
+    After reading the text file, these 1D cells will automatically be revolved using the
+    user-specified number of \f$\theta\f$ and \f$\varphi\f$ bins.
 
-    \note It is \em not allowed to omit the irrelevant columns; they must be present with zero
-    values.
+    \note It is \em not allowed to omit the unused columns; they must be present with zero values.
 
     If the 1D or 2D input file specifies an integrated mass type (as opposed to a mass density),
     the mass of each 1D or 2D cell is evenly distributed over the revolved 3D bins.
@@ -96,9 +98,9 @@ class SphericalCellSnapshot : public Snapshot
     //================= Construction - Destruction =================
 
 public:
-    /** This function sets the number of auto-revolve azimuth and inclination bins; see the class
+    /** This function sets the number of auto-revolve inclination and azimuth bins; see the class
         header for more information. */
-    void setNumAutoRevolveBins(int numAzimuthBins, int numInclinationBins);
+    void setNumAutoRevolveBins(int numInclinationBins, int numAzimuthBins);
 
     //========== Reading ==========
 
@@ -190,8 +192,8 @@ public:
 
 private:
     // data members initialized during configuration
-    int _numAutoAzimuthBins{0};      // must be 2 or more to enable 2D auto-revolve feature
-    int _numAutoInclinationBins{0};  // must be 2 or more as well to enable 1D auto-revolve feature
+    int _numAutoInclinationBins{0};  // must be 2 or more to enable inclination auto-revolve feature
+    int _numAutoAzimuthBins{0};      // must be 2 or more to enable azimuth auto-revolve feature
 
     // data members initialized when reading the input file
     vector<Array> _propv;          // cell properties as imported

--- a/SKIRT/core/SphericalCellSnapshot.hpp
+++ b/SKIRT/core/SphericalCellSnapshot.hpp
@@ -1,0 +1,209 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef SPHERICALCELLSNAPSHOT_HPP
+#define SPHERICALCELLSNAPSHOT_HPP
+
+#include "BoxSearch.hpp"
+#include "Snapshot.hpp"
+#include "SphericalCell.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** A SphericalCellSnapshot object represents the data in a 1D, 2D or 3D snapshot imported from a
+    column text file and discretized using spherical coordinates.
+
+    <em>3D data</em>
+
+    By default, each line in the text file represents a 3D spherical cell lined up with the
+    spherical coordinate axes. The columns specify the coordinates of the bordering surfaces, along
+    with properties such as density. Specifically, each cell is bordered by:
+
+    - two spheres centered on the origin defined by radii \f$0 \le r_\text{min} \le
+    r_\text{max}\f$,
+
+    - two polar half-cones defined by inclination angles \f$0 \le \theta_\text{min} \le
+    \theta_\text{max} \le \pi\f$,
+
+    - two meridional half-planes defined by azimuth angles \f$-\pi \le \varphi_\text{min} \le
+    \varphi_\text{max} \le \pi\f$ with \f$\varphi_\text{max} - \varphi_\text{min} \le \pi\f$.
+
+    \note Because of the limitations on the range of \f$\varphi\f$, a cell cannot straddle the
+    negative x-axis of the Cartesian model coordinate system, and it cannot span more than half of
+    the azimuth circle. Also, because of the limitations on the range of \f$\theta\f$, a
+    cell cannot straddle the z-axis of the Cartesian model coordinate system.
+
+    The intention is for the cells to define a partition of the spatial domain, and usually they
+    will, however this is not enforced. When two or more cells overlap at a given position, the
+    properties for that position will be taken from the cell that is listed first in the imported
+    file. When no cells overlap a given position, the density at that position is considered to be
+    zero. To avoid thin slices of zero density between cells, the coordinates for common walls or
+    corners in neighboring cells should be identical.
+
+    <em>Velocities</em>
+
+    If velocity or magnetic field vectors are being imported, the class converts these from
+    spherical to Cartesian coordinates using \f[\begin{aligned} v_\text{x} &=
+    v_{r}\sin\theta\cos\varphi + v_\theta\cos\theta\cos\varphi - v_\varphi\sin\varphi \\ v_\text{y}
+    &= v_{r}\sin\theta\sin\varphi + v_\theta\cos\theta\sin\varphi + v_\varphi\cos\varphi \\
+    v_\text{z} &= v_{r}\cos\theta - v_\theta\sin\theta \end{aligned}\f] where \f$\theta =
+    (\theta_\text{min} + \theta_\text{max})/2\f$ and \f$\varphi = (\varphi_\text{min} +
+    \varphi_\text{max})/2\f$ are the central inclination and azimuth angles of the corresponding
+    cell.
+
+    <em>2D or 1D data</em>
+
+    If the 2D auto-revolve feature is enabled, each line in the text file represents a 2D cell in
+    the meridional plane with \f$\varphi=0\f$. The cells are defined using just the radial and
+    inclination borders. After reading the text file, these 2D cells will automatically be revolved
+    around the z-axis using a user-specified number of \f$\varphi\f$ bins.
+
+    If the 1D auto-revolve feature is enabled, each line in the text file represents a 1D cell
+    along the vertical axis (with \f$\theta=0\f$ and \f$\varphi=0\f$). The cells are defined using
+    just the radial borders. After reading the text file, these 1D cells will automatically be
+    revolved around the origin using a user-specified number of \f$\theta\f$ and \f$\varphi\f$
+    bins.
+
+    To enable the 2D auto-revolve feature, the number of azimuth auto-revolve bins must be set to
+    at least 2. To enable the 1D auto-revolve feature, the number of inclination auto-revolve bins
+    must be set to at least 2 as well. Also, for 2D all \f$\varphi_\text{min}\f$ and
+    \f$\varphi_\text{max}\f$ values in the input file must be exactly zero. For 1D, all
+    \f$\theta_\text{min}\f$ and \f$\theta_\text{max}\f$ values in the input file must be exactly
+    zero as well. A nonzero value in these columns will trigger a fatal error.
+
+    \note It is \em not allowed to omit the irrelevant columns; they must be present with zero
+    values.
+
+    If the 1D or 2D input file specifies an integrated mass type (as opposed to a mass density),
+    the mass of each 1D or 2D cell is evenly distributed over the revolved 3D bins.
+
+    For a model that includes velocities, the velocities will be converted from spherical to
+    Cartesian coordinates as described above after revolving to a 3D representation. Because the
+    result of this conversion depends on the inclination and azimuth angles, the user must set a
+    sufficiently high number of auto-revolve bins to properly resolve the revolved velocity field.
+
+    <em>Implementation</em>
+
+    This class is based on the Snapshot class; it uses the facilities offered there to configure
+    and read the snapshot data, and it implements all functions in the general Snapshot public
+    interface. If the snapshot configuration requires the ability to determine the density at a
+    given spatial position, an effort is made to accelerate the search for the cell containing that
+    position even for a large number of cells. */
+class SphericalCellSnapshot : public Snapshot
+{
+    //================= Construction - Destruction =================
+
+public:
+    /** This function sets the number of auto-revolve azimuth and inclination bins; see the class
+        header for more information. */
+    void setNumAutoRevolveBins(int numAzimuthBins, int numInclinationBins);
+
+    //========== Reading ==========
+
+public:
+    /** This function reads the snapshot data from the input file, honoring the options set through
+        the configuration functions, stores the data for later use, and closes the file by calling
+        the base class Snapshot::close() function.
+
+        Cells with an associated temperature above the cutoff temperature (if one has been
+        configured) are assigned a density value of zero, so that they have zero mass regardless of
+        the imported mass/density properties. Note that we cannot simply ignore these cells because
+        an empty cell may overlap and thus hide (a portion of) a nonempty cell later in the list.
+
+        If velocity and/or magnetic field vectors are being imported, the function converts these
+        from spherical to Cartesian coordinates as described in the class header.
+
+        The function also logs some statistical information about the import. If the snapshot
+        configuration requires the ability to determine the density at a given spatial position,
+        this function builds a data structure that accelerates the search for the appropriate cell.
+        */
+    void readAndClose() override;
+
+    //=========== Interrogation ==========
+
+public:
+    /** This function returns the bounding box lined up with the coordinate axes surrounding all
+        cells. */
+    Box extent() const override;
+
+    /** This function returns the number of cells in the snapshot. */
+    int numEntities() const override;
+
+    /** This function returns the volume of the cell with index \em m. If the index is out of
+        range, the behavior is undefined. */
+    double volume(int m) const override;
+
+    /** This function returns the mass density associated with the cell with index \em m. If no
+        density policy has been set or no mass information is being imported, or if the index is
+        out of range, the behavior is undefined. */
+    double density(int m) const override;
+
+    /** This function returns the mass density of the cell containing the specified point
+        \f${\bf{r}}\f$. If the point is not inside any cell, the function returns zero. If no
+        density policy has been set or no mass information is being imported, the behavior is
+        undefined. */
+    double density(Position bfr) const override;
+
+    /** This function returns the total mass represented by the snapshot, in other words the sum of
+        the masses of all cells. If no density policy has been set or no mass information is being
+        imported, the behavior is undefined. */
+    double mass() const override;
+
+    /** This function returns the position of the center of the cell with index \em m. If the index
+        is out of range, the behavior is undefined. */
+    Position position(int m) const override;
+
+    /** This function returns a random position drawn uniformly from the cell with index \em m. If
+        the index is out of range, the behavior is undefined. */
+    Position generatePosition(int m) const override;
+
+    /** This function returns a random position within the spatial domain of the snapshot, drawn
+        from the mass density distribution represented by the snapshot. The function first selects
+        a random cell from the discrete probability distribution formed by the respective cell
+        masses, and then generates a random position within that cell. If no density policy has
+        been set or no mass information is being imported, the behavior is undefined. */
+    Position generatePosition() const override;
+
+protected:
+    /** This function returns a reference to an array containing the imported properties (in column
+        order) for the cell with index \f$0\le m \le N_\mathrm{ent}-1\f$. If the index is out of
+        range, the behavior is undefined. */
+    const Array& properties(int m) const override;
+
+public:
+    /** This function sets the specified entity collection to the cell containing the specified
+        point \f${\bf{r}}\f$, or to the empty collection if the point is outside the domain or if
+        there are no cells in the snapshot. If the search data structures were not created,
+        invoking this function causes undefined behavior. */
+    void getEntities(EntityCollection& entities, Position bfr) const override;
+
+    /** This function replaces the contents of the specified entity collection by the set of cells
+        that overlap the specified path with starting point \f${\bf{r}}\f$ and direction
+        \f${\bf{k}}\f$. The weight of a cell is given by the length of the path segment inside the
+        cell. If the path does not overlap any cells, the collection will be empty. If the search
+        data structures were not created, invoking this function causes undefined behavior. */
+    void getEntities(EntityCollection& entities, Position bfr, Direction bfk) const override;
+
+    //======================== Data Members ========================
+
+private:
+    // data members initialized during configuration
+    int _numAutoAzimuthBins{0};      // must be 2 or more to enable 2D auto-revolve feature
+    int _numAutoInclinationBins{0};  // must be 2 or more as well to enable 1D auto-revolve feature
+
+    // data members initialized when reading the input file
+    vector<Array> _propv;          // cell properties as imported
+    vector<SphericalCell> _cellv;  // imported coordinates converted to a spherical cell object
+
+    // data members initialized after reading the input file if a density policy has been set
+    Array _rhov;        // density for each cell (not normalized)
+    Array _cumrhov;     // normalized cumulative density distribution for cells
+    double _mass{0.};   // total effective mass
+    BoxSearch _search;  // search structure for locating cells
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SphericalCellSource.cpp
+++ b/SKIRT/core/SphericalCellSource.cpp
@@ -1,0 +1,36 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "SphericalCellSource.hpp"
+#include "SphericalCellSnapshot.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+Snapshot* SphericalCellSource::createAndOpenSnapshot()
+{
+    // create and open the snapshot
+    auto snapshot = new SphericalCellSnapshot;
+    snapshot->open(this, filename(), "spherical source cells");
+
+    // honor custom column reordering
+    snapshot->useColumns(useColumns());
+
+    // configure the cell bounding box columns
+    snapshot->setCoordinateSystem(SphericalCellSnapshot::CoordinateSystem::SPHERICAL);
+    snapshot->importBox();
+    switch (autoRevolve())
+    {
+        case AutoRevolveType::None: break;
+        case AutoRevolveType::Inclination: snapshot->setNumAutoRevolveBins(numInclinationRevolveBins(), 0); break;
+        case AutoRevolveType::Azimuth: snapshot->setNumAutoRevolveBins(0, numAzimuthRevolveBins()); break;
+        case AutoRevolveType::InclinationAndAzimuth:
+            snapshot->setNumAutoRevolveBins(numInclinationRevolveBins(), numAzimuthRevolveBins());
+            break;
+    }
+
+    return snapshot;
+}
+
+////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SphericalCellSource.hpp
+++ b/SKIRT/core/SphericalCellSource.hpp
@@ -1,0 +1,93 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef SPHERICALCELLSOURCE_HPP
+#define SPHERICALCELLSOURCE_HPP
+
+#include "ImportedSource.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** A SphericalCellSource instance represents a primary radiation source with a spatial and
+    spectral luminosity distribution described by a list of spherical cells lined up with the
+    spherical coordinate axes; refer to the SphericalCellSnapshot class for more information. The
+    cell data is usually extracted from a cosmological simulation snapshot, and it must be provided
+    in a column text file formatted as described below.
+
+    Refer to the description of the TextInFile class for information on overall formatting and on
+    how to include header lines specifying the units for each column in the input file. In case the
+    input file has no unit specifications, the default units mentioned below are used instead. The
+    number of columns expected in the input file depends on the options configured by the user for
+    this SphericalCellSource instance, including the selected %SEDFamily:
+
+    \f[ r_\mathrm{min}\,(\mathrm{pc}) \quad \theta_\mathrm{min}\,(\mathrm{deg}) \quad
+    \varphi_\mathrm{min}\,(\mathrm{deg}) \quad r_\mathrm{max}\,(\mathrm{pc}) \quad
+    \theta_\mathrm{max}\,(\mathrm{deg}) \quad \varphi_\mathrm{max}\,(\mathrm{deg}) \quad [
+    v_x\,(\mathrm{km/s}) \quad v_y\,(\mathrm{km/s}) \quad v_z\,(\mathrm{km/s}) \quad [
+    \sigma_v\,(\mathrm{km/s}) ] \quad [M_\mathrm{curr}\,(\mathrm{M}_\odot)] \quad b\,(1) \quad
+    \dots \text{SED family parameters} \dots \f]
+
+    The first six columns specify the coordinates of the bordering surfaces of the cell. The \em
+    autoRevolve property controls a feature to automatically revolve 2D data to 3D. See the
+    SphericalCellSnapshot class for more information.
+
+    If the \em importVelocity option is enabled, the next three columns specify the \f$v_r\f$,
+    \f$v_\theta\f$, \f$v_\varphi\f$ components of the bulk velocity, in spherical coordinates, for
+    the source population represented by the cell. If additionally the \em importVelocityDispersion
+    option is enabled, the next column specifies the velocity dispersion \f$\sigma_v\f$, adjusting
+    the velocity for each photon packet launch with a random offset sampled from a spherically
+    symmetric Gaussian distribution. If the \em importCurrentMass option is enabled, the next
+    column provides the current mass of the cell, \f$M_\mathrm{curr}\f$. This mass is currently
+    only used for probing the input model. If the \em importBias option is enabled, the next column
+    specifies the bias parameter, \f$b\f$, which is used to bias the photon sampling for each cell
+    (see the documentation of the ImportedSource class).
+
+    The remaining columns specify the parameters required by the configured %SED family to select
+    and scale the appropriate %SED. For example for the Bruzual-Charlot %SED family, the remaining
+    columns provide the initial mass, the metallicity, and the age of the stellar population
+    represented by the cell. Refer to the documentation of the configured type of SEDFamily for
+    information about the expected parameters and their default units. */
+class SphericalCellSource : public ImportedSource
+{
+    /** The enumeration type for selecting the auto-revolve option. */
+    ENUM_DEF(AutoRevolveType, None, Inclination, Azimuth, InclinationAndAzimuth)
+        ENUM_VAL(AutoRevolveType, None, "no auto-revolve")
+        ENUM_VAL(AutoRevolveType, Inclination, "auto-revolve inclination")
+        ENUM_VAL(AutoRevolveType, Azimuth, "auto-revolve azimuth")
+        ENUM_VAL(AutoRevolveType, InclinationAndAzimuth, "auto-revolve both inclination and azimuth")
+    ENUM_END()
+
+    ITEM_CONCRETE(SphericalCellSource, ImportedSource, "a primary source imported from spherical cell data")
+        ATTRIBUTE_TYPE_DISPLAYED_IF(SphericalCellSource, "Level2")
+
+        PROPERTY_ENUM(autoRevolve, AutoRevolveType, "automatically revolve 1D or 2D data to a 3D model")
+        ATTRIBUTE_DEFAULT_VALUE(autoRevolve, "None")
+
+        PROPERTY_INT(numInclinationRevolveBins, "the number of inclination bins for auto-revolving 1D or 2D data")
+        ATTRIBUTE_RELEVANT_IF(numInclinationRevolveBins, "autoRevolveInclination|autoRevolveInclinationAndAzimuth")
+        ATTRIBUTE_MIN_VALUE(numInclinationRevolveBins, "2")
+        ATTRIBUTE_MAX_VALUE(numInclinationRevolveBins, "1024")
+        ATTRIBUTE_DEFAULT_VALUE(numInclinationRevolveBins, "16")
+
+        PROPERTY_INT(numAzimuthRevolveBins, "the number of azimuth bins for auto-revolving 1D or 2D data")
+        ATTRIBUTE_RELEVANT_IF(numAzimuthRevolveBins, "autoRevolveAzimuth|autoRevolveInclinationAndAzimuth")
+        ATTRIBUTE_MIN_VALUE(numAzimuthRevolveBins, "2")
+        ATTRIBUTE_MAX_VALUE(numAzimuthRevolveBins, "1024")
+        ATTRIBUTE_DEFAULT_VALUE(numAzimuthRevolveBins, "16")
+
+    ITEM_END()
+
+    //============= Construction - Setup - Destruction =============
+
+protected:
+    /** This function constructs a new SphericalCellSource object, calls its open() function, and
+        returns a pointer to the object. Ownership of the Snapshot object is transferred to the
+        caller. */
+    Snapshot* createAndOpenSnapshot() override;
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/core/SymCosMesh.cpp
+++ b/SKIRT/core/SymCosMesh.cpp
@@ -1,0 +1,24 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "SymCosMesh.hpp"
+#include "NR.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+Array SymCosMesh::mesh() const
+{
+    Array tv;
+
+    // get a linear grid in the interval [1, -1]
+    NR::buildLinearGrid(tv, 1., -1., numBins());
+
+    // convert it to the desired spacing and scale
+    tv = acos(tv) / M_PI;
+
+    return tv;
+}
+
+//////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/SymCosMesh.hpp
+++ b/SKIRT/core/SymCosMesh.hpp
@@ -1,0 +1,43 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef SYMCOSMESH_HPP
+#define SYMCOSMESH_HPP
+
+#include "Mesh.hpp"
+
+//////////////////////////////////////////////////////////////////////
+
+/** The SymCosMesh class represents a symmetric cosine mesh. The mesh points are spaced such that
+    when the mesh is used to subdivide a spherical volume into conical slices by polar inclination
+    angle \f$0 \le \theta \le \pi\f$, the resulting slices have equal volume. Specifically, the
+    mesh is contructed as follows:
+
+    - construct an equidistant linear mesh over the (inverted) interval \f$[1,-1]\f$ with the
+    requested number of bins;
+
+    - replace each mesh point by the arc-cosine of its value, resulting in a mesh with the intended
+    spacing over the interval \f$[0,\pi]\f$;
+
+    - divide each mesh point by \f$\pi\f$, rescaling the mesh to the unit interval \f$[0,1]\f$.
+
+    The scaling in the latter step is required to conform to the standards for all Mesh classes.
+    When the mesh is actually used to discretize an inclination angle, it will be scaled back to
+    the range \f$[0,\pi]\f$. */
+class SymCosMesh : public Mesh
+{
+    ITEM_CONCRETE(SymCosMesh, Mesh, "a symmetric cosine mesh")
+    ITEM_END()
+
+    //======================== Other Functions =======================
+
+public:
+    /** This function returns an array containing the mesh points. */
+    Array mesh() const override;
+};
+
+//////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/utils/Cubic.hpp
+++ b/SKIRT/utils/Cubic.hpp
@@ -1,0 +1,27 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef CUBIC_HPP
+#define CUBIC_HPP
+
+#include "Basics.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+/** This static class offers some basic functions to raise values to the third power. */
+class Cubic
+{
+public:
+    /** This function returns \f$x^3\f$. */
+    static double pow3(double x) { return x * x * x; }
+
+    /** This function returns \f$x_1^3 - x_0^3 = (x_1-x_0)(x_1^2 + x_1 x_0 + x_0^2)\f$. The second
+        form is used because it is more numerically stable. */
+    static double pow3(double x0, double x1) { return (x1 - x0) * (x1 * x1 + x1 * x0 + x0 * x0); }
+};
+
+////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/utils/CylCell.cpp
+++ b/SKIRT/utils/CylCell.cpp
@@ -40,7 +40,7 @@ bool CylCell::contains(Vec r) const
     double R = sqrt(r.x() * r.x() + r.y() * r.y());
     if (R < _Rmin || R >= _Rmax) return false;
 
-    // as an expection, don't exclude pi from the maximum
+    // as an exception, don't exclude pi from the maximum
     double phi = atan2(r.y(), r.x());
     if (phi < _phimin || phi > _phimax) return false;
     if (phi != M_PI && phi == _phimax) return false;

--- a/SKIRT/utils/CylCell.hpp
+++ b/SKIRT/utils/CylCell.hpp
@@ -22,7 +22,7 @@
 
     - two horizontal planes defined by \f$z_\text{min} \le z_\text{max}\f$.
 
-    \note Because of the limitations on the range of \f$\varphi\f$, a Cylcell cannot straddle the
+    \note Because of the limitations on the range of \f$\varphi\f$, a CylCell cannot straddle the
     negative x-axis of the Cartesian model coordinate system, and it cannot span more than half of
     the azimuth circle.
 

--- a/SKIRT/utils/CylindricalCell.cpp
+++ b/SKIRT/utils/CylindricalCell.cpp
@@ -3,27 +3,27 @@
 ////       © Astronomical Observatory, Ghent University         ////
 ///////////////////////////////////////////////////////////////// */
 
-#include "CylCell.hpp"
+#include "CylindricalCell.hpp"
 #include "Quadratic.hpp"
 #include <array>
 
 //////////////////////////////////////////////////////////////////////
 
-CylCell::CylCell(double Rmin, double phimin, double zmin, double Rmax, double phimax, double zmax)
+CylindricalCell::CylindricalCell(double Rmin, double phimin, double zmin, double Rmax, double phimax, double zmax)
     : _Rmin(Rmin), _phimin(phimin), _zmin(zmin), _Rmax(Rmax), _phimax(phimax), _zmax(zmax), _cosphimin(cos(phimin)),
       _sinphimin(sin(phimin)), _cosphimax(cos(phimax)), _sinphimax(sin(phimax))
 {}
 
 //////////////////////////////////////////////////////////////////////
 
-double CylCell::volume() const
+double CylindricalCell::volume() const
 {
     return 0.5 * (_Rmax - _Rmin) * (_Rmax + _Rmin) * (_phimax - _phimin) * (_zmax - _zmin);
 }
 
 //////////////////////////////////////////////////////////////////////
 
-Vec CylCell::center() const
+Vec CylindricalCell::center() const
 {
     double R = 0.5 * (_Rmin + _Rmax);
     double phi = 0.5 * (_phimin + _phimax);
@@ -33,7 +33,7 @@ Vec CylCell::center() const
 
 //////////////////////////////////////////////////////////////////////
 
-bool CylCell::contains(Vec r) const
+bool CylindricalCell::contains(Vec r) const
 {
     if (r.z() < _zmin || r.z() >= _zmax) return false;
 
@@ -50,7 +50,7 @@ bool CylCell::contains(Vec r) const
 
 //////////////////////////////////////////////////////////////////////
 
-Box CylCell::boundingBox() const
+Box CylindricalCell::boundingBox() const
 {
     // the (x,y) coordinates of the four corner points
     double x1 = _Rmin * _cosphimin;
@@ -79,7 +79,7 @@ Box CylCell::boundingBox() const
 
 //////////////////////////////////////////////////////////////////////
 
-double CylCell::intersection(Vec r, const Vec k) const
+double CylindricalCell::intersection(Vec r, const Vec k) const
 {
     // small value used to check for parallel directions
     constexpr double eps = 1e-12;

--- a/SKIRT/utils/CylindricalCell.cpp
+++ b/SKIRT/utils/CylindricalCell.cpp
@@ -4,6 +4,8 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "CylindricalCell.hpp"
+#include "Box.hpp"
+#include "Position.hpp"
 #include "Quadratic.hpp"
 #include <array>
 
@@ -23,12 +25,12 @@ double CylindricalCell::volume() const
 
 //////////////////////////////////////////////////////////////////////
 
-Vec CylindricalCell::center() const
+Position CylindricalCell::center() const
 {
     double R = 0.5 * (_Rmin + _Rmax);
     double phi = 0.5 * (_phimin + _phimax);
     double z = 0.5 * (_zmin + _zmax);
-    return Vec(R * cos(phi), R * sin(phi), z);
+    return Position(R, phi, z, Position::CoordinateSystem::CYLINDRICAL);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/CylindricalCell.hpp
+++ b/SKIRT/utils/CylindricalCell.hpp
@@ -3,15 +3,15 @@
 ////       © Astronomical Observatory, Ghent University         ////
 ///////////////////////////////////////////////////////////////// */
 
-#ifndef CYLCELL_HPP
-#define CYLCELL_HPP
+#ifndef CYLINDRICALCELL_HPP
+#define CYLINDRICALCELL_HPP
 
 #include "Box.hpp"
 
 //////////////////////////////////////////////////////////////////////
 
-/** CylCell is a low-level class for working with basic three-dimensional cells in cylindrical
-    coordinates. Each CylCell instance represents a cell bordered by:
+/** CylindricalCell is a low-level class for working with basic three-dimensional cells in
+    cylindrical coordinates. Each CylindricalCell instance represents a cell bordered by:
 
     - two vertical cylinders centered on the origin defined by radii \f$0 \le R_\text{min} \le
     R_\text{max}\f$,
@@ -22,24 +22,24 @@
 
     - two horizontal planes defined by \f$z_\text{min} \le z_\text{max}\f$.
 
-    \note Because of the limitations on the range of \f$\varphi\f$, a CylCell cannot straddle the
-    negative x-axis of the Cartesian model coordinate system, and it cannot span more than half of
-    the azimuth circle.
+    \note Because of the limitations on the range of \f$\varphi\f$, a CylindricalCell cannot
+    straddle the negative x-axis of the Cartesian model coordinate system, and it cannot span more
+    than half of the azimuth circle.
 
     The class offers functions to retrieve various basic properties of the cell, such as its border
     coordinates and its volume, and for geometric operations such as determining whether a given
     Cartesian position is inside the cell. */
-class CylCell
+class CylindricalCell
 {
 public:
     /** The default constructor creates an empty cell at the origin, i.e. it initializes all border
         coordinates to zero. */
-    CylCell() {}
+    CylindricalCell() {}
 
     /** This constructor initializes the cell border coordinates to the values provided as
         arguments. It does not verify that these values conform to the limits described in the
         class header. Non-comforming values lead to undefined behavior. */
-    CylCell(double Rmin, double phimin, double zmin, double Rmax, double phimax, double zmax);
+    CylindricalCell(double Rmin, double phimin, double zmin, double Rmax, double phimax, double zmax);
 
     /** This function stores the cell border coordinates in the provided arguments. */
     void extent(double& Rmin, double& phimin, double& zmin, double& Rmax, double& phimax, double& zmax) const

--- a/SKIRT/utils/CylindricalCell.hpp
+++ b/SKIRT/utils/CylindricalCell.hpp
@@ -6,7 +6,9 @@
 #ifndef CYLINDRICALCELL_HPP
 #define CYLINDRICALCELL_HPP
 
-#include "Box.hpp"
+#include "Vec.hpp"
+class Box;
+class Position;
 
 //////////////////////////////////////////////////////////////////////
 
@@ -83,7 +85,7 @@ public:
 
         As stated above the function returns this position after converting it to Cartesian
         coordinates. */
-    Vec center() const;
+    Position center() const;
 
     /** This function returns true if the Cartesian position \f${\bf{r}}=(x,y,z)\f$ is inside the
         cell, and false otherwise. A position on an edge or face on the "lower" side of the cell is

--- a/SKIRT/utils/CylindricalCell.hpp
+++ b/SKIRT/utils/CylindricalCell.hpp
@@ -28,7 +28,7 @@
 
     The class offers functions to retrieve various basic properties of the cell, such as its border
     coordinates and its volume, and for geometric operations such as determining whether a given
-    Cartesian position is inside the cell. */
+    Cartesian position is inside the cell or calculating the intersection with a ray. */
 class CylindricalCell
 {
 public:
@@ -38,7 +38,7 @@ public:
 
     /** This constructor initializes the cell border coordinates to the values provided as
         arguments. It does not verify that these values conform to the limits described in the
-        class header. Non-comforming values lead to undefined behavior. */
+        class header. Non-conforming values lead to undefined behavior. */
     CylindricalCell(double Rmin, double phimin, double zmin, double Rmax, double phimax, double zmax);
 
     /** This function stores the cell border coordinates in the provided arguments. */
@@ -70,15 +70,6 @@ public:
     /** This function returns the \f$z_\text{max}\f$ border coordinate of the cell. */
     double zmax() const { return _zmax; }
 
-    /** This function returns the width \f$R_\text{max}-R_\text{min}\f$ of the cell. */
-    double Rwidth() const { return _Rmax - _Rmin; }
-
-    /** This function returns the width \f$\varphi_\text{max}-\varphi_\text{min}\f$ of the cell. */
-    double phiwidth() const { return _phimax - _phimin; }
-
-    /** This function returns the width \f$z_\text{max}-z_\text{min}\f$ of the cell. */
-    double zwidth() const { return _zmax - _zmin; }
-
     /** This function returns the volume of the cell, given by \f$\frac{1}{2}
         (R_\text{max}^2-R_\text{min}^2) (\varphi_\text{max}-\varphi_\text{min})
         (z_\text{max}-z_\text{min})\f$. */
@@ -105,10 +96,10 @@ public:
         cuboid lined up with the Cartesian coordinate axes that encloses the cell.
 
         The bounds along the z-axis are the same for Cylindrical and Cartesian coordinates, but the
-        function needs to to specifically determine the bounding rectangle projected on the xy
-        plane. This bounding rectangle must of course enclose the four corner points of the cell.
-        In addition, if the cell straddles one of the coordinate axes, the bounding rectangle must
-        also enclose a point on that axis at radius Rmax. */
+        function needs to specifically determine the bounding rectangle projected on the xy plane.
+        This bounding rectangle must of course enclose the four corner points of the cell. In
+        addition, if the cell straddles one of the coordinate axes, the bounding rectangle must
+        also enclose a point on that axis at radius \f$R_\text{max}\f$. */
     Box boundingBox() const;
 
     /** This function intersects the receiving cell with a ray (half-line) defined by the specified

--- a/SKIRT/utils/NR.hpp
+++ b/SKIRT/utils/NR.hpp
@@ -533,7 +533,7 @@ public:
         Consider the pdf values \f$p_i\f$ and \f$p_{i+1}\f$ at two consecutive grid points
         \f$x_i\f$ and \f$x_{i+1}\f$. Assuming power-law behavior, the pdf between these two grid
         points can be written as \f[ p(x) = p_i \left(\frac{x}{x_i}\right)^{\alpha_i},
-        \quad\mathrm{with}\; \alpha_i = \frac{\ln p_{i+1}/\ln p_i}{\ln x_{i+1}/\ln x_i} \f]
+        \quad\mathrm{with}\; \alpha_i = \frac{\ln(p_{i+1}/p_i)} {\ln(x_{i+1}/x_i)} \f]
 
         The area under the curve is then \f[ \int_{x_i}^{x_{i+1}} p(x)\,\mathrm{d}x =
         \int_{x_i}^{x_{i+1}} p_i \left(\frac{x}{x_i}\right)^{\alpha_i}\mathrm{d}x = p_i x_i

--- a/SKIRT/utils/SphericalCell.cpp
+++ b/SKIRT/utils/SphericalCell.cpp
@@ -89,6 +89,20 @@ Box SphericalCell::boundingBox() const
             xmax = max(xmax, x);
             ymax = max(ymax, y);
         }
+
+        void extendx(double r, double sintheta, double sign)
+        {
+            double x = r * sintheta * sign;
+            xmin = min(xmin, x);
+            xmax = max(xmax, x);
+        }
+
+        void extendy(double r, double sintheta, double sign)
+        {
+            double y = r * sintheta * sign;
+            ymin = min(ymin, y);
+            ymax = max(ymax, y);
+        }
     };
 
     // initialize the equatorial bounds from the projected coordinates of the eight corner points
@@ -110,30 +124,10 @@ Box SphericalCell::boundingBox() const
     }
 
     // extend with radial points if phi crosses an axis
-    if (_phimin <= -M_PI_2 && _phimax >= -M_PI_2)  // negative y
-    {
-        constexpr double cosphi = 0.;
-        constexpr double sinphi = -1.;
-        eqbox.extend(_rmax, _sinthetamin, cosphi, sinphi);
-        eqbox.extend(_rmax, _sinthetamax, cosphi, sinphi);
-        if (thetacross) eqbox.extend(_rmax, 1., cosphi, sinphi);
-    }
-    if (_phimin <= 0. && _phimax >= 0.)  // positive x
-    {
-        constexpr double cosphi = 1.;
-        constexpr double sinphi = 0.;
-        eqbox.extend(_rmax, _sinthetamin, cosphi, sinphi);
-        eqbox.extend(_rmax, _sinthetamax, cosphi, sinphi);
-        if (thetacross) eqbox.extend(_rmax, 1., cosphi, sinphi);
-    }
-    if (_phimin <= M_PI_2 && _phimax >= M_PI_2)  // positive y
-    {
-        constexpr double cosphi = 0.;
-        constexpr double sinphi = 1.;
-        eqbox.extend(_rmax, _sinthetamin, cosphi, sinphi);
-        eqbox.extend(_rmax, _sinthetamax, cosphi, sinphi);
-        if (thetacross) eqbox.extend(_rmax, 1., cosphi, sinphi);
-    }
+    double sintheta = thetacross ? 1. : max(_sinthetamin, _sinthetamax);
+    if (_phimin <= -M_PI_2 && _phimax >= -M_PI_2) eqbox.extendy(_rmax, sintheta, -1.);  // negative y
+    if (_phimin <= M_PI_2 && _phimax >= M_PI_2) eqbox.extendy(_rmax, sintheta, 1.);  // positive y
+    if (_phimin <= 0. && _phimax >= 0.) eqbox.extendx(_rmax, sintheta, 1.);  // positive x
 
     return Box(eqbox.xmin, eqbox.ymin, zmin, eqbox.xmax, eqbox.ymax, zmax);
 }

--- a/SKIRT/utils/SphericalCell.cpp
+++ b/SKIRT/utils/SphericalCell.cpp
@@ -1,0 +1,193 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#include "SphericalCell.hpp"
+#include "Box.hpp"
+#include "Cubic.hpp"
+#include "Position.hpp"
+#include "Quadratic.hpp"
+#include <array>
+
+//////////////////////////////////////////////////////////////////////
+
+SphericalCell::SphericalCell(double rmin, double thetamin, double phimin, double rmax, double thetamax, double phimax)
+    : _rmin(rmin), _thetamin(thetamin), _phimin(phimin), _rmax(rmax), _thetamax(thetamax), _phimax(phimax),
+      _cosphimin(cos(phimin)), _sinphimin(sin(phimin)), _cosphimax(cos(phimax)), _sinphimax(sin(phimax)),
+      _costhetamin(cos(thetamin)), _sinthetamin(sin(thetamin)), _costhetamax(cos(thetamax)), _sinthetamax(sin(thetamax))
+{}
+
+//////////////////////////////////////////////////////////////////////
+
+double SphericalCell::volume() const
+{
+    return (1. / 3.) * Cubic::pow3(_rmin, _rmax) * (_costhetamin - _costhetamax) * (_phimax - _phimin);
+}
+
+//////////////////////////////////////////////////////////////////////
+
+Position SphericalCell::center() const
+{
+    double r = 0.5 * (_rmin + _rmax);
+    double theta = 0.5 * (_thetamin + _thetamax);
+    double phi = 0.5 * (_phimin + _phimax);
+    return Position(r, theta, phi, Position::CoordinateSystem::SPHERICAL);
+}
+
+//////////////////////////////////////////////////////////////////////
+
+bool SphericalCell::contains(Vec bfr) const
+{
+    double r = bfr.norm();
+    if (r < _rmin || r >= _rmax) return false;
+    // avoid trying to determine the angles for the origin
+    if (r == 0. && _rmin == 0.) return true;
+
+    // as an exception, don't exclude pi from the maximum
+    double theta = acos(bfr.z() / r);
+    if (theta < _thetamin || theta > _thetamax) return false;
+    if (theta != M_PI && theta == _thetamax) return false;
+
+    // as an exception, don't exclude pi from the maximum
+    double phi = atan2(bfr.y(), bfr.x());
+    if (phi < _phimin || phi > _phimax) return false;
+    if (phi != M_PI && phi == _phimax) return false;
+
+    return true;
+}
+
+//////////////////////////////////////////////////////////////////////
+
+Box SphericalCell::boundingBox() const
+{
+    // find the vertical bounds in meridional plane
+    double z1 = _rmin * _costhetamin;
+    double z2 = _rmin * _costhetamax;
+    double z3 = _rmax * _costhetamin;
+    double z4 = _rmax * _costhetamax;
+    double zmin = min({z1, z2, z3, z4});
+    double zmax = max({z1, z2, z3, z4});
+
+    // trivial class representing an equatorial Cartesian bounding box enclosing the projection of points defined
+    // in spherical coordinates; because the sine and cosine for the relevant angles are precalculated, these
+    // values are specified rather than the angles themselves.
+    struct EqBox
+    {
+        double xmin, ymin, xmax, ymax;
+
+        EqBox(double r, double sintheta, double cosphi, double sinphi)
+            : xmin(r * sintheta * cosphi), ymin(r * sintheta * sinphi), xmax(xmin), ymax(ymin)
+        {}
+
+        void extend(double r, double sintheta, double cosphi, double sinphi)
+        {
+            double x = r * sintheta * cosphi;
+            double y = r * sintheta * sinphi;
+            xmin = min(xmin, x);
+            ymin = min(ymin, y);
+            xmax = max(xmax, x);
+            ymax = max(ymax, y);
+        }
+    };
+
+    // initialize the equatorial bounds from the projected coordinates of the eight corner points
+    EqBox eqbox(_rmin, _sinthetamin, _cosphimin, _sinphimin);
+    eqbox.extend(_rmin, _sinthetamin, _cosphimax, _sinphimax);
+    eqbox.extend(_rmin, _sinthetamax, _cosphimin, _sinphimin);
+    eqbox.extend(_rmin, _sinthetamax, _cosphimax, _sinphimax);
+    eqbox.extend(_rmax, _sinthetamin, _cosphimin, _sinphimin);
+    eqbox.extend(_rmax, _sinthetamin, _cosphimax, _sinphimax);
+    eqbox.extend(_rmax, _sinthetamax, _cosphimin, _sinphimin);
+    eqbox.extend(_rmax, _sinthetamax, _cosphimax, _sinphimax);
+
+    // extend with radial points if theta crosses the equatorial plane
+    double thetacross = (_thetamin <= M_PI_2 && _thetamax >= M_PI_2);
+    if (thetacross)
+    {
+        eqbox.extend(_rmax, 1., _cosphimin, _sinphimin);
+        eqbox.extend(_rmax, 1., _cosphimax, _sinphimax);
+    }
+
+    // extend with radial points if phi crosses an axis
+    if (_phimin <= -M_PI_2 && _phimax >= -M_PI_2)  // negative y
+    {
+        constexpr double cosphi = 0.;
+        constexpr double sinphi = -1.;
+        eqbox.extend(_rmax, _sinthetamin, cosphi, sinphi);
+        eqbox.extend(_rmax, _sinthetamax, cosphi, sinphi);
+        if (thetacross) eqbox.extend(_rmax, 1., cosphi, sinphi);
+    }
+    if (_phimin <= 0. && _phimax >= 0.)  // positive x
+    {
+        constexpr double cosphi = 1.;
+        constexpr double sinphi = 0.;
+        eqbox.extend(_rmax, _sinthetamin, cosphi, sinphi);
+        eqbox.extend(_rmax, _sinthetamax, cosphi, sinphi);
+        if (thetacross) eqbox.extend(_rmax, 1., cosphi, sinphi);
+    }
+    if (_phimin <= M_PI_2 && _phimax >= M_PI_2)  // positive y
+    {
+        constexpr double cosphi = 0.;
+        constexpr double sinphi = 1.;
+        eqbox.extend(_rmax, _sinthetamin, cosphi, sinphi);
+        eqbox.extend(_rmax, _sinthetamax, cosphi, sinphi);
+        if (thetacross) eqbox.extend(_rmax, 1., cosphi, sinphi);
+    }
+
+    return Box(eqbox.xmin, eqbox.ymin, zmin, eqbox.xmax, eqbox.ymax, zmax);
+}
+
+//////////////////////////////////////////////////////////////////////
+
+double SphericalCell::intersection(Vec r, const Vec k) const
+{
+    // small value used to check for parallel directions
+    constexpr double eps = 1e-12;
+
+    // allocate room for the 8 possible intersections (1 per plane and 2 per cylinder)
+    // plus the starting position (which starts the first segment).
+    // initialize the array to zeroes:
+    //  - leave the first value at zero to represent the starting position
+    //  - overwrite the other values for each intersection, or leave at zero if there is none
+    enum { START, ZMIN, ZMAX, PHIMIN, PHIMAX, RMIN1, RMIN2, RMAX1, RMAX2, LEN };
+    std::array<double, LEN> sv = {};
+
+    // intersection with meridional phimin plane
+    {
+        double q = k.x() * _sinphimin - k.y() * _cosphimin;
+        if (abs(q) >= eps)
+        {
+            sv[PHIMIN] = -(r.x() * _sinphimin - r.y() * _cosphimin) / q;
+        }
+    }
+
+    // intersection with meridional phimax plane
+    {
+        double q = k.x() * _sinphimax - k.y() * _cosphimax;
+        if (abs(q) >= eps)
+        {
+            sv[PHIMAX] = -(r.x() * _sinphimax - r.y() * _cosphimax) / q;
+        }
+    }
+
+    // sort the intersection points
+    std::sort(sv.begin(), sv.end());
+
+    // accumulate the length of all segments that are beyond the starting position and inside the cell
+    // (there is always at least one zero in the list)
+    double length = 0.;
+    for (auto sp = std::find_if(sv.begin() + 1, sv.end(), [](double s) { return s > 0; }); sp != sv.end(); ++sp)
+    {
+        // get the start and end points for this segment
+        double s1 = *(sp - 1);
+        double s2 = *sp;
+
+        // if the midpoint is inside the cell, add the segment length
+        double s = 0.5 * (s1 + s2);
+        if (contains(Vec(r.x() + s * k.x(), r.y() + s * k.y(), r.z() + s * k.z()))) length += s2 - s1;
+    }
+    return length;
+}
+
+//////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/SphericalCell.hpp
+++ b/SKIRT/utils/SphericalCell.hpp
@@ -1,0 +1,161 @@
+/*//////////////////////////////////////////////////////////////////
+////     The SKIRT project -- advanced radiative transfer       ////
+////       © Astronomical Observatory, Ghent University         ////
+///////////////////////////////////////////////////////////////// */
+
+#ifndef SPHERICALCELL_HPP
+#define SPHERICALCELL_HPP
+
+#include "Vec.hpp"
+class Box;
+class Position;
+
+//////////////////////////////////////////////////////////////////////
+
+/** SphericalCell is a low-level class for working with basic three-dimensional cells in spherical
+    coordinates. Each SphericalCell instance represents a cell bordered by:
+
+    - two spheres centered on the origin defined by radii \f$0 \le r_\text{min} \le
+    r_\text{max}\f$,
+
+    - two polar half-cones defined by inclination angles \f$0 \le \theta_\text{min} \le
+    \theta_\text{max} \le \pi\\f$,
+
+    - two meridional half-planes (with \f$r>0\f$) defined by azimuth angles \f$-\pi \le
+    \varphi_\text{min} \le \varphi_\text{max} \le \pi\f$ with \f$\varphi_\text{max} -
+    \varphi_\text{min} \le \pi\f$,
+
+    \note Because of the limitations on the range of \f$\varphi\f$, a SphericalCell cannot straddle
+    the negative x-axis of the Cartesian model coordinate system, and it cannot span more than half
+    of the azimuth circle. Also, because of the limitations on the range of \f$\theta\f$, a
+    SphericalCell cannot straddle the z-axis of the Cartesian model coordinate system.
+
+    The class offers functions to retrieve various basic properties of the cell, such as its border
+    coordinates and its volume, and for geometric operations such as determining whether a given
+    Cartesian position is inside the cell or calculating the intersection with a ray. */
+class SphericalCell
+{
+public:
+    /** The default constructor creates an empty cell at the origin, i.e. it initializes all border
+        coordinates to zero. */
+    SphericalCell() {}
+
+    /** This constructor initializes the cell border coordinates to the values provided as
+        arguments. It does not verify that these values conform to the limits described in the
+        class header. Non-conforming values lead to undefined behavior. */
+    SphericalCell(double rmin, double thetamin, double phimin, double rmax, double thetamax, double phimax);
+
+    /** This function stores the cell border coordinates in the provided arguments. */
+    void extent(double& rmin, double& thetamin, double& phimin, double& rmax, double& thetamax, double& phimax) const
+    {
+        rmin = _rmin;
+        thetamin = _thetamin;
+        phimin = _phimin;
+        rmax = _rmax;
+        thetamax = _thetamax;
+        phimax = _phimax;
+    }
+
+    /** This function returns the \f$r_\text{min}\f$ border coordinate of the cell. */
+    double rmin() const { return _rmin; }
+
+    /** This function returns the \f$\theta_\text{min}\f$ border coordinate of the cell. */
+    double thetamin() const { return _thetamin; }
+
+    /** This function returns the \f$\varphi_\text{min}\f$ border coordinate of the cell. */
+    double phimin() const { return _phimin; }
+
+    /** This function returns the \f$R_\text{max}\f$ border coordinate of the cell. */
+    double rmax() const { return _rmax; }
+
+    /** This function returns the \f$\theta_\text{max}\f$ border coordinate of the cell. */
+    double thetamax() const { return _thetamax; }
+
+    /** This function returns the \f$\varphi_\text{max}\f$ border coordinate of the cell. */
+    double phimax() const { return _phimax; }
+
+    /** This function returns the volume of the cell, given by \f$\frac{1}{3}
+        \left(r_\text{max}^3-r_\text{min}^3\right)
+        \left(\cos\theta_\text{min}-\cos\theta_\text{max}\right)
+        \left(\varphi_\text{max}-\varphi_\text{min}\right)\f$. */
+    double volume() const;
+
+    /** This function returns the "center" of the cell in Cartesian coordinates. This position is
+        defined as the halfway point between the cell borders in spherical coordinates, i.e.
+        \f[\begin{aligned} r_\text{ctr} = (r_\text{min} + r_\text{max})/2 \\ \theta_\text{ctr} =
+        (\theta_\text{min} + \theta_\text{max})/2 \\ \varphi_\text{ctr} = (\varphi_\text{min} +
+        \varphi_\text{max})/2. \end{aligned}\f]
+
+        As stated above the function returns this position after converting it to Cartesian
+        coordinates. */
+    Position center() const;
+
+    /** This function returns true if the Cartesian position \f${\bf{bfr}}=(x,y,z)\f$ is inside the
+        cell, and false otherwise. A position on an edge or face on the "lower" side of the cell is
+        considered to be contained in the cell, while a position on an edge or face on the "upper"
+        side of the cell is considered \em not to be contained in the cell. This approach avoids
+        duplicate containment of adjacent cells. */
+    bool contains(Vec bfr) const;
+
+    /** This function returns the Cartesian bounding box of the cell, in other words the smallest
+        cuboid lined up with the Cartesian coordinate axes that encloses the cell.
+
+        The intersection of a conical cell boundary and a spherical cell boundary is a horizontal
+        circle segment. This means that the z coordinate of the intersection does not depend on
+        \f$\varphi\f$, and the vertical bounds of the cell can be determined by considering the
+        cell's corner points in the meridional plane.
+
+        For the projection on the equatorial plane, things are more complicated. If the cell
+        straddles an x or y axis in the azimuthal direction, or if it straddles the xy plane in the
+        polar direction, the projection of the outer sphere boundary on the x and/or y axes extends
+        beyond the projection of the cell corner points. The bounding box must thus enclose the
+        corresponding extreme points in addition to the cell corner points. */
+    Box boundingBox() const;
+
+    /** This function intersects the receiving cell with a ray (half-line) defined by the specified
+        starting position \f$\bf{r}\f$ and direction \f$\bf{k}\f$. If the ray does not intersect
+        the cell, the function returns zero. If the ray does intersect the cell, the function
+        returns the length of the intersection segment, or if applicable, the sum of the two
+        intersection segments (because a spherical cell is concave, a ray can intersect it multiple
+        times). If the starting position is inside the cell, only the portion of the ray inside the
+        cell is taken into account.
+
+        A ray that touches the cell border in a single point is not considered to intersect. A ray
+        along an edge or face on the "lower" side of the cell is considered to intersect, while ray
+        along an edge or face on the "upper" side of the cell is considered \em not to intersect.
+        This approach avoids duplicate intersection of adjacent cells.
+
+        <em>Implementation</em>
+
+        The function uses the following strategy. First it calculates all intersection points with
+        the bordering surfaces and sorts them on distance along the ray. Then, for each segment
+        between consecutive intersections beyond the ray's starting point, it determines whether
+        the segment's midpoint is inside the cell or not, and accumulates the lengths of the inside
+        segments. This automatically takes care of the cases where the ray lies in one of the
+        bordering surfaces.
+
+        The ray equation can be written as \f[\begin{cases} x = r_\text{x} + k_\text{x}s \\ y =
+        r_\text{y} + k_\text{y}s \\ z = r_\text{z} + k_\text{z}s \\ \end{cases} \quad \text{with}
+        \;s>0.\f]
+
+        Intersection with a sphere [XXX]
+
+        Intersection with a cone [XXX]
+
+        Intersection with a meridional plane with equation \f$\sin\varphi_* x = \cos\varphi_* y\f$
+        yields \f[ s = -\;\frac{r_\text{x}\sin\varphi_* - r_\text{y}\cos\varphi_*}
+        {k_\text{x}\sin\varphi_* - k_\text{y}\cos\varphi_*} \f] */
+    double intersection(Vec r, const Vec k) const;
+
+private:
+    // These data members represent the spherical border coordinates
+    double _rmin{0}, _thetamin{0}, _phimin{0}, _rmax{0}, _thetamax{0}, _phimax{0};
+
+    // These data members remember frequently used and expensive to calculate values
+    double _cosphimin{1}, _sinphimin{0}, _cosphimax{1}, _sinphimax{0};
+    double _costhetamin{1}, _sinthetamin{0}, _costhetamax{1}, _sinthetamax{0};
+};
+
+//////////////////////////////////////////////////////////////////////
+
+#endif

--- a/SKIRT/utils/SphericalCell.hpp
+++ b/SKIRT/utils/SphericalCell.hpp
@@ -19,7 +19,7 @@ class Position;
     r_\text{max}\f$,
 
     - two polar half-cones defined by inclination angles \f$0 \le \theta_\text{min} \le
-    \theta_\text{max} \le \pi\\f$,
+    \theta_\text{max} \le \pi\f$,
 
     - two meridional half-planes (with \f$r>0\f$) defined by azimuth angles \f$-\pi \le
     \varphi_\text{min} \le \varphi_\text{max} \le \pi\f$ with \f$\varphi_\text{max} -
@@ -90,7 +90,7 @@ public:
         coordinates. */
     Position center() const;
 
-    /** This function returns true if the Cartesian position \f${\bf{bfr}}=(x,y,z)\f$ is inside the
+    /** This function returns true if the Cartesian position \f$\bf{r}=(x,y,z)\f$ is inside the
         cell, and false otherwise. A position on an edge or face on the "lower" side of the cell is
         considered to be contained in the cell, while a position on an edge or face on the "upper"
         side of the cell is considered \em not to be contained in the cell. This approach avoids
@@ -134,16 +134,19 @@ public:
         segments. This automatically takes care of the cases where the ray lies in one of the
         bordering surfaces.
 
-        The ray equation can be written as \f[\begin{cases} x = r_\text{x} + k_\text{x}s \\ y =
-        r_\text{y} + k_\text{y}s \\ z = r_\text{z} + k_\text{z}s \\ \end{cases} \quad \text{with}
-        \;s>0.\f]
+        The ray can be represented by its parameter equation \f${\bf{x}}={\bf{r}}+s\,{\bf{k}}\f$,
+        with \f${\bf{k}}\f$ a unit vector.
 
-        Intersection with a sphere [XXX]
+        The two intersection points with a radial boundary sphere \f${\bf{x}}^2=r_*^2\f$ are
+        obtained by solving the quadratic equation \f$s^2 + 2\,({\bf{r}}\cdot{\bf{k}})\,s +
+        ({\bf{r}}^2-r_*^2)=0\f$ for \f$s\f$.
 
-        Intersection with a cone [XXX]
+        The two intersection points with an angular boundary cone \f$x_z^2=c^2\,{\bf{x}}^2\f$ (with
+        \f$c=\cos\theta_*\f$) are obtained by solving the quadratic equation \f$(c^2-k_z^2)\,s^2 +
+        2\,(c^2\,{\bf{r}}\cdot{\bf{k}}-r_z k_z)\,s + (c^2\,{\bf{r}}^2-r_z^2)=0\f$ for \f$s\f$.
 
-        Intersection with a meridional plane with equation \f$\sin\varphi_* x = \cos\varphi_* y\f$
-        yields \f[ s = -\;\frac{r_\text{x}\sin\varphi_* - r_\text{y}\cos\varphi_*}
+        The intersection point with a meriodonal plane \f$\sin\varphi_* x = \cos\varphi_* y\f$ is
+        obtained by \f[ s = -\;\frac{r_\text{x}\sin\varphi_* - r_\text{y}\cos\varphi_*}
         {k_\text{x}\sin\varphi_* - k_\text{y}\cos\varphi_*} \f] */
     double intersection(Vec r, const Vec k) const;
 


### PR DESCRIPTION
**Description**
This update adds the capability to import 1D, 2D, or 3D snapshots defined in spherical coordinates through the `SphericalSnapshot` class and the related import classes for sources and media. The functionality is very similar to what has been offered by the `CylindricalSnapshot` and related classes in a previous update.

The update also adds the `SymCosMesh` class, which can be used with the Sphere2DSpatialGrid and Sphere3DSpatialGrid classes to define a polar grid that has equal-volume bins.

**Motivation**
This update rounds up the effort to fully support non-Cartesian coordinates for both import and photon shooting.

**Tests**
New functional tests were added for the new classes; the existing tests did not change.
