### PR TITLE
Fix compiler errors for GCC 15.1

### DIFF
--- a/SKIRT/fitsio/putcol.c
+++ b/SKIRT/fitsio/putcol.c
@@ -21,9 +21,9 @@ int ffppx(  fitsfile *fptr,  /* I - FITS file pointer                       */
   Write an array of pixels to the primary array.  The datatype of the
   input array is defined by the 2nd argument. Data conversion
   and scaling will be performed if necessary (e.g, if the datatype of
-  the FITS array is not the same as the array being written). 
-  
-  This routine is simillar to ffppr, except it supports writing to 
+  the FITS array is not the same as the array being written).
+
+  This routine is simillar to ffppr, except it supports writing to
   large images with more than 2**31 pixels.
 */
 {
@@ -111,9 +111,9 @@ int ffppxll(  fitsfile *fptr,  /* I - FITS file pointer                       */
   Write an array of pixels to the primary array.  The datatype of the
   input array is defined by the 2nd argument. Data conversion
   and scaling will be performed if necessary (e.g, if the datatype of
-  the FITS array is not the same as the array being written). 
-  
-  This routine is simillar to ffppr, except it supports writing to 
+  the FITS array is not the same as the array being written).
+
+  This routine is simillar to ffppr, except it supports writing to
   large images with more than 2**31 pixels.
 */
 {
@@ -235,12 +235,12 @@ int ffppxn(  fitsfile *fptr,  /* I - FITS file pointer                       */
 
     if (datatype == TBYTE)
     {
-      ffppnb(fptr, group, firstelem, nelem, (unsigned char *) array, 
+      ffppnb(fptr, group, firstelem, nelem, (unsigned char *) array,
              *(unsigned char *) nulval, status);
     }
     else if (datatype == TSBYTE)
     {
-      ffppnsb(fptr, group, firstelem, nelem, (signed char *) array, 
+      ffppnsb(fptr, group, firstelem, nelem, (signed char *) array,
              *(signed char *) nulval, status);
     }
     else if (datatype == TUSHORT)
@@ -343,12 +343,12 @@ int ffppxnll(  fitsfile *fptr,  /* I - FITS file pointer                       *
 
     if (datatype == TBYTE)
     {
-      ffppnb(fptr, group, firstelem, nelem, (unsigned char *) array, 
+      ffppnb(fptr, group, firstelem, nelem, (unsigned char *) array,
              *(unsigned char *) nulval, status);
     }
     else if (datatype == TSBYTE)
     {
-      ffppnsb(fptr, group, firstelem, nelem, (signed char *) array, 
+      ffppnsb(fptr, group, firstelem, nelem, (signed char *) array,
              *(signed char *) nulval, status);
     }
     else if (datatype == TUSHORT)
@@ -509,12 +509,12 @@ int ffppn(  fitsfile *fptr,  /* I - FITS file pointer                       */
 
     if (datatype == TBYTE)
     {
-      ffppnb(fptr, group, firstelem, nelem, (unsigned char *) array, 
+      ffppnb(fptr, group, firstelem, nelem, (unsigned char *) array,
              *(unsigned char *) nulval, status);
     }
     else if (datatype == TSBYTE)
     {
-      ffppnsb(fptr, group, firstelem, nelem, (signed char *) array, 
+      ffppnsb(fptr, group, firstelem, nelem, (signed char *) array,
              *(signed char *) nulval, status);
     }
     else if (datatype == TUSHORT)
@@ -648,7 +648,7 @@ int ffpss(  fitsfile *fptr,   /* I - FITS file pointer                       */
     {
         ffpssjj(fptr, 1, naxis, naxes, blc, trc,
                (LONGLONG *) array, status);
-    }    
+    }
     else if (datatype == TFLOAT)
     {
         ffpsse(fptr, 1, naxis, naxes, blc, trc,
@@ -686,7 +686,7 @@ int ffpcl(  fitsfile *fptr,  /* I - FITS file pointer                       */
 
     if (datatype == TBIT)
     {
-      ffpclx(fptr, colnum, firstrow, (long) firstelem, (long) nelem, (char *) array, 
+      ffpclx(fptr, colnum, firstrow, (long) firstelem, (long) nelem, (char *) array,
              status);
     }
     else if (datatype == TBYTE)
@@ -701,7 +701,7 @@ int ffpcl(  fitsfile *fptr,  /* I - FITS file pointer                       */
     }
     else if (datatype == TUSHORT)
     {
-      ffpclui(fptr, colnum, firstrow, firstelem, nelem, 
+      ffpclui(fptr, colnum, firstrow, firstelem, nelem,
              (unsigned short *) array, status);
     }
     else if (datatype == TSHORT)
@@ -916,7 +916,7 @@ int fits_iter_set_by_num(iteratorCol *col, /* I - iterator column structure */
 */
 {
     col->fptr = fptr;
-    col->colnum = colnum; 
+    col->colnum = colnum;
     col->datatype = datatype;
     col->iotype = iotype;
     return(0);
@@ -950,7 +950,7 @@ int fits_iter_set_colnum(iteratorCol *col, /* I - iterator column structure */
   set iterator column parameter
 */
 {
-    col->colnum = colnum; 
+    col->colnum = colnum;
     return(0);
 }
 /*--------------------------------------------------------------------------*/
@@ -1077,7 +1077,7 @@ int ffiter(int n_cols,
            int *status)
 /*
    The iterator function.  This function will pass the specified
-   columns from a FITS table or pixels from a FITS image to the 
+   columns from a FITS table or pixels from a FITS image to the
    user-supplied function.  Depending on the size of the table
    or image, only a subset of the rows or pixels may be passed to the
    function on each call, in which case the function will be called
@@ -1085,7 +1085,7 @@ int ffiter(int n_cols,
 */
 {
     typedef struct  /* structure to store the column null value */
-    {  
+    {
         int      nullsize;    /* length of the null value, in bytes */
         union {   /*  default null value for the column */
             char   *stringnull;
@@ -1099,7 +1099,7 @@ int ffiter(int n_cols,
             unsigned long  ulongnull;
             float  floatnull;
             double doublenull;
-	    LONGLONG longlongnull;
+            LONGLONG longlongnull;
         } null;
     } colNulls;
 
@@ -1111,7 +1111,7 @@ int ffiter(int n_cols,
     long rept, rowrept, width, tnull, naxes[9] = {1,1,1,1,1,1,1,1,1}, groups;
     double zeros = 0.;
     char message[FLEN_ERRMSG], keyname[FLEN_KEYWORD], nullstr[FLEN_VALUE];
-    char **stringptr, *nullptr, *cptr;
+    char **stringptr, *nulptr, *cptr;
 
     if (*status > 0)
         return(*status);
@@ -1124,7 +1124,7 @@ int ffiter(int n_cols,
 
     /*------------------------------------------------------------*/
     /* Make sure column numbers and datatypes are in legal range  */
-    /* and column numbers and datatypes are legal.                */ 
+    /* and column numbers and datatypes are legal.                */
     /* Also fill in other parameters in the column structure.     */
     /*------------------------------------------------------------*/
 
@@ -1133,11 +1133,11 @@ int ffiter(int n_cols,
     for (jj = 0; jj < n_cols; jj++)
     {
         /* check that output datatype code value is legal */
-        type = cols[jj].datatype;  
+        type = cols[jj].datatype;
 
         /* Allow variable length arrays for InputCol and InputOutputCol columns,
-	   but not for OutputCol columns.  Variable length arrays have a
-	   negative type code value. */
+           but not for OutputCol columns.  Variable length arrays have a
+           negative type code value. */
 
         if ((cols[jj].iotype != OutputCol) && (type<0)) {
             type*=-1;
@@ -1145,21 +1145,21 @@ int ffiter(int n_cols,
 
         if (type != 0      && type != TBYTE  &&
             type != TSBYTE && type != TLOGICAL && type != TSTRING &&
-            type != TSHORT && type != TINT     && type != TLONG && 
+            type != TSHORT && type != TINT     && type != TLONG &&
             type != TFLOAT && type != TDOUBLE  && type != TCOMPLEX &&
             type != TULONG && type != TUSHORT  && type != TDBLCOMPLEX &&
-	    type != TLONGLONG )
+            type != TLONGLONG )
         {
-	    if (type < 0) {
-	      snprintf(message,FLEN_ERRMSG,
+            if (type < 0) {
+              snprintf(message,FLEN_ERRMSG,
               "Variable length array not allowed for output column number %d (ffiter)",
                     jj + 1);
-	    } else {
+            } else {
             snprintf(message,FLEN_ERRMSG,
                    "Illegal datatype for column number %d: %d  (ffiter)",
                     jj + 1, cols[jj].datatype);
-	    }
-	    
+            }
+
             ffpmsg(message);
             return(*status = BAD_DATATYPE);
         }
@@ -1214,7 +1214,7 @@ int ffiter(int n_cols,
             }
 
             /* check that the column number is valid */
-            if (cols[jj].colnum < 1 || 
+            if (cols[jj].colnum < 1 ||
                 cols[jj].colnum > ((cols[jj].fptr)->Fptr)->tfield)
             {
                 snprintf(message,FLEN_ERRMSG,
@@ -1377,31 +1377,31 @@ int ffiter(int n_cols,
             if (ffgtcl(cols[jj].fptr, cols[jj].colnum, &typecode, &rept,
                   &width, status) > 0)
                 goto cleanup;
-		
-	    if (typecode < 0) {  /* if any variable length arrays, then the */ 
-	        n_optimum = 1;   /* must process the table 1 row at a time */
-		
+
+            if (typecode < 0) {  /* if any variable length arrays, then the */
+                n_optimum = 1;   /* must process the table 1 row at a time */
+
               /* Allow variable length arrays for InputCol and InputOutputCol columns,
-	       but not for OutputCol columns.  Variable length arrays have a
-	       negative type code value. */
+               but not for OutputCol columns.  Variable length arrays have a
+               negative type code value. */
 
               if (cols[jj].iotype == OutputCol) {
- 	        snprintf(message,FLEN_ERRMSG,
+                snprintf(message,FLEN_ERRMSG,
                 "Variable length array not allowed for output column number %d (ffiter)",
                     jj + 1);
                 ffpmsg(message);
                 return(*status = BAD_DATATYPE);
               }
-	   }
+           }
         }
 
         /* special case where sizeof(long) = 8: use TINT instead of TLONG */
         if (abs(typecode) == TLONG && sizeof(long) == 8 && sizeof(int) == 4) {
-		if(typecode<0) {
-			typecode = -TINT;
-		} else {
-			typecode = TINT;
-		}
+                if(typecode<0) {
+                        typecode = -TINT;
+                } else {
+                        typecode = TINT;
+                }
         }
 
         /* Special case: interprete 'X' column as 'B' */
@@ -1423,7 +1423,7 @@ int ffiter(int n_cols,
         /* calc total number of elements to do on each iteration */
         if (hdutype == IMAGE_HDU || cols[jj].datatype == TSTRING)
         {
-            ntodo = n_optimum; 
+            ntodo = n_optimum;
             cols[jj].repeat = 1;
 
             /* get the BLANK keyword value, if it exists */
@@ -1440,18 +1440,18 @@ int ffiter(int n_cols,
         }
         else
         {
-	    if (typecode < 0) 
-	    {
+            if (typecode < 0)
+            {
               /* get max size of the variable length vector; dont't trust the value
-	         given by the TFORM keyword  */
-	      rept = 1;
-	      for (ii = 0; ii < totaln; ii++) {
-		ffgdes(cols[jj].fptr, cols[jj].colnum, frow + ii, &rowrept, NULL, status);
-		
-		rept = maxvalue(rept, rowrept);
-	      }
+                 given by the TFORM keyword  */
+              rept = 1;
+              for (ii = 0; ii < totaln; ii++) {
+                ffgdes(cols[jj].fptr, cols[jj].colnum, frow + ii, &rowrept, NULL, status);
+
+                rept = maxvalue(rept, rowrept);
+              }
             }
-	    
+
             ntodo = n_optimum * rept;   /* vector columns */
             cols[jj].repeat = rept;
 
@@ -1477,7 +1477,7 @@ int ffiter(int n_cols,
                         if (*cptr == '\0')  /* TNULLn is all blanks? */
                             tnull = LONG_MIN;
                         else
-                        {                                                
+                        {
                             /* attempt to read TNULLn string as an integer */
                             ffc2ii(nullstr, &tnull, &tstatus);
 
@@ -1692,7 +1692,7 @@ int ffiter(int n_cols,
 
          case TSTRING:
           /* allocate array of pointers to all the strings  */
-	  if( hdutype==ASCII_TBL ) rept = width;
+          if( hdutype==ASCII_TBL ) rept = width;
           stringptr = calloc((ntodo + 1) , sizeof(stringptr));
           cols[jj].array = stringptr;
           col[jj].nullsize  = rept + 1;  /* number of bytes per value */
@@ -1743,7 +1743,7 @@ int ffiter(int n_cols,
           col[jj].nullsize  = sizeof(LONGLONG);  /* number of bytes per value */
 
           if (abs(typecode) == TBYTE || abs(typecode) == TSHORT || abs(typecode) == TLONG ||
-	      abs(typecode) == TLONGLONG || abs(typecode) == TINT)
+              abs(typecode) == TLONGLONG || abs(typecode) == TINT)
           {
               col[jj].null.longlongnull = tnull;
           }
@@ -1799,7 +1799,7 @@ int ffiter(int n_cols,
             defaultnull = &col[jj].null.charnull; /* ptr to the null value */
           }
 
-          if (hdutype == IMAGE_HDU)   
+          if (hdutype == IMAGE_HDU)
           {
               if (ffgpv(cols[jj].fptr, cols[jj].datatype,
                     felement, cols[jj].repeat * ntodo, defaultnull,
@@ -1810,15 +1810,15 @@ int ffiter(int n_cols,
           }
           else
           {
-	      if (ffgtcl(cols[jj].fptr, cols[jj].colnum, &typecode, &rept,&width, status) > 0)
-	          goto cleanup;
-		  
-	      if (typecode<0)
-	      {
-	        /* get size of the variable length vector */
-		ffgdes(cols[jj].fptr, cols[jj].colnum, frow,&cols[jj].repeat, NULL,status);
-	      }
-		
+              if (ffgtcl(cols[jj].fptr, cols[jj].colnum, &typecode, &rept,&width, status) > 0)
+                  goto cleanup;
+
+              if (typecode<0)
+              {
+                /* get size of the variable length vector */
+                ffgdes(cols[jj].fptr, cols[jj].colnum, frow,&cols[jj].repeat, NULL,status);
+              }
+
               if (ffgcv(cols[jj].fptr, cols[jj].datatype, cols[jj].colnum,
                     frow, felement, cols[jj].repeat * ntodo, defaultnull,
                     dataptr,  &anynul, status) > 0)
@@ -1830,7 +1830,7 @@ int ffiter(int n_cols,
           /* copy the appropriate null value into first array element */
 
           if (anynul)   /* are there any nulls in the data? */
-          {   
+          {
             if (cols[jj].datatype == TSTRING)
             {
               stringptr = cols[jj].array;
@@ -1846,29 +1846,29 @@ int ffiter(int n_cols,
             if (cols[jj].datatype == TSTRING)
             {
               stringptr = cols[jj].array;
-              memset(*stringptr, 0, col[jj].nullsize);  
+              memset(*stringptr, 0, col[jj].nullsize);
             }
             else
             {
-              memset(cols[jj].array, 0, col[jj].nullsize);  
+              memset(cols[jj].array, 0, col[jj].nullsize);
             }
           }
         }
       }
 
-      if (*status > 0) 
+      if (*status > 0)
          break;   /* looks like an error occurred; quit immediately */
 
       /* call work function */
 
-      if (hdutype == IMAGE_HDU) 
+      if (hdutype == IMAGE_HDU)
           *status = work_fn(totaln, offset, felement, ntodo, n_cols, cols,
                     userPointer);
       else
           *status = work_fn(totaln, offset, frow, ntodo, n_cols, cols,
                     userPointer);
 
-      if (*status > 0 || *status < -1 ) 
+      if (*status > 0 || *status < -1 )
          break;   /* looks like an error occurred; quit immediately */
 
       /*  write output columns  before quiting if status = -1 */
@@ -1881,46 +1881,46 @@ int ffiter(int n_cols,
           {
             stringptr = cols[jj].array;
             dataptr = stringptr + 1;
-            nullptr = *stringptr;
+            nulptr = *stringptr;
             nbytes = 2;
           }
           else
           {
             dataptr = (char *) cols[jj].array + col[jj].nullsize;
-            nullptr = (char *) cols[jj].array;
+            nulptr = (char *) cols[jj].array;
             nbytes = col[jj].nullsize;
           }
 
-          if (memcmp(nullptr, &zeros, nbytes) ) 
+          if (memcmp(nulptr, &zeros, nbytes) )
           {
             /* null value flag not zero; must check for and write nulls */
-            if (hdutype == IMAGE_HDU)   
+            if (hdutype == IMAGE_HDU)
             {
-                if (ffppn(cols[jj].fptr, cols[jj].datatype, 
+                if (ffppn(cols[jj].fptr, cols[jj].datatype,
                       felement, cols[jj].repeat * ntodo, dataptr,
-                      nullptr, &tstatus) > 0)
+                      nulptr, &tstatus) > 0)
                 break;
             }
             else
             {
-	    	if (ffgtcl(cols[jj].fptr, cols[jj].colnum, &typecode, &rept,&width, status) > 0)
-		    goto cleanup;
-		    
-		if (typecode<0)  /* variable length array colum */
-		{
-		   ffgdes(cols[jj].fptr, cols[jj].colnum, frow,&cols[jj].repeat, NULL,status);
-		}
+                if (ffgtcl(cols[jj].fptr, cols[jj].colnum, &typecode, &rept,&width, status) > 0)
+                    goto cleanup;
+
+                if (typecode<0)  /* variable length array colum */
+                {
+                   ffgdes(cols[jj].fptr, cols[jj].colnum, frow,&cols[jj].repeat, NULL,status);
+                }
 
                 if (ffpcn(cols[jj].fptr, cols[jj].datatype, cols[jj].colnum, frow,
                       felement, cols[jj].repeat * ntodo, dataptr,
-                      nullptr, &tstatus) > 0)
+                      nulptr, &tstatus) > 0)
                 break;
             }
           }
           else
-          { 
+          {
             /* no null values; just write the array */
-            if (hdutype == IMAGE_HDU)   
+            if (hdutype == IMAGE_HDU)
             {
                 if (ffppr(cols[jj].fptr, cols[jj].datatype,
                       felement, cols[jj].repeat * ntodo, dataptr,
@@ -1929,13 +1929,13 @@ int ffiter(int n_cols,
             }
             else
             {
-	    	if (ffgtcl(cols[jj].fptr, cols[jj].colnum, &typecode, &rept,&width, status) > 0)
-		    goto cleanup;
-		    
-		if (typecode<0)  /* variable length array column */
-		{
-		   ffgdes(cols[jj].fptr, cols[jj].colnum, frow,&cols[jj].repeat, NULL,status);
-		}
+                if (ffgtcl(cols[jj].fptr, cols[jj].colnum, &typecode, &rept,&width, status) > 0)
+                    goto cleanup;
+
+                if (typecode<0)  /* variable length array column */
+                {
+                   ffgdes(cols[jj].fptr, cols[jj].colnum, frow,&cols[jj].repeat, NULL,status);
+                }
 
                  if (ffpcl(cols[jj].fptr, cols[jj].datatype, cols[jj].colnum, frow,
                       felement, cols[jj].repeat * ntodo, dataptr,
@@ -1949,7 +1949,7 @@ int ffiter(int n_cols,
       if (*status == 0)
          *status = tstatus;   /* propagate any error status from the writes */
 
-      if (*status) 
+      if (*status)
          break;   /* exit on any error */
 
       nleft -= ntodo;

--- a/SMILE/fundamentals/Basics.hpp
+++ b/SMILE/fundamentals/Basics.hpp
@@ -22,6 +22,7 @@
 #include <climits>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <initializer_list>
 #include <iterator>
@@ -56,6 +57,7 @@ using std::vector;
     | \<climits\>          | C-style integral limits, e.g. INT_MAX
     | \<cmath\>            | mathematical functions, e.g. sin, exp, pow
     | \<cstddef\>          | standard types, e.g. size_t
+    | \<cstdint\>          | fixed integer types, e.g. uint64_t
     | \<cstdlib\>          | c-style functions, e.g. atol, strtol, div
     | \<initializer_list\> | initializer lists
     | \<iterator\>         | iterators and iterator support

--- a/downloadResources.sh
+++ b/downloadResources.sh
@@ -81,7 +81,13 @@ do
         then
             echo -n "Retrieving compressed file size: "
             SIZE="$($GETSIZE$URLBASE$ZIPFILENAME 2>&1 | grep -i Length | awk '{print int(0.5 + $2/1024/1024)}')"
-            echo "$SIZE MB"
+            if [ -z $SIZE ]
+            then
+                echo "unable to retrieve file size"
+                SIZE=0
+            else
+                echo "$SIZE MB"
+            fi
             if [ $SIZE -gt 1024 ]
             then
                 read -p "This is a large file > $(($SIZE/1024)) GB; do you want to proceed? [y/n] " RESPONSE


### PR DESCRIPTION
**Description**
The recent GCC version 15.1 introduced some incompatible changes that caused compilation to fail.
- the `<cstdint>` header must now be included explicitly (as opposed to implicitly through another header)
- `nullptr` is now a keyword also in plain C and thus can no longer be used as an variable name

The SKIRT code has been adapted to comply with these changes.

**Context**
This problem was reported in issue #250.
