### PR TITLE
Update BPASS SED family with new versions

### DIFF
--- a/SKIRT/core/BpassSED.cpp
+++ b/SKIRT/core/BpassSED.cpp
@@ -15,7 +15,7 @@ const SEDFamily* BpassSED::getFamilyAndParameters(Array& parameters)
     NR::assign(parameters, 1., _metallicity, _age);
 
     // construct the library of SED models
-    return new BpassSEDFamily(this);
+    return new BpassSEDFamily(this, BpassSEDFamily::IMF::Chabrier300, BpassSEDFamily::Resolution::Original);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/BpassSEDFamily.cpp
+++ b/SKIRT/core/BpassSEDFamily.cpp
@@ -8,9 +8,12 @@
 
 ////////////////////////////////////////////////////////////////////
 
-BpassSEDFamily::BpassSEDFamily(SimulationItem* parent)
+BpassSEDFamily::BpassSEDFamily(SimulationItem* parent, IMF imf,
+                               Resolution resolution)
 {
     parent->addChild(this);
+    _imf = imf;
+    _resolution = resolution;
     setup();
 }
 
@@ -20,7 +23,15 @@ void BpassSEDFamily::setupSelfBefore()
 {
     SEDFamily::setupSelfBefore();
 
-    _table.open(this, "BpassSEDFamily_Chabrier300", "lambda(m),Z(1),t(yr)", "Llambda(W/m)", false);
+    string name = "BpassSEDFamily";
+    switch (_imf)
+    {
+        case IMF::Chabrier100: name += "_Chabrier100"; break;
+        case IMF::Chabrier300: name += "_Chabrier300"; break;
+    }
+    if (_resolution == Resolution::Downsampled) name += "_downsampled";
+
+    _table.open(this, name, "lambda(m),Z(1),t(yr)", "Llambda(W/m)", false);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/BpassSEDFamily.hpp
+++ b/SKIRT/core/BpassSEDFamily.hpp
@@ -14,20 +14,27 @@
 /** An instance of the BpassSEDFamily class represents a BPASS family of single stellar population
     (SSP) %SED templates (Eldridge, Stanway et al, 2017, PASA 34, 58; Stanway and Eldridge, 2018,
     MNRAS, 479, 75). We use the BPASS data release version 2.2.1 (July 2018) of the model that
-    includes binary stellar systems and that assumes a Chabrier IMF with an upper mass limit of 300
-    solar masses (the "bin-imf_chab300" model).
+    includes binary stellar systems and that assumes a Chabrier IMF.
 
     The SED templates are parametrized on metallicity (1e-5 - 0.04) and age (1 Myr - 100 Gyr), and
-    scale with the initial mass of the SSP. The wavelength grid has a resolution of 1 Angstrom over
-    the complete range (1 Angstrom - 10 micron). This corresponds to a spectral resolution as shown
-    in the figure below.
+    scale with the initial mass of the SSP.
+ 
+    This class offers two user-configured options:
 
-    \image html BpassSEDFamily.png
+    \em IMF determines the IMF, more specifically the upper limit of the stellar mass range:
+      - Chabrier100: Chabrier IMF with stellar masses from 0.1 to 100 \f$\mathrm{M}_\odot\f$
+      - Chabrier300: Chabrier IMF with stellar masses from 0.1 to 300 \f$\mathrm{M}_\odot\f$
 
-    The data were downloaded from the BPASS web site at https://bpass.auckland.ac.nz/9.html and
-    converted to SKIRT stored table format for inclusion in the <b>optional</b> BPASS resource
-    pack. The stored table is opened during setup, and it is subsequently interpolated to the
-    desired parameters and wavelength grid when needed.
+    \em resolution determines the spectral resolution and the wavelength coverage
+      - Original: the wavelength grid has a resolution of 1 Angstrom over the wavelength range
+        between 1 Angstrom and 10 micron. This is the original resolution and wavelength coverage
+        of the BPASS library, downloaded from the BPASS web site at
+        https://bpass.auckland.ac.nz/9.html.
+      - Downsampled: the wavelength coverage is downsampled. Between 1 Angstrom and 0.6
+        micron, the original resolution of 1 Angstrom is retained. Between 0.6 and 10 micron the
+        resolution is lowered to \f$R=711\f$ (2000 grid points). Finally, a flux point is added at 160
+        micron to ensure that the Rayleigh-Jeans tail of the SED is properly covered. This one
+        additional point is using the slope between 8 and 10 micron.
 
     When imported from a text column file, the parameters for this %SED family must appear in the
     following order in the specified default units (unless these units are overridden by column
@@ -36,13 +43,33 @@
 
     <b>IMPORTANT NOTE TO THE USER</b>
 
-    Because of its substantial size (450 MB compressed) the resource file required by this class is
+    Because of their substantial size, the resource files required by this class are
     contained in a separate, <b>optional</b> resource pack, which can be installed by running the
     \c downloadResources.sh shell script in the SKIRT \c git directory or can be obtained from the
     download page on the SKIRT web site. */
+
 class BpassSEDFamily : public SEDFamily
 {
+    /** The enumeration type indicating the IMF to use */
+    ENUM_DEF(IMF, Chabrier100, Chabrier300)
+        ENUM_VAL(IMF, Chabrier100, "Chabrier IMF (0.1-100 Msun)")
+        ENUM_VAL(IMF, Chabrier300, "Chabrier IMF (0.1-300 Msun)")
+    ENUM_END()
+
+    /** The enumeration type indicating the wavelength resolution and spectral range */
+    ENUM_DEF(Resolution, Original, Downsampled)
+        ENUM_VAL(Resolution, Original, "Original wavelength resolution and range")
+        ENUM_VAL(Resolution, Downsampled, "Downsampled wavelength resolution and extended wavelength range")
+    ENUM_END()
+
     ITEM_CONCRETE(BpassSEDFamily, SEDFamily, "a BPASS SED family for single stellar populations")
+    
+    PROPERTY_ENUM(imf, IMF, "IMF")
+    ATTRIBUTE_DEFAULT_VALUE(imf, "Chabrier300")
+
+    PROPERTY_ENUM(resolution, Resolution, "the wavelength resolution")
+    ATTRIBUTE_DEFAULT_VALUE(resolution, "Original")
+    
     ITEM_END()
 
     //============= Construction - Setup - Destruction =============
@@ -53,7 +80,8 @@ public:
         newly created object is hooked up as a child to the specified parent in the simulation
         hierarchy (so it will automatically be deleted), and its setup() function has been called.
         */
-    explicit BpassSEDFamily(SimulationItem* parent);
+    explicit BpassSEDFamily(SimulationItem* parent, IMF imf,
+                            Resolution resolution);
 
 protected:
     /** This function opens the appropriate resource file (in SKIRT stored table format). */


### PR DESCRIPTION
**Description**
The BPASS SED family has been extended with new options: the user now has the choice between two IMF options and two wavelength resolutions/ranges.

**Motivation**
The BPASS SED family was only available in one version: the version corresponding to a Chabrier IMF with stellar masses from 0.1 to 300 Msun. It was only available in the native wavelength resolution and range (1 Å resolution in the range between 1 Å and 10 µm). The current update introduces more flexibility:
- The user can now choose between two different IMF choices: a Chabrier IMF from 0.1 to 100 Msun, and a Chabrier IMF between 0.1 and 300 Msun. These two options are chosen in order to be fully compatible with the ToddlersSEDFamily.
- The user can now choose between the original wavelength resolution and range (constant wavelength resolution of 1 Å in the range between 1 Å and 10 µm) or a downgraded wavelength resolution and extended range (lower wavelength resolution between 0.6 and 10 µm, and an extended wavelength coverage in the Rayleigh-Jeans tail up to 160 µm).

**Tests**
Tests on the compatibility have been performed by @andreagebek and @anandutsavkapoor. 