### PR TITLE
Fix spurious bug in secondary continuous gas emission

### DIFF
--- a/SKIRT/core/ContGasSecondarySource.cpp
+++ b/SKIRT/core/ContGasSecondarySource.cpp
@@ -136,7 +136,7 @@ namespace
                 _m = -1;
                 _mix = mix;
                 auto wavelengthGrid = mix->emissionWavelengthGrid();
-                _wavelengthGrid = wavelengthGrid->extlambdav();
+                _wavelengthGrid = wavelengthGrid->lambdav();
                 _wavelengthRange = wavelengthGrid->wavelengthRange();
                 _numWavelengths = _wavelengthGrid.size();
             }


### PR DESCRIPTION
**Description**
This update fixes a bug in the framework supporting secondary continuous gas emission. The bug caused spurious problems where the emission would be incorrect depending on unpredictable circumstances (because the code was reading information beyond an array).

**Context**
This problem was reported by @anandutsavkapoor.
