### PR TITLE
Output Stokes Q, U, and V flux contributions

### DIFF
--- a/SKIRT/core/FluxRecorder.cpp
+++ b/SKIRT/core/FluxRecorder.cpp
@@ -27,12 +27,30 @@ namespace
         Transparent,
         PrimaryDirect,
         PrimaryScattered,
-        SecondaryTransparent,
         SecondaryDirect,
         SecondaryScattered,
+        SecondaryTransparent,
         TotalQ,
         TotalU,
         TotalV,
+        TransparentQ,
+        TransparentU,
+        TransparentV,
+        PrimaryDirectQ,
+        PrimaryDirectU,
+        PrimaryDirectV,
+        PrimaryScatteredQ,
+        PrimaryScatteredU,
+        PrimaryScatteredV,
+        SecondaryDirectQ,
+        SecondaryDirectU,
+        SecondaryDirectV,
+        SecondaryScatteredQ,
+        SecondaryScatteredU,
+        SecondaryScatteredV,
+        SecondaryTransparentQ,
+        SecondaryTransparentU,
+        SecondaryTransparentV,
         PrimaryScatteredLevel
     };
 
@@ -192,6 +210,36 @@ void FluxRecorder::finalizeConfiguration()
         _ifu[TotalU].resize(lenIFU);
         _sed[TotalV].resize(lenSED);
         _ifu[TotalV].resize(lenIFU);
+        
+        if (!_recordTotalOnly)
+        {
+            _sed[TransparentQ].resize(lenSED);
+            _sed[TransparentU].resize(lenSED);
+            _sed[TransparentV].resize(lenSED);
+            
+            _sed[PrimaryDirectQ].resize(lenSED);
+            _sed[PrimaryDirectU].resize(lenSED);
+            _sed[PrimaryDirectV].resize(lenSED);
+            
+            _sed[PrimaryScatteredQ].resize(lenSED);
+            _sed[PrimaryScatteredU].resize(lenSED);
+            _sed[PrimaryScatteredV].resize(lenSED);
+            
+            if (_hasMediumEmission)
+            {
+                _sed[SecondaryTransparentQ].resize(lenSED);
+                _sed[SecondaryTransparentU].resize(lenSED);
+                _sed[SecondaryTransparentV].resize(lenSED);
+                
+                _sed[SecondaryDirectQ].resize(lenSED);
+                _sed[SecondaryDirectU].resize(lenSED);
+                _sed[SecondaryDirectV].resize(lenSED);
+                
+                _sed[SecondaryScatteredQ].resize(lenSED);
+                _sed[SecondaryScatteredU].resize(lenSED);
+                _sed[SecondaryScatteredV].resize(lenSED);
+            }
+        }
     }
 
     // allocate and resize the statistics detector arrays
@@ -300,6 +348,46 @@ void FluxRecorder::detect(PhotonPacket* pp, int l, double distance)
                 LockFree::add(_sed[TotalQ][ell], Lext * pp->stokesQ());
                 LockFree::add(_sed[TotalU][ell], Lext * pp->stokesU());
                 LockFree::add(_sed[TotalV][ell], Lext * pp->stokesV());
+                
+                if (!_recordTotalOnly)
+                {
+                    if (pp->hasPrimaryOrigin())
+                    {
+                        if (numScatt == 0)
+                        {
+                            LockFree::add(_sed[TransparentQ][ell], L * pp->stokesQ());
+                            LockFree::add(_sed[TransparentU][ell], L * pp->stokesU());
+                            LockFree::add(_sed[TransparentV][ell], L * pp->stokesV());
+                            LockFree::add(_sed[PrimaryDirectQ][ell], Lext * pp->stokesQ());
+                            LockFree::add(_sed[PrimaryDirectU][ell], Lext * pp->stokesU());
+                            LockFree::add(_sed[PrimaryDirectV][ell], Lext * pp->stokesV());
+                        }
+                        else
+                        {
+                            LockFree::add(_sed[PrimaryScatteredQ][ell], Lext * pp->stokesQ());
+                            LockFree::add(_sed[PrimaryScatteredU][ell], Lext * pp->stokesU());
+                            LockFree::add(_sed[PrimaryScatteredV][ell], Lext * pp->stokesV());
+                        }
+                    }
+                    else
+                    {
+                        if (numScatt == 0)
+                        {
+                            LockFree::add(_sed[SecondaryTransparentQ][ell], L * pp->stokesQ());
+                            LockFree::add(_sed[SecondaryTransparentU][ell], L * pp->stokesU());
+                            LockFree::add(_sed[SecondaryTransparentV][ell], L * pp->stokesV());
+                            LockFree::add(_sed[SecondaryDirectQ][ell], Lext * pp->stokesQ());
+                            LockFree::add(_sed[SecondaryDirectU][ell], Lext * pp->stokesU());
+                            LockFree::add(_sed[SecondaryDirectV][ell], Lext * pp->stokesV());
+                        }
+                        else
+                        {
+                            LockFree::add(_sed[SecondaryScatteredQ][ell], Lext * pp->stokesQ());
+                            LockFree::add(_sed[SecondaryScatteredU][ell], Lext * pp->stokesU());
+                            LockFree::add(_sed[SecondaryScatteredV][ell], Lext * pp->stokesV());
+                        }
+                    }
+                }
             }
         }
 
@@ -462,6 +550,22 @@ void FluxRecorder::calibrateAndWrite()
         {
             sedNames.insert(sedNames.end(), {"total Stokes Q", "total Stokes U", "total Stokes V"});
             sedArrays.insert(sedArrays.end(), {&_sed[TotalQ], &_sed[TotalU], &_sed[TotalV]});
+            
+            if (_recordComponents && !_recordTotalOnly)
+            {
+                sedNames.insert(sedNames.end(), {"transparent Stokes Q", "transparent Stokes U", "transparent Stokes V",
+                                                 "direct primary Stokes Q", "direct primary Stokes U", "direct primary Stokes V",
+                                                 "scattered primary Stokes Q", "scattered primary Stokes U", "scattered primary Stokes V",
+                                                 "direct secondary Stokes Q", "direct secondary Stokes U", "direct secondary Stokes V",
+                                                 "scattered secondary Stokes Q", "scattered secondary Stokes U", "scattered secondary Stokes V",
+                                                 "transparent secondary Stokes Q", "transparent secondary Stokes U", "transparent secondary Stokes V"});
+                sedArrays.insert(sedArrays.end(), {&_sed[TransparentQ], &_sed[TransparentU], &_sed[TransparentV],
+                                                   &_sed[PrimaryDirectQ], &_sed[PrimaryDirectU], &_sed[PrimaryDirectV],
+                                                   &_sed[PrimaryScatteredQ], &_sed[PrimaryScatteredU], &_sed[PrimaryScatteredV],
+                                                   &_sed[SecondaryDirectQ], &_sed[SecondaryDirectU], &_sed[SecondaryDirectV],
+                                                   &_sed[SecondaryScatteredQ], &_sed[SecondaryScatteredU], &_sed[SecondaryScatteredV],
+                                                   &_sed[SecondaryTransparentQ], &_sed[SecondaryTransparentU], &_sed[SecondaryTransparentV]});
+            }
         }
 
         // add the scattering levels, if requested, even if they are all zero

--- a/SKIRT/core/FluxRecorder.cpp
+++ b/SKIRT/core/FluxRecorder.cpp
@@ -210,31 +210,31 @@ void FluxRecorder::finalizeConfiguration()
         _ifu[TotalU].resize(lenIFU);
         _sed[TotalV].resize(lenSED);
         _ifu[TotalV].resize(lenIFU);
-        
+
         if (!_recordTotalOnly)
         {
             _sed[TransparentQ].resize(lenSED);
             _sed[TransparentU].resize(lenSED);
             _sed[TransparentV].resize(lenSED);
-            
+
             _sed[PrimaryDirectQ].resize(lenSED);
             _sed[PrimaryDirectU].resize(lenSED);
             _sed[PrimaryDirectV].resize(lenSED);
-            
+
             _sed[PrimaryScatteredQ].resize(lenSED);
             _sed[PrimaryScatteredU].resize(lenSED);
             _sed[PrimaryScatteredV].resize(lenSED);
-            
+
             if (_hasMediumEmission)
             {
                 _sed[SecondaryTransparentQ].resize(lenSED);
                 _sed[SecondaryTransparentU].resize(lenSED);
                 _sed[SecondaryTransparentV].resize(lenSED);
-                
+
                 _sed[SecondaryDirectQ].resize(lenSED);
                 _sed[SecondaryDirectU].resize(lenSED);
                 _sed[SecondaryDirectV].resize(lenSED);
-                
+
                 _sed[SecondaryScatteredQ].resize(lenSED);
                 _sed[SecondaryScatteredU].resize(lenSED);
                 _sed[SecondaryScatteredV].resize(lenSED);
@@ -348,7 +348,7 @@ void FluxRecorder::detect(PhotonPacket* pp, int l, double distance)
                 LockFree::add(_sed[TotalQ][ell], Lext * pp->stokesQ());
                 LockFree::add(_sed[TotalU][ell], Lext * pp->stokesU());
                 LockFree::add(_sed[TotalV][ell], Lext * pp->stokesV());
-                
+
                 if (!_recordTotalOnly)
                 {
                     if (pp->hasPrimaryOrigin())
@@ -550,21 +550,24 @@ void FluxRecorder::calibrateAndWrite()
         {
             sedNames.insert(sedNames.end(), {"total Stokes Q", "total Stokes U", "total Stokes V"});
             sedArrays.insert(sedArrays.end(), {&_sed[TotalQ], &_sed[TotalU], &_sed[TotalV]});
-            
+
             if (_recordComponents && !_recordTotalOnly)
             {
-                sedNames.insert(sedNames.end(), {"transparent Stokes Q", "transparent Stokes U", "transparent Stokes V",
-                                                 "direct primary Stokes Q", "direct primary Stokes U", "direct primary Stokes V",
-                                                 "scattered primary Stokes Q", "scattered primary Stokes U", "scattered primary Stokes V",
-                                                 "direct secondary Stokes Q", "direct secondary Stokes U", "direct secondary Stokes V",
-                                                 "scattered secondary Stokes Q", "scattered secondary Stokes U", "scattered secondary Stokes V",
-                                                 "transparent secondary Stokes Q", "transparent secondary Stokes U", "transparent secondary Stokes V"});
-                sedArrays.insert(sedArrays.end(), {&_sed[TransparentQ], &_sed[TransparentU], &_sed[TransparentV],
-                                                   &_sed[PrimaryDirectQ], &_sed[PrimaryDirectU], &_sed[PrimaryDirectV],
-                                                   &_sed[PrimaryScatteredQ], &_sed[PrimaryScatteredU], &_sed[PrimaryScatteredV],
-                                                   &_sed[SecondaryDirectQ], &_sed[SecondaryDirectU], &_sed[SecondaryDirectV],
-                                                   &_sed[SecondaryScatteredQ], &_sed[SecondaryScatteredU], &_sed[SecondaryScatteredV],
-                                                   &_sed[SecondaryTransparentQ], &_sed[SecondaryTransparentU], &_sed[SecondaryTransparentV]});
+                sedNames.insert(
+                    sedNames.end(),
+                    {"transparent Stokes Q", "transparent Stokes U", "transparent Stokes V", "direct primary Stokes Q",
+                     "direct primary Stokes U", "direct primary Stokes V", "scattered primary Stokes Q",
+                     "scattered primary Stokes U", "scattered primary Stokes V", "direct secondary Stokes Q",
+                     "direct secondary Stokes U", "direct secondary Stokes V", "scattered secondary Stokes Q",
+                     "scattered secondary Stokes U", "scattered secondary Stokes V", "transparent secondary Stokes Q",
+                     "transparent secondary Stokes U", "transparent secondary Stokes V"});
+                sedArrays.insert(sedArrays.end(),
+                                 {&_sed[TransparentQ], &_sed[TransparentU], &_sed[TransparentV], &_sed[PrimaryDirectQ],
+                                  &_sed[PrimaryDirectU], &_sed[PrimaryDirectV], &_sed[PrimaryScatteredQ],
+                                  &_sed[PrimaryScatteredU], &_sed[PrimaryScatteredV], &_sed[SecondaryDirectQ],
+                                  &_sed[SecondaryDirectU], &_sed[SecondaryDirectV], &_sed[SecondaryScatteredQ],
+                                  &_sed[SecondaryScatteredU], &_sed[SecondaryScatteredV], &_sed[SecondaryTransparentQ],
+                                  &_sed[SecondaryTransparentU], &_sed[SecondaryTransparentV]});
             }
         }
 

--- a/SKIRT/core/FluxRecorder.cpp
+++ b/SKIRT/core/FluxRecorder.cpp
@@ -227,10 +227,6 @@ void FluxRecorder::finalizeConfiguration()
 
             if (_hasMediumEmission)
             {
-                _sed[SecondaryTransparentQ].resize(lenSED);
-                _sed[SecondaryTransparentU].resize(lenSED);
-                _sed[SecondaryTransparentV].resize(lenSED);
-
                 _sed[SecondaryDirectQ].resize(lenSED);
                 _sed[SecondaryDirectU].resize(lenSED);
                 _sed[SecondaryDirectV].resize(lenSED);
@@ -238,6 +234,10 @@ void FluxRecorder::finalizeConfiguration()
                 _sed[SecondaryScatteredQ].resize(lenSED);
                 _sed[SecondaryScatteredU].resize(lenSED);
                 _sed[SecondaryScatteredV].resize(lenSED);
+
+                _sed[SecondaryTransparentQ].resize(lenSED);
+                _sed[SecondaryTransparentU].resize(lenSED);
+                _sed[SecondaryTransparentV].resize(lenSED);
             }
         }
     }
@@ -373,12 +373,12 @@ void FluxRecorder::detect(PhotonPacket* pp, int l, double distance)
                     {
                         if (numScatt == 0)
                         {
-                            LockFree::add(_sed[SecondaryTransparentQ][ell], L * pp->stokesQ());
-                            LockFree::add(_sed[SecondaryTransparentU][ell], L * pp->stokesU());
-                            LockFree::add(_sed[SecondaryTransparentV][ell], L * pp->stokesV());
                             LockFree::add(_sed[SecondaryDirectQ][ell], Lext * pp->stokesQ());
                             LockFree::add(_sed[SecondaryDirectU][ell], Lext * pp->stokesU());
                             LockFree::add(_sed[SecondaryDirectV][ell], Lext * pp->stokesV());
+                            LockFree::add(_sed[SecondaryTransparentQ][ell], L * pp->stokesQ());
+                            LockFree::add(_sed[SecondaryTransparentU][ell], L * pp->stokesU());
+                            LockFree::add(_sed[SecondaryTransparentV][ell], L * pp->stokesV());
                         }
                         else
                         {


### PR DESCRIPTION
**Description and motivation**
We extend the FluxRecorder to also output the flux contributions (i.e., direct, scattered, secondary) of the Stokes Q, Stokes U, and Stokes V photon fluxes when modelling polarisation, which is crucial to analyse and interpret (X-ray) polarisation simulations. The main motivation is the analysis of a project I am working on now, but I have missed this functionality before.

We decided to only output the flux contributions for the SED instruments and not for the IFU instruments, in order to not let the number of output files explode (one IFU per contribution). If this information would be required for IFUs in the future, SKIRT can be extended following the same pattern.

The order of the columns could be debated. Now the order seems illogical as the pattern is different for Stokes I vs. Q, U, and V. But this is consistent with the current implementation (i.e., not changing the order of the columns that are already there).

I also changed the order "SecondaryTransparent, SecondaryDirect, SecondaryScattered" -> "SecondaryDirect, SecondaryScattered, SecondaryTransparent" in the code (no effect for the user), to be consistent with the order of the output columns.

**Tests**
As a test case, we ran X-ray radiative transfer simulations of an AGN torus, centred on a polarised X-ray point source (PL=10%, gamma = 30 deg). We compare the total Stokes parameters to the current implementation: [CompareCurrentNew.pdf](https://github.com/user-attachments/files/25044143/CompareCurrentNew.pdf). We plot the Stokes Q and Stokes U contribution (noting that Stokes V is not being studied in X-rays): [StokesUComponents.pdf](https://github.com/user-attachments/files/25044151/StokesUComponents.pdf) and 
[StokesQComponents.pdf](https://github.com/user-attachments/files/25044150/StokesQComponents.pdf). Finally, we checked if the Stokes contributions add up to the total Stokes parameters: [ConsistencyCheck.pdf](https://github.com/user-attachments/files/25044148/ConsistencyCheck.pdf).

Also confirmed there are no changes to the IFU instrument output.




