### PR TITLE
Custom filter for SKIRT instruments (applied to filtering X-ray fluorescent line photons)

### DIFF
--- a/SKIRT/core/FluxRecorder.cpp
+++ b/SKIRT/core/FluxRecorder.cpp
@@ -137,6 +137,13 @@ void FluxRecorder::includeSurfaceBrightnessForLocal(int numPixelsX, int numPixel
 
 ////////////////////////////////////////////////////////////////////
 
+void FluxRecorder::setFilter(const std::string& filter)
+{
+    _filter = filter;
+}
+
+////////////////////////////////////////////////////////////////////
+
 void FluxRecorder::finalizeConfiguration()
 {
     // get a pointer to the medium system, if present
@@ -217,6 +224,12 @@ void FluxRecorder::finalizeConfiguration()
 
 void FluxRecorder::detect(PhotonPacket* pp, int l, double distance)
 {
+    // If a filter is applied to the instrument, and the photon does not match the filter: abort
+    if (_filter != "none"
+        && ((_filter[0] == '^' && pp->filterTag() == _filter.substr(1)) ||  // skip if tag matches negated filter
+            (_filter[0] != '^' && pp->filterTag() != _filter)))             // skip if tag doesn't match positive filter
+        return;
+
     // abort if we're not recording integrated fluxes and the photon packet arrives outside of the frame
     if (!_includeFluxDensity && l < 0) return;
 

--- a/SKIRT/core/FluxRecorder.hpp
+++ b/SKIRT/core/FluxRecorder.hpp
@@ -232,6 +232,10 @@ public:
                                           double incrementY, double centerX, double centerY,
                                           string quantityXY = string());
 
+    /** This function sets an instrument-specific filter, on which the instrument will filter, only
+     recording photons with this filter tag (none means no filter, ^ inverses the filter)  */
+    void setFilter(const string& filterTag);
+
     /** This function completes the configuration of the recorder. It must be called after any of
         the configuration functions, and before the first invocation of the detect() function. */
     void finalizeConfiguration();
@@ -334,6 +338,7 @@ private:
     bool _recordStatistics{false};
     bool _includeFluxDensity{false};
     bool _includeSurfaceBrightness{false};
+    string _filter{"none"};
 
     // recorder configuration on observer angles, received from client during configuration
     double _inclination{0};

--- a/SKIRT/core/Instrument.cpp
+++ b/SKIRT/core/Instrument.cpp
@@ -26,6 +26,7 @@ void Instrument::setupSelfBefore()
     _recorder = new FluxRecorder(this);
     _recorder->setSimulationInfo(instrumentName(), instrumentWavelengthGrid(), hasMedium, hasMediumEmission);
     _recorder->setUserFlags(_recordComponents, _numScatteringLevels, _recordPolarization, _recordStatistics);
+    _recorder->setFilter(_filter);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/Instrument.hpp
+++ b/SKIRT/core/Instrument.hpp
@@ -54,6 +54,11 @@ class Instrument : public SimulationItem
         ATTRIBUTE_DEFAULT_VALUE(recordStatistics, "false")
         ATTRIBUTE_DISPLAYED_IF(recordStatistics, "Level2")
 
+        PROPERTY_STRING(filter,
+                        "only record photons matching this keyword (none means no filter, ^ inverses the filter)")
+        ATTRIBUTE_DEFAULT_VALUE(filter, "none")
+        ATTRIBUTE_DISPLAYED_IF(filter, "Level3")
+
     ITEM_END()
 
     //============= Construction - Setup - Destruction =============

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -1201,6 +1201,9 @@ void XRayAtomicGasMix::peeloffScattering(double& I, double& Q, double& U, double
 
         // update the photon packet wavelength to the (possibly sampled) wavelength of this fluorescence transition
         lambda = scatinfo->lambda;
+
+        // tag the photon as being fluorescent, so that the peel-off photon inherits this tag
+        const_cast<PhotonPacket*>(pp)->setTag("FL");
     }
 
     // if we have dispersion, Doppler-shift the outgoing wavelength from the electron rest frame
@@ -1246,6 +1249,9 @@ void XRayAtomicGasMix::performScattering(double lambda, const MaterialState* sta
 
         // clear the stokes vector (only relevant if polarization support is enabled)
         pp->setUnpolarized();
+
+        // tag the photon as being fluorescent
+        pp->setTag("FL");
     }
 
     // if we have dispersion, Doppler-shift the outgoing wavelength from the electron rest frame

--- a/SKIRT/utils/PhotonPacket.cpp
+++ b/SKIRT/utils/PhotonPacket.cpp
@@ -27,6 +27,7 @@ void PhotonPacket::launch(size_t historyIndex, double lambda, double L, Position
     _compIndex = 0;
     _historyIndex = historyIndex;
     _nscatt = 0;
+    _filterTag.clear();
     setPosition(bfr);
     setDirection(bfk);
     if (bvi) _lambda = shiftedEmissionWavelength(lambda, bfk, bvi->velocity());
@@ -54,6 +55,13 @@ void PhotonPacket::setSecondaryOrigin(int mediumCompIndex)
 
 ////////////////////////////////////////////////////////////////////
 
+void PhotonPacket::setTag(string filterTag)
+{
+    _filterTag = filterTag;
+}
+
+////////////////////////////////////////////////////////////////////
+
 void PhotonPacket::launchEmissionPeelOff(const PhotonPacket* pp, Direction bfk)
 {
     _lambda = pp->_lambda;
@@ -62,6 +70,7 @@ void PhotonPacket::launchEmissionPeelOff(const PhotonPacket* pp, Direction bfk)
     _compIndex = pp->_compIndex;
     _historyIndex = pp->_historyIndex;
     _nscatt = 0;
+    _filterTag = pp->_filterTag;
     setPosition(pp->position());
     setDirection(bfk);
     if (pp->_bvi) _lambda = shiftedEmissionWavelength(_lambda0, bfk, pp->_bvi->velocity());
@@ -84,6 +93,7 @@ void PhotonPacket::launchScatteringPeelOff(const PhotonPacket* pp, Direction bfk
     _compIndex = pp->_compIndex;
     _historyIndex = pp->_historyIndex;
     _nscatt = pp->_nscatt + 1;
+    _filterTag = pp->_filterTag;
     setPosition(pp->position());
     setDirection(bfk);
     setUnpolarized();

--- a/SKIRT/utils/PhotonPacket.hpp
+++ b/SKIRT/utils/PhotonPacket.hpp
@@ -105,6 +105,12 @@ public:
         launch. */
     void setSecondaryOrigin(int mediumCompIndex);
 
+    /** This function allows specific interactions to tag the photon packet, so that instruments can
+        filter on this tag. This information is used by some instruments to record fluxes seperately
+        based on the interactions they experienced. This function should be called at the interaction
+        of interest. */
+    void setTag(string filterTag);
+
     /** This function initializes a peel off photon packet being sent to an instrument for an
         emission event. The arguments specify the base photon packet from which the peel off
         derives and the direction towards the instrument. The function copies the relevant values
@@ -167,6 +173,10 @@ public:
     /** This function returns the luminosity \f$L\f$ represented by the photon packet, calculated
         from its current wavelength and weight. */
     double luminosity() const { return _W / _lambda; }
+
+    /** This function returns the filter tag, which can then be used by instruments to filter photons.
+        The tag is free-form (e.g. "FL") and may be empty when no filter applies. */
+    const string& filterTag() const { return _filterTag; }
 
     /** This function returns true if the photon packet originated from a primary source, false
         otherwise. */
@@ -333,6 +343,7 @@ private:
     int _compIndex{0};        // sign * (index of the originating source or medium component + 1)
                               //  0: uninitialized   >0: primary   <0: secondary
     size_t _historyIndex{0};  // index of the photon packet's history in the current emission segment
+    string _filterTag{""};    // filter tag on which any instrument can filter, initialised to ""
 
     // information on life cycle
     int _nscatt{0};  // number of experienced scattering events


### PR DESCRIPTION
**Description**
Instruments (SEDInstruments, FrameInstruments, ...) can now have an optional "filter" tag in the .ski file, which allows to filter photons on a specific tag that can be applied during the RT process, such as a specific interaction of interest. We introduced the "FL" tag to filter on X-ray fluorescent photons (and "^FL" to filter non-line photons, see below). All changes are listed here: [changes.txt](https://github.com/user-attachments/files/22429679/changes.txt)

**Motivation**
In X-ray spectral fitting, fluorescent lines are commonly introduced as a separate spectral component. Other X-ray RT codes provide these lines separately, but in SKIRT, they are included in the reprocessed (scattered) flux component, mixed with the Compton scattered continuum. This feature was requested by a large X-ray research group, that plans to move to SKIRT.

**Tests**
Relevant tests are attached below, comparing (and demonstrating) the new implementation to the old implementation:
[instrumentFilter.zip](https://github.com/user-attachments/files/22430147/instrumentFilter.zip)
I specifically tested that the runtime of a SKIRT simulation does not increase when no filter is applied (master version vs new version without a filter). When a filter is applied, the simulation time is marginally reduced (less photons are detected). 

**Guidelines**
This SEDInstrument only records fluorescent lines (see the very last keyword):
SEDInstrument instrumentName="new_FLfilter" distance="1 cm" inclination="66.4218215217981651 deg" azimuth="0 deg" roll="0 deg" radius="0 pc" recordComponents="true" numScatteringLevels="0" recordPolarization="false" recordStatistics="false" filter="FL"

This SEDInstrument only records all that is not fluorescent lines (^ inverses the filter):
SEDInstrument instrumentName="new_inverseFLfilter" distance="1 cm" inclination="66.4218215217981651 deg" azimuth="0 deg" roll="0 deg" radius="0 pc" recordComponents="true" numScatteringLevels="0" recordPolarization="false" recordStatistics="false" filter="^FL"

Without the optional filter keyword, there is no filter (default=none):
SEDInstrument instrumentName="new_inverseFLfilter" distance="1 cm" inclination="66.4218215217981651 deg" azimuth="0 deg" roll="0 deg" radius="0 pc" recordComponents="true" numScatteringLevels="0" recordPolarization="false" recordStatistics="false"

[filterSim.pdf](https://github.com/user-attachments/files/22430152/filterSim.pdf)
[physicalSim.pdf](https://github.com/user-attachments/files/22430154/physicalSim.pdf)
