### PR TITLE
Make instruments record fluorescence as secondary emission 

### DIFF
--- a/SKIRT/core/Configuration.cpp
+++ b/SKIRT/core/Configuration.cpp
@@ -11,7 +11,6 @@
 #include "MaterialMix.hpp"
 #include "MaterialWavelengthRangeInterface.hpp"
 #include "MonteCarloSimulation.hpp"
-#include "NR.hpp"
 #include "OligoWavelengthDistribution.hpp"
 #include "OligoWavelengthGrid.hpp"
 #include "ProbeSystem.hpp"
@@ -325,9 +324,13 @@ void Configuration::setupSelfBefore()
     _hasSingleConstantSectionMedium = numMedia == 1 && _hasConstantSectionMedium;
     _hasMultipleConstantSectionMedia = numMedia > 1 && _hasConstantSectionMedium;
 
-    // check for scattering dispersion
+    // check for scattering dispersion and for emulating secondary emission
     for (auto medium : ms->media())
+    {
         if (medium->mix()->hasScatteringDispersion()) _hasScatteringDispersion = true;
+        if (medium->mix()->scatteringEmulatesSecondaryEmission()) _scatteringEmulatesSecondaryEmission = true;
+    }
+    _needIndividualPeelOff = _hasScatteringDispersion | _scatteringEmulatesSecondaryEmission;
 
     // check for magnetic fields
     for (int h = 0; h != numMedia; ++h)

--- a/SKIRT/core/Configuration.hpp
+++ b/SKIRT/core/Configuration.hpp
@@ -210,8 +210,9 @@ public:
     bool hasMultipleConstantSectionMedia() const { return _hasMultipleConstantSectionMedia; }
 
     /** Returns true if a scattering interaction for one or more media may adjust the wavelength of
-        the interacting photon packet, and false otherwise. */
-    bool hasScatteringDispersion() const { return _hasScatteringDispersion; }
+        the interacting photon packet or may emulate secondary emission during primary emission,
+        and false otherwise. */
+    bool needIndividualPeelOff() const { return _needIndividualPeelOff; }
 
     /** Returns true if all media in the simulation support polarization, and false if none of the
         media do. A mixture of support and no support for polarization is not allowed and will
@@ -467,6 +468,8 @@ private:
     bool _hasSingleConstantSectionMedium{false};
     bool _hasMultipleConstantSectionMedia{false};
     bool _hasScatteringDispersion{false};
+    bool _scatteringEmulatesSecondaryEmission{false};
+    bool _needIndividualPeelOff{false};
     bool _hasPolarization{false};
     bool _hasSpheroidalPolarization{false};
 

--- a/SKIRT/core/Configuration.hpp
+++ b/SKIRT/core/Configuration.hpp
@@ -209,9 +209,12 @@ public:
         weight factors. */
     bool hasMultipleConstantSectionMedia() const { return _hasMultipleConstantSectionMedia; }
 
+    /** Returns true if a scattering interaction for one or more media may emulate secondary
+        emission, and false otherwise. */
+    bool scatteringEmulatesSecondaryEmission() const { return _scatteringEmulatesSecondaryEmission; }
+
     /** Returns true if a scattering interaction for one or more media may adjust the wavelength of
-        the interacting photon packet or may emulate secondary emission during primary emission,
-        and false otherwise. */
+        the interacting photon packet or may emulate secondary emission, and false otherwise. */
     bool needIndividualPeelOff() const { return _needIndividualPeelOff; }
 
     /** Returns true if all media in the simulation support polarization, and false if none of the

--- a/SKIRT/core/DustMix.cpp
+++ b/SKIRT/core/DustMix.cpp
@@ -427,7 +427,7 @@ namespace
 
 ////////////////////////////////////////////////////////////////////
 
-void DustMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs,
+bool DustMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs,
                                 Direction bfky, const MaterialState* /*state*/, const PhotonPacket* pp) const
 {
     switch (scatteringMode())
@@ -482,6 +482,7 @@ void DustMix::peeloffScattering(double& I, double& Q, double& U, double& V, doub
             break;
         }
     }
+    return false;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/DustMix.hpp
+++ b/SKIRT/core/DustMix.hpp
@@ -277,7 +277,7 @@ public:
         plane, applies the Mueller matrix on the Stokes vector, and further rotates the Stokes
         vector from the reference direction in the peel-off scattering plane to the x-axis of the
         instrument to which the peel-off photon packet is headed. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+    bool peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
                            const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial

--- a/SKIRT/core/ElectronMix.cpp
+++ b/SKIRT/core/ElectronMix.cpp
@@ -171,7 +171,7 @@ namespace
 
 ////////////////////////////////////////////////////////////////////
 
-void ElectronMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs,
+bool ElectronMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs,
                                     Direction bfky, const MaterialState* state, const PhotonPacket* pp) const
 {
     // if we have dispersion, adjust the incoming wavelength to the electron rest frame
@@ -197,6 +197,7 @@ void ElectronMix::peeloffScattering(double& I, double& Q, double& U, double& V, 
     {
         lambda = PhotonPacket::shiftedEmissionWavelength(lambda, bfkobs, scatinfo->velocity);
     }
+    return false;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/ElectronMix.hpp
+++ b/SKIRT/core/ElectronMix.hpp
@@ -170,7 +170,7 @@ public:
 
         If \em includePolarization has been set to true, the function supports polarization;
         otherwise it does not. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+    bool peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
                            const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial

--- a/SKIRT/core/FragmentDustMixDecorator.cpp
+++ b/SKIRT/core/FragmentDustMixDecorator.cpp
@@ -213,7 +213,7 @@ double FragmentDustMixDecorator::opacityExt(double lambda, const MaterialState* 
 
 ////////////////////////////////////////////////////////////////////
 
-void FragmentDustMixDecorator::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda,
+bool FragmentDustMixDecorator::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda,
                                                  Direction bfkobs, Direction bfky, const MaterialState* state,
                                                  const PhotonPacket* pp) const
 {
@@ -240,6 +240,7 @@ void FragmentDustMixDecorator::peeloffScattering(double& I, double& Q, double& U
             V += Vf * wf;
         }
     }
+    return false;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/FragmentDustMixDecorator.hpp
+++ b/SKIRT/core/FragmentDustMixDecorator.hpp
@@ -184,7 +184,7 @@ public:
         the fragment. The contributions to the Stokes vector components are stored in the \em I,
         \em Q, \em U, \em V arguments, which are guaranteed to be initialized to zero by the
         caller. For dust mixes, the wavelength remains unchanged. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+    bool peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
                            const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial

--- a/SKIRT/core/Instrument.cpp
+++ b/SKIRT/core/Instrument.cpp
@@ -5,7 +5,6 @@
 
 #include "Instrument.hpp"
 #include "Configuration.hpp"
-#include "FatalError.hpp"
 #include "FluxRecorder.hpp"
 
 ////////////////////////////////////////////////////////////////////
@@ -20,7 +19,7 @@ void Instrument::setupSelfBefore()
 
     // discover details about the simulation
     bool hasMedium = config->hasMedium();
-    bool hasMediumEmission = config->hasSecondaryEmission();
+    bool hasMediumEmission = config->hasSecondaryEmission() || config->scatteringEmulatesSecondaryEmission();
 
     // partially configure the flux recorder
     _recorder = new FluxRecorder(this);

--- a/SKIRT/core/LyaNeutralHydrogenGasMix.cpp
+++ b/SKIRT/core/LyaNeutralHydrogenGasMix.cpp
@@ -132,7 +132,7 @@ double LyaNeutralHydrogenGasMix::opacityExt(double lambda, const MaterialState* 
 
 ////////////////////////////////////////////////////////////////////
 
-void LyaNeutralHydrogenGasMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda,
+bool LyaNeutralHydrogenGasMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda,
                                                  Direction bfkobs, Direction bfky, const MaterialState* state,
                                                  const PhotonPacket* pp) const
 {
@@ -159,6 +159,8 @@ void LyaNeutralHydrogenGasMix::peeloffScattering(double& I, double& Q, double& U
 
     // Doppler-shift the photon packet wavelength into and out of the atom frame
     lambda = LyaUtils::shiftWavelength(lambda, scatinfo->velocity, pp->direction(), bfkobs);
+
+    return false;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/LyaNeutralHydrogenGasMix.hpp
+++ b/SKIRT/core/LyaNeutralHydrogenGasMix.hpp
@@ -146,7 +146,7 @@ public:
         For the Lyman-alpha material mix, the function implements resonant scattering without or
         with support for polarization depending on the user-configured \em includePolarization
         property. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+    bool peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
                            const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial

--- a/SKIRT/core/MaterialMix.cpp
+++ b/SKIRT/core/MaterialMix.cpp
@@ -76,6 +76,13 @@ bool MaterialMix::hasScatteringDispersion() const
 
 ////////////////////////////////////////////////////////////////////
 
+bool MaterialMix::scatteringEmulatesSecondaryEmission() const
+{
+    return false;
+}
+
+////////////////////////////////////////////////////////////////////
+
 MaterialMix::DynamicStateType MaterialMix::hasDynamicMediumState() const
 {
     return DynamicStateType::None;

--- a/SKIRT/core/MaterialMix.cpp
+++ b/SKIRT/core/MaterialMix.cpp
@@ -140,9 +140,9 @@ double MaterialMix::asymmpar(double /*lambda*/) const
 
 ////////////////////////////////////////////////////////////////////
 
-void MaterialMix::peeloffScattering(double& /*I*/, double& /*Q*/, double& /*U*/, double& /*V*/, double& /*lambda*/,
-                                         Direction /*bfkobs*/, Direction /*bfky*/, const MaterialState* /*state*/,
-                                         const PhotonPacket* /*pp*/) const
+bool MaterialMix::peeloffScattering(double& /*I*/, double& /*Q*/, double& /*U*/, double& /*V*/, double& /*lambda*/,
+                                    Direction /*bfkobs*/, Direction /*bfky*/, const MaterialState* /*state*/,
+                                    const PhotonPacket* /*pp*/) const
 {
     throw FATALERROR("This function implementation should never be called");
 }

--- a/SKIRT/core/MaterialMix.cpp
+++ b/SKIRT/core/MaterialMix.cpp
@@ -140,6 +140,22 @@ double MaterialMix::asymmpar(double /*lambda*/) const
 
 ////////////////////////////////////////////////////////////////////
 
+void MaterialMix::peeloffScattering(double& /*I*/, double& /*Q*/, double& /*U*/, double& /*V*/, double& /*lambda*/,
+                                         Direction /*bfkobs*/, Direction /*bfky*/, const MaterialState* /*state*/,
+                                         const PhotonPacket* /*pp*/) const
+{
+    throw FATALERROR("This function implementation should never be called");
+}
+
+////////////////////////////////////////////////////////////////////
+
+void MaterialMix::performScattering(double /*lambda*/, const MaterialState* /*state*/, PhotonPacket* /*pp*/) const
+{
+    throw FATALERROR("This function implementation should never be called");
+}
+
+////////////////////////////////////////////////////////////////////
+
 DisjointWavelengthGrid* MaterialMix::emissionWavelengthGrid() const
 {
     throw FATALERROR("This function implementation should never be called");

--- a/SKIRT/core/MaterialMix.hpp
+++ b/SKIRT/core/MaterialMix.hpp
@@ -463,9 +463,11 @@ public:
         by the probability that a photon packet would be scattered into the direction
         \f${\bf{k}}_{\text{obs}}\f$ if its original propagation direction was \f${\bf{k}}\f$. For a
         given medium component, this biasing factor is equal to the value of the scattering phase
-        function \f$\Phi({\bf{k}},{\bf{k}}_{\text{obs}})\f$ for that medium component. */
+        function \f$\Phi({\bf{k}},{\bf{k}}_{\text{obs}})\f$ for that medium component.
+
+        The default implementation in this base class throws a fatal error. */
     virtual void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs,
-                                   Direction bfky, const MaterialState* state, const PhotonPacket* pp) const = 0;
+                                   Direction bfky, const MaterialState* state, const PhotonPacket* pp) const;
 
     /** This function performs a scattering event on the specified photon packet in the spatial
         cell and medium component represented by the specified material state and the receiving
@@ -481,8 +483,10 @@ public:
         temperature of a gas medium, and any relevant properties of the incoming photon packet such
         as the polarization state. The first argument specifies the perceived wavelength of the
         photon packet at the scattering location so that this value does not need to be
-        recalculated within the function. */
-    virtual void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const = 0;
+        recalculated within the function.
+
+        The default implementation in this base class throws a fatal error. */
+    virtual void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const;
 
     //======== Secondary continuum emission =======
 

--- a/SKIRT/core/MaterialMix.hpp
+++ b/SKIRT/core/MaterialMix.hpp
@@ -283,6 +283,13 @@ public:
         implementation in this base class returns false. */
     virtual bool hasScatteringDispersion() const;
 
+    /** This function returns true if some of the outgoing photon packets of a scattering
+        interaction for this material mix may emulate secondary emission, and false otherwise.
+        These special photon packets will be recorded by instruments as if they originated during
+        secondary emission. This feature is used, for example, to implement fluorescence as a
+        scattering interaction. The default implementation in this base class returns false. */
+    virtual bool scatteringEmulatesSecondaryEmission() const;
+
     /** This enumeration is used to indicate whether a dynamic medium state (DMS) update algorithm
         is provided, and if so, when it should be executed:
 

--- a/SKIRT/core/MaterialMix.hpp
+++ b/SKIRT/core/MaterialMix.hpp
@@ -456,7 +456,9 @@ public:
         contributions to the Stokes vector components are stored in the \em I, \em Q, \em U, \em V
         arguments, which are guaranteed to be initialized to zero by the caller. If there is a
         wavelength shift, the new wavelength value replaces the incoming value of the \em lambda
-        argument.
+        argument. The function returns true if the scattering interaction emulates secondary
+        emission (e.g., to implement fluorescence as scattering), and false otherwise (i.e. in the
+        vast majority of cases).
 
         Since we force the peel-off photon packet to be scattered from the direction \f${\bf{k}}\f$
         into the direction \f${\bf{k}}_{\text{obs}}\f$, the corresponding biasing factor is given
@@ -466,7 +468,7 @@ public:
         function \f$\Phi({\bf{k}},{\bf{k}}_{\text{obs}})\f$ for that medium component.
 
         The default implementation in this base class throws a fatal error. */
-    virtual void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs,
+    virtual bool peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs,
                                    Direction bfky, const MaterialState* state, const PhotonPacket* pp) const;
 
     /** This function performs a scattering event on the specified photon packet in the spatial

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -5,7 +5,6 @@
 
 #include "MediumSystem.hpp"
 #include "Configuration.hpp"
-#include "Constants.hpp"
 #include "DensityInCellInterface.hpp"
 #include "DisjointWavelengthGrid.hpp"
 #include "FatalError.hpp"
@@ -778,7 +777,7 @@ void MediumSystem::peelOffScattering(int h, double w, double lambda, Direction b
     double I = 0., Q = 0., U = 0., V = 0.;
     MaterialState mst(_state, m, h);
     pp->setScatteringComponent(h);
-    mix(m, h)->peeloffScattering(I, Q, U, V, lambda, bfkobs, bfky, &mst, pp);
+    bool emulatedSecondaryEmission = mix(m, h)->peeloffScattering(I, Q, U, V, lambda, bfkobs, bfky, &mst, pp);
 
     // pass the result to the peel-off photon packet
     ppp->launchScatteringPeelOff(pp, bfkobs, _state.bulkVelocity(m), lambda, I * w);
@@ -788,6 +787,7 @@ void MediumSystem::peelOffScattering(int h, double w, double lambda, Direction b
         // so the reference direction is no longer used and can be left unspecified
         ppp->setPolarized(I, Q, U, V);
     }
+    if (emulatedSecondaryEmission) ppp->setEmulatedSecondaryOrigin(h);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/MonteCarloSimulation.cpp
+++ b/SKIRT/core/MonteCarloSimulation.cpp
@@ -4,7 +4,6 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "MonteCarloSimulation.hpp"
-#include "FatalError.hpp"
 #include "Log.hpp"
 #include "Parallel.hpp"
 #include "ParallelFactory.hpp"
@@ -559,7 +558,7 @@ void MonteCarloSimulation::performLifeCycle(size_t firstIndex, size_t numIndices
                                 mediumSystem()->setExtinctionOpticalDepths(&pp);
 
                             // advance the packet
-                            if (store) storeRadiationField(&pp);
+                            if (store) storeRadiationField(primary, &pp);
                             simulateForcedPropagation(&pp);
 
                             // if the packet's weight drops below the threshold, terminate it
@@ -623,7 +622,7 @@ void MonteCarloSimulation::peelOffEmission(const PhotonPacket* pp, PhotonPacket*
 
 ////////////////////////////////////////////////////////////////////
 
-void MonteCarloSimulation::storeRadiationField(const PhotonPacket* pp)
+void MonteCarloSimulation::storeRadiationField(bool primary, const PhotonPacket* pp)
 {
     // use a faster version in case there are no kinematics
     if (_config->hasConstantPerceivedWavelength())
@@ -632,8 +631,6 @@ void MonteCarloSimulation::storeRadiationField(const PhotonPacket* pp)
         if (ell >= 0)
         {
             double luminosity = pp->luminosity();
-            bool hasPrimaryOrigin = pp->hasPrimaryOrigin();
-
             double lnExtBeg = 0.;  // extinction factor and its logarithm at begin of current segment
             double extBeg = 1.;
             for (const auto& segment : pp->segments())
@@ -646,7 +643,7 @@ void MonteCarloSimulation::storeRadiationField(const PhotonPacket* pp)
                     // use this flavor of the lnmean function to avoid recalculating the logarithm of the extinction
                     double extMean = SpecialFunctions::lnmean(extEnd, extBeg, lnExtEnd, lnExtBeg);
                     double Lds = luminosity * extMean * segment.ds();
-                    mediumSystem()->storeRadiationField(hasPrimaryOrigin, m, ell, Lds);
+                    mediumSystem()->storeRadiationField(primary, m, ell, Lds);
                 }
                 lnExtBeg = lnExtEnd;
                 extBeg = extEnd;
@@ -672,7 +669,7 @@ void MonteCarloSimulation::storeRadiationField(const PhotonPacket* pp)
                     // use this flavor of the lnmean function to avoid recalculating the logarithm of the extinction
                     double extMean = SpecialFunctions::lnmean(extEnd, extBeg, lnExtEnd, lnExtBeg);
                     double Lds = pp->perceivedLuminosity(lambda) * extMean * segment.ds();
-                    mediumSystem()->storeRadiationField(pp->hasPrimaryOrigin(), m, ell, Lds);
+                    mediumSystem()->storeRadiationField(primary, m, ell, Lds);
                 }
             }
             lnExtBeg = lnExtEnd;

--- a/SKIRT/core/MonteCarloSimulation.cpp
+++ b/SKIRT/core/MonteCarloSimulation.cpp
@@ -782,7 +782,7 @@ void MonteCarloSimulation::peelOffScattering(PhotonPacket* pp, PhotonPacket* ppp
     if (!mediumSystem()->weightsForScattering(wv, lambda, pp)) return;
 
     // now do the actual peel-off
-    if (_config->hasScatteringDispersion())
+    if (_config->needIndividualPeelOff())
     {
         // if wavelengths may change, send a peel-off photon packet per medium component to each instrument
         int numMedia = wv.size();

--- a/SKIRT/core/MonteCarloSimulation.hpp
+++ b/SKIRT/core/MonteCarloSimulation.hpp
@@ -527,7 +527,7 @@ private:
         accumulated over all photon packets contributing to the bin. The resulting mean intensity
         \f$J_\lambda\f$ is expressed as an amount of energy per unit of time, per unit of area, per
         unit of wavelength, and per unit of solid angle. */
-    void storeRadiationField(const PhotonPacket* pp);
+    void storeRadiationField(bool primary, const PhotonPacket* pp);
 
     /** This function determines the next scattering location of a photon packet in a photon life
         cycle with forced scattering and simulates its propagation to that position. The function

--- a/SKIRT/core/NonLTELineGasMix.cpp
+++ b/SKIRT/core/NonLTELineGasMix.cpp
@@ -648,19 +648,7 @@ double NonLTELineGasMix::opacityExt(double lambda, const MaterialState* state, c
     return opacityAbs(lambda, state, pp);
 }
 
-////////////////////////////////////////////////////////////////////
-
-void NonLTELineGasMix::peeloffScattering(double& /*I*/, double& /*Q*/, double& /*U*/, double& /*V*/, double& /*lambda*/,
-                                         Direction /*bfkobs*/, Direction /*bfky*/, const MaterialState* /*state*/,
-                                         const PhotonPacket* /*pp*/) const
-{}
-
-////////////////////////////////////////////////////////////////////
-
-void NonLTELineGasMix::performScattering(double /*lambda*/, const MaterialState* /*state*/, PhotonPacket* /*pp*/) const
-{}
-
-////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////
 
 Array NonLTELineGasMix::lineEmissionCenters() const
 {

--- a/SKIRT/core/NonLTELineGasMix.hpp
+++ b/SKIRT/core/NonLTELineGasMix.hpp
@@ -490,13 +490,6 @@ public:
         opacity is zero. The photon packet properties are not used. */
     double opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
 
-    /** This function does nothing because the lines under consideration do not scatter. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
-                           const MaterialState* state, const PhotonPacket* pp) const override;
-
-    /** This function does nothing because the lines under consideration do not scatter. */
-    void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const override;
-
     //======== Secondary emission =======
 
     /** This function returns a list with the line centers of the supported transitions. */

--- a/SKIRT/core/SpinFlipAbsorptionMix.cpp
+++ b/SKIRT/core/SpinFlipAbsorptionMix.cpp
@@ -131,19 +131,6 @@ double SpinFlipAbsorptionMix::opacityExt(double lambda, const MaterialState* sta
 
 ////////////////////////////////////////////////////////////////////
 
-void SpinFlipAbsorptionMix::peeloffScattering(double& /*I*/, double& /*Q*/, double& /*U*/, double& /*V*/,
-                                              double& /*lambda*/, Direction /*bfkobs*/, Direction /*bfky*/,
-                                              const MaterialState* /*state*/, const PhotonPacket* /*pp*/) const
-{}
-
-////////////////////////////////////////////////////////////////////
-
-void SpinFlipAbsorptionMix::performScattering(double /*lambda*/, const MaterialState* /*state*/,
-                                              PhotonPacket* /*pp*/) const
-{}
-
-////////////////////////////////////////////////////////////////////
-
 double SpinFlipAbsorptionMix::indicativeTemperature(const MaterialState* state, const Array& /*Jv*/) const
 {
     return state->temperature();

--- a/SKIRT/core/SpinFlipAbsorptionMix.hpp
+++ b/SKIRT/core/SpinFlipAbsorptionMix.hpp
@@ -135,13 +135,6 @@ public:
         scattering opacity is zero. The photon packet properties are not used. */
     double opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
 
-    /** This function does nothing because the 21 cm line does not scatter. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
-                           const MaterialState* state, const PhotonPacket* pp) const override;
-
-    /** This function does nothing because the 21 cm line does not scatter. */
-    void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const override;
-
     //======== Temperature =======
 
     /** This function returns an indicative temperature of the material mix when it would be

--- a/SKIRT/core/SpinFlipHydrogenGasMix.cpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.cpp
@@ -218,19 +218,6 @@ double SpinFlipHydrogenGasMix::opacityExt(double lambda, const MaterialState* st
 
 ////////////////////////////////////////////////////////////////////
 
-void SpinFlipHydrogenGasMix::peeloffScattering(double& /*I*/, double& /*Q*/, double& /*U*/, double& /*V*/,
-                                               double& /*lambda*/, Direction /*bfkobs*/, Direction /*bfky*/,
-                                               const MaterialState* /*state*/, const PhotonPacket* /*pp*/) const
-{}
-
-////////////////////////////////////////////////////////////////////
-
-void SpinFlipHydrogenGasMix::performScattering(double /*lambda*/, const MaterialState* /*state*/,
-                                               PhotonPacket* /*pp*/) const
-{}
-
-////////////////////////////////////////////////////////////////////
-
 Array SpinFlipHydrogenGasMix::lineEmissionCenters() const
 {
     Array centers(1);

--- a/SKIRT/core/SpinFlipHydrogenGasMix.hpp
+++ b/SKIRT/core/SpinFlipHydrogenGasMix.hpp
@@ -308,13 +308,6 @@ public:
         scattering opacity is zero. The photon packet properties are not used. */
     double opacityExt(double lambda, const MaterialState* state, const PhotonPacket* pp) const override;
 
-    /** This function does nothing because the 21 cm line does not scatter. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
-                           const MaterialState* state, const PhotonPacket* pp) const override;
-
-    /** This function does nothing because the 21 cm line does not scatter. */
-    void performScattering(double lambda, const MaterialState* state, PhotonPacket* pp) const override;
-
     //======== Secondary emission =======
 
     /** This function returns a list including a single item: the line center of the 21 cm hydrogen

--- a/SKIRT/core/TrivialGasMix.cpp
+++ b/SKIRT/core/TrivialGasMix.cpp
@@ -89,7 +89,7 @@ double TrivialGasMix::opacityExt(double /*lambda*/, const MaterialState* state, 
 
 ////////////////////////////////////////////////////////////////////
 
-void TrivialGasMix::peeloffScattering(double& I, double& /*Q*/, double& /*U*/, double& /*V*/, double& /*lambda*/,
+bool TrivialGasMix::peeloffScattering(double& I, double& /*Q*/, double& /*U*/, double& /*V*/, double& /*lambda*/,
                                       Direction bfkobs, Direction /*bfky*/, const MaterialState* /*state*/,
                                       const PhotonPacket* pp) const
 {
@@ -101,6 +101,8 @@ void TrivialGasMix::peeloffScattering(double& I, double& /*Q*/, double& /*U*/, d
 
     // store this value as the intensity
     I = value;
+
+    return false;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/core/TrivialGasMix.hpp
+++ b/SKIRT/core/TrivialGasMix.hpp
@@ -107,7 +107,7 @@ public:
         material mix to the peel-off photon luminosity for the given observer direction. The
         material state, wavelength and photon packet properties other than direction are not used.
         */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+    bool peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
                            const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event for this material mix on the specified photon

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -1176,7 +1176,7 @@ void XRayAtomicGasMix::setScatteringInfoIfNeeded(PhotonPacket::ScatteringInfo* s
 
 ////////////////////////////////////////////////////////////////////
 
-void XRayAtomicGasMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs,
+bool XRayAtomicGasMix::peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs,
                                          Direction bfky, const MaterialState* /*state*/, const PhotonPacket* pp) const
 {
     // draw a random scattering channel and atom velocity, unless a previous peel-off stored this already
@@ -1212,6 +1212,9 @@ void XRayAtomicGasMix::peeloffScattering(double& I, double& Q, double& U, double
 
     // if we have dispersion, Doppler-shift the outgoing wavelength from the electron rest frame
     if (temperature() > 0.) lambda = PhotonPacket::shiftedEmissionWavelength(lambda, bfkobs, scatinfo->velocity);
+
+    // return true for fluorescence, false otherwise
+    return scatinfo->species >= static_cast<int>(2 * numAtoms);
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -1253,6 +1256,9 @@ void XRayAtomicGasMix::performScattering(double lambda, const MaterialState* sta
 
         // clear the stokes vector (only relevant if polarization support is enabled)
         pp->setUnpolarized();
+
+        // indicate that this packet emulates secondary emission;
+        pp->setEmulatedSecondaryOrigin(state->mediumIndex());
     }
 
     // if we have dispersion, Doppler-shift the outgoing wavelength from the electron rest frame

--- a/SKIRT/core/XRayAtomicGasMix.cpp
+++ b/SKIRT/core/XRayAtomicGasMix.cpp
@@ -1075,6 +1075,13 @@ bool XRayAtomicGasMix::hasScatteringDispersion() const
 
 ////////////////////////////////////////////////////////////////////
 
+bool XRayAtomicGasMix::scatteringEmulatesSecondaryEmission() const
+{
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////
+
 vector<StateVariable> XRayAtomicGasMix::specificStateVariableInfo() const
 {
     return vector<StateVariable>{StateVariable::numberDensity()};

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -346,6 +346,10 @@ public:
         may (and usually does) adjust the wavelength of the interacting photon packet. */
     bool hasScatteringDispersion() const override;
 
+    /** This function returns true, indicating that a scattering interaction for this material mix
+        may emulate secondary emission. This is used to implement fluorescence as scattering. */
+    bool scatteringEmulatesSecondaryEmission() const override;
+
     //======== Medium state setup =======
 
 public:

--- a/SKIRT/core/XRayAtomicGasMix.hpp
+++ b/SKIRT/core/XRayAtomicGasMix.hpp
@@ -419,7 +419,7 @@ public:
         bias weight is trivially one because emission is isotropic and unpolarized, and the
         outgoing wavelength is determined by Doppler-shifting the rest wavelength of the selected
         fluorescence transition for the selected atom velocity. */
-    void peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
+    bool peeloffScattering(double& I, double& Q, double& U, double& V, double& lambda, Direction bfkobs, Direction bfky,
                            const MaterialState* state, const PhotonPacket* pp) const override;
 
     /** This function performs a scattering event on the specified photon packet in the spatial

--- a/SKIRT/utils/PhotonPacket.cpp
+++ b/SKIRT/utils/PhotonPacket.cpp
@@ -54,6 +54,13 @@ void PhotonPacket::setSecondaryOrigin(int mediumCompIndex)
 
 ////////////////////////////////////////////////////////////////////
 
+void PhotonPacket::setEmulatedSecondaryOrigin(int mediumCompIndex)
+{
+    // to be implemented
+}
+
+////////////////////////////////////////////////////////////////////
+
 void PhotonPacket::launchEmissionPeelOff(const PhotonPacket* pp, Direction bfk)
 {
     _lambda = pp->_lambda;

--- a/SKIRT/utils/PhotonPacket.cpp
+++ b/SKIRT/utils/PhotonPacket.cpp
@@ -56,7 +56,8 @@ void PhotonPacket::setSecondaryOrigin(int mediumCompIndex)
 
 void PhotonPacket::setEmulatedSecondaryOrigin(int mediumCompIndex)
 {
-    // to be implemented
+    _nscatt = 0;
+    setSecondaryOrigin(mediumCompIndex);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/PhotonPacket.hpp
+++ b/SKIRT/utils/PhotonPacket.hpp
@@ -105,6 +105,13 @@ public:
         launch. */
     void setSecondaryOrigin(int mediumCompIndex);
 
+    /** This function rebrands the photon packet's origin after it has been involved in a
+        scattering interaction that emulates secondary emission. Specifically, it resets the
+        scattering counter and establishes that the photon packet has been emitted by the specified
+        medium, overwriting the packet's previous origin. This function should be called just after
+        launching the packet outgoing from the scattering interaction. */
+    void setEmulatedSecondaryOrigin(int mediumCompIndex);
+
     /** This function initializes a peel off photon packet being sent to an instrument for an
         emission event. The arguments specify the base photon packet from which the peel off
         derives and the direction towards the instrument. The function copies the relevant values


### PR DESCRIPTION
**Motivation**
While fluorescence is a form of secondary emission by a given medium, the `XRayAtomicGasMix` class instead implements fluorescence as a form of scattering. This substantially simplifies the implementation, but it also means that - before this update - fluorescence radiation is mixed in with primary radiation and cannot be recorded separately. 

 A group of users in the X-ray community requested to resolve this issue, because in X-ray spectral fitting fluorescent lines are commonly introduced as a separate spectral component.  Furthermore, other future material types may face a similar problem.

**Description**
With this update, fluorescence photon packets are "rebranded" during the scattering event to look like secondary emission packets, and the instruments record them accordingly (assuming the _recordComponents_ property is enabled).

Future material mixes may use this feature to rebrand photon packets that emulate secondary emission through a scattering interaction, including but not restricted to fluorescence.

**Caveats**
The emulation of secondary emission by rebranding photon packets only works for recording by instruments. Specifically:
- The LaunchedPacketsProbe ignores rebranding; it just counts original emissions.
- The procedure for storing the radiation field similarly ignores rebranding; it stores contributions from rebranded photon packets according to their original emission. For example, if the simulation includes secondary emission by dust, the radiation field used to calculate secondary emission spectrum will include the contributions from rebranded photon packets.

**Tests**
Apart from the expected changes in recorded X-ray flux components, all functional tests produce binary identical results.

**Context**
This feature was requested by @BertVdM.
