### PR TITLE
Index the medium state array in 64-bit arithmetic

### DIFF
--- a/SKIRT/core/MediumState.cpp
+++ b/SKIRT/core/MediumState.cpp
@@ -161,7 +161,7 @@ void MediumState::calculateAggregate()
     if (_numAggregateCells)
     {
         // clear the variables in the current aggregate state
-        for (int i = 0; i != _numVars; ++i) _data[_numVars * _numCells + i] = 0.;
+        for (size_t i = 0; i != _numVars; ++i) _data[_numVars * _numCells + i] = 0.;
 
         // calculate the current aggregate state
         for (int m = 0; m != _numCells; ++m)
@@ -186,7 +186,7 @@ void MediumState::pushAggregate()
         // shift the previous aggregate states to make room
         for (int m = _numCells + _numAggregateCells - 1; m != _numCells; --m)
         {
-            for (int i = 0; i != _numVars; ++i) _data[_numVars * m + i] = _data[_numVars * (m - 1) + i];
+            for (size_t i = 0; i != _numVars; ++i) _data[_numVars * m + i] = _data[_numVars * (m - 1) + i];
         }
     }
 }
@@ -202,7 +202,7 @@ void MediumState::setVolume(int m, double value)
 
 void MediumState::setBulkVelocity(int m, Vec value)
 {
-    int i = _numVars * m + _off_velo;
+    size_t i = _numVars * m + _off_velo;
     _data[i] = value.x();
     _data[i + 1] = value.y();
     _data[i + 2] = value.z();
@@ -212,7 +212,7 @@ void MediumState::setBulkVelocity(int m, Vec value)
 
 void MediumState::setMagneticField(int m, Vec value)
 {
-    int i = _numVars * m + _off_mfld;
+    size_t i = _numVars * m + _off_mfld;
     _data[i] = value.x();
     _data[i + 1] = value.y();
     _data[i + 2] = value.z();

--- a/SKIRT/core/MediumState.hpp
+++ b/SKIRT/core/MediumState.hpp
@@ -228,7 +228,7 @@ public:
     {
         if (_off_velo)
         {
-            int i = _numVars * m + _off_velo;
+            size_t i = _numVars * m + _off_velo;
             return Vec(_data[i], _data[i + 1], _data[i + 2]);
         }
         return Vec();
@@ -240,7 +240,7 @@ public:
     {
         if (_off_mfld)
         {
-            int i = _numVars * m + _off_mfld;
+            size_t i = _numVars * m + _off_mfld;
             return Vec(_data[i], _data[i + 1], _data[i + 2]);
         }
         return Vec();
@@ -272,7 +272,7 @@ private:
     int _numCells{0};
     int _numMedia{0};
     int _numAggregateCells{0};
-    int _numVars{0};
+    size_t _numVars{0};
 
     // offsets used for mapping common and specific variables (for each medium component) to indices in the data array
     int _off_volu{0};


### PR DESCRIPTION
**Description**

`MediumState` indexes its data array as `_data[_numVars * m + off]`, where both `_numVars` and `m` are `int`. The multiplication is therefore performed in 32 bits and wraps once the product passes 2^31, which yields a negative index and a segmentation fault. The allocation itself is correct, since `initAllocate()` casts to `size_t`, so the array is allocated at full size and only the indexing overflows.

This declares `_numVars` as `size_t`. The index expressions themselves are unchanged: the multiplication is simply promoted to 64 bits. Same is done for loop counters, and four indices in `bulkVelocity()`, `magneticField()` and their setters change from `int` to `size_t`, because they assigned the product back into an `int` and would otherwise have truncated it even with a 64-bit multiplication.

**Motivation**

The limit is 2^31 / numVars cells, so how quickly it is reached depends on how many state variables a material mix stores per cell. For most mixes numVars is small and one would need hundreds of millions of cells, which is why this has gone unnoticed. `DiffuseIonizedGasMix` caches the photoionisation opacity per cell, so numVars is high enough that the limit drops to a cell number routinely found in SKIRT simulations. In tests, a 128^3 grid reached it. The failure is also silent, which makes it hard to attribute. The log stops after "Calculating medium properties for N cells".

**Tests**

- A 128^3 Cartesian grid (2 097 152 cells) with `DiffuseIonizedGasMix`: segfaults during medium state setup on master, completes setup and proceeds through the photon cycle with this change.
- Builds clean against current master with no new warnings.

**Guidelines**

clang-format 18 applied, Doxygen comments left intact, no new naming introduced, branch taken from current master.

**Context**

The failure being silent is not  addressed here.