### PR TITLE
Tiny technical adjustments

### DIFF
--- a/SKIRT/core/DiffuseIonizedGasMix.cpp
+++ b/SKIRT/core/DiffuseIonizedGasMix.cpp
@@ -22,6 +22,17 @@
 
 namespace
 {
+    // Minimum ionization parameter for emission: cells with logU <= this get T = _minTEmit
+    // in updateTemperatureFromStab() and are also directly gated in emissionSpectrum().
+    static constexpr double _minLogUEmit = -6.50;
+
+    // Temperature floor [K] applied to cells below the logU emission gate
+    static constexpr double _minTEmit = 300.0;
+
+    // Log-space floor for logU and logR2..logR5: uninitialised cells sit here, and computed
+    // values are clamped here. "At the floor" is detected with `value <= _logFloor`.
+    static constexpr double _logFloor = -99.0;
+
     // Solar reference metallicity (GASS10).
     static constexpr double _solarZ = 0.014;
 

--- a/SKIRT/core/DiffuseIonizedGasMix.hpp
+++ b/SKIRT/core/DiffuseIonizedGasMix.hpp
@@ -505,10 +505,6 @@ private:
     // Emission wavelength grid
     DisjointWavelengthGrid* _emissionWavelengthGrid = nullptr;
 
-    // Minimum ionization parameter for emission: cells with logU <= this get T = _minTEmit
-    // in updateTemperatureFromStab() and are also directly gated in emissionSpectrum().
-    static constexpr double _minLogUEmit = -6.50;
-
     // Cached density ceiling in m^-3 (0 = disabled), set in setupSelfBefore from maxHydrogenDensity
     double _maxNH_m3 = 0.;
 
@@ -517,13 +513,6 @@ private:
     // and blending-weight hot path.
     double _transitionLogUMin = 0.;
     double _transitionLogUMax = 0.;
-
-    // Temperature floor [K] applied to cells below the logU emission gate
-    static constexpr double _minTEmit = 300.0;
-
-    // Log-space floor for logU and logR2..logR5: uninitialised cells sit here, and computed
-    // values are clamped here. "At the floor" is detected with `value <= _logFloor`.
-    static constexpr double _logFloor = -99.0;
 
     // Custom state variable indices
     int _indexHeliumAbundance = 0;

--- a/SKIRT/utils/BoxSearch.cpp
+++ b/SKIRT/utils/BoxSearch.cpp
@@ -130,7 +130,7 @@ void BoxSearch::loadEntities(int numEntities, std::function<Box(int)> bounds,
     // calculate statistics
     _minEntitiesPerBlock = numEntities;
     _maxEntitiesPerBlock = 0;
-    int totalEntityReferences = 0;
+    size_t totalEntityReferences = 0;
     for (const auto& list : _listv)
     {
         int size = list.size();

--- a/SKIRT/utils/CylindricalCell.cpp
+++ b/SKIRT/utils/CylindricalCell.cpp
@@ -11,9 +11,25 @@
 
 //////////////////////////////////////////////////////////////////////
 
+namespace
+{
+    // snap a cosine or sine value to 0 or 1 to avoid rounding errors in the calculations
+    double snap(double v)
+    {
+        constexpr double eps = 1e-12;
+        if (abs(v) < eps) return 0.;
+        if (v > 1. - eps) return 1.;
+        if (v < -1. + eps) return -1.;
+        return v;
+    }
+}
+
+//////////////////////////////////////////////////////////////////////
+
 CylindricalCell::CylindricalCell(double Rmin, double phimin, double zmin, double Rmax, double phimax, double zmax)
-    : _Rmin(Rmin), _phimin(phimin), _zmin(zmin), _Rmax(Rmax), _phimax(phimax), _zmax(zmax), _cosphimin(cos(phimin)),
-      _sinphimin(sin(phimin)), _cosphimax(cos(phimax)), _sinphimax(sin(phimax))
+    : _Rmin(Rmin), _phimin(phimin), _zmin(zmin), _Rmax(Rmax), _phimax(phimax), _zmax(zmax),
+      _cosphimin(snap(cos(phimin))), _sinphimin(snap(sin(phimin))), _cosphimax(snap(cos(phimax))),
+      _sinphimax(snap(sin(phimax)))
 {}
 
 //////////////////////////////////////////////////////////////////////

--- a/SKIRT/utils/SphericalCell.cpp
+++ b/SKIRT/utils/SphericalCell.cpp
@@ -12,10 +12,26 @@
 
 //////////////////////////////////////////////////////////////////////
 
+namespace
+{
+    // snap a cosine or sine value to 0 or 1 to avoid rounding errors in the calculations
+    double snap(double v)
+    {
+        constexpr double eps = 1e-12;
+        if (abs(v) < eps) return 0.;
+        if (v > 1. - eps) return 1.;
+        if (v < -1. + eps) return -1.;
+        return v;
+    }
+}
+
+//////////////////////////////////////////////////////////////////////
+
 SphericalCell::SphericalCell(double rmin, double thetamin, double phimin, double rmax, double thetamax, double phimax)
     : _rmin(rmin), _thetamin(thetamin), _phimin(phimin), _rmax(rmax), _thetamax(thetamax), _phimax(phimax),
-      _cosphimin(cos(phimin)), _sinphimin(sin(phimin)), _cosphimax(cos(phimax)), _sinphimax(sin(phimax)),
-      _costhetamin(cos(thetamin)), _sinthetamin(sin(thetamin)), _costhetamax(cos(thetamax)), _sinthetamax(sin(thetamax))
+      _cosphimin(snap(cos(phimin))), _sinphimin(snap(sin(phimin))), _cosphimax(snap(cos(phimax))),
+      _sinphimax(snap(sin(phimax))), _costhetamin(snap(cos(thetamin))), _sinthetamin(snap(sin(thetamin))),
+      _costhetamax(snap(cos(thetamax))), _sinthetamax(snap(sin(thetamax)))
 {}
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Description**
This update fixes a few minor things:
- The bounding box for cylindrical and spherical cells would sometimes not fully enclose the cell (by a very small margin).
- For a very large number of imported particles or cells, the reported average nr of entities in the corresponding search structure would be incorrect (without affecting the search structure).
- The constexpr values in the header file of the DiffuseIonizedGasMix class would cause build issues in debug mode.

**Motivation**
Even tiny bugs are worth fixing.
