### PR TITLE
Spatial grids with lower symmetry than the primary sources

### DIFF
--- a/SKIRT/core/AxAngularDistribution.hpp
+++ b/SKIRT/core/AxAngularDistribution.hpp
@@ -19,17 +19,17 @@
 class AxAngularDistribution : public AngularDistribution
 {
     ITEM_ABSTRACT(AxAngularDistribution, AngularDistribution, "an axisymmetric angular emission profile")
-        ATTRIBUTE_TYPE_INSERT(AxAngularDistribution, "Dimension2")
+        ATTRIBUTE_TYPE_INSERT(AxAngularDistribution, "SourceDimension2,Dimension2")
 
         PROPERTY_DOUBLE(symmetryX, "the direction of the positive symmetry axis, x component")
         ATTRIBUTE_QUANTITY(symmetryX, "length")
         ATTRIBUTE_DEFAULT_VALUE(symmetryX, "0")
-        ATTRIBUTE_INSERT(symmetryX, "symmetryX:Dimension3")
+        ATTRIBUTE_INSERT(symmetryX, "symmetryX:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(symmetryY, "the direction of the positive symmetry axis, y component")
         ATTRIBUTE_QUANTITY(symmetryY, "length")
         ATTRIBUTE_DEFAULT_VALUE(symmetryY, "0")
-        ATTRIBUTE_INSERT(symmetryY, "symmetryY:Dimension3")
+        ATTRIBUTE_INSERT(symmetryY, "symmetryY:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(symmetryZ, "the direction of the positive symmetry axis, z component")
         ATTRIBUTE_QUANTITY(symmetryZ, "length")

--- a/SKIRT/core/AxGeometry.hpp
+++ b/SKIRT/core/AxGeometry.hpp
@@ -16,7 +16,7 @@
 class AxGeometry : public Geometry
 {
     ITEM_ABSTRACT(AxGeometry, Geometry, "an axisymmetric geometry")
-        ATTRIBUTE_TYPE_INSERT(AxGeometry, "Dimension2")
+        ATTRIBUTE_TYPE_INSERT(AxGeometry, "InMedia:MediaDimension2,Dimension2;SourceDimension2,Dimension2")
     ITEM_END()
 
     //======================== Other Functions =======================

--- a/SKIRT/core/AxPowerLawRedistributeGeometryDecorator.hpp
+++ b/SKIRT/core/AxPowerLawRedistributeGeometryDecorator.hpp
@@ -22,7 +22,8 @@ class AxPowerLawRedistributeGeometryDecorator : public RedistributeGeometryDecor
 {
     ITEM_CONCRETE(AxPowerLawRedistributeGeometryDecorator, RedistributeGeometryDecorator,
                   "a decorator that redistributes another geometry with an axial power law")
-        ATTRIBUTE_TYPE_INSERT(AxPowerLawRedistributeGeometryDecorator, "Dimension2")
+        ATTRIBUTE_TYPE_INSERT(AxPowerLawRedistributeGeometryDecorator,
+                              "InMedia:MediaDimension2,Dimension2;SourceDimension2,Dimension2")
 
         PROPERTY_DOUBLE(RExponent, "the negative power of the radial part of the weight function")
         ATTRIBUTE_MIN_VALUE(RExponent, "[0")

--- a/SKIRT/core/BoxClipGeometryDecorator.hpp
+++ b/SKIRT/core/BoxClipGeometryDecorator.hpp
@@ -17,7 +17,8 @@ class BoxClipGeometryDecorator : public ClipGeometryDecorator
 {
     ITEM_CONCRETE(BoxClipGeometryDecorator, ClipGeometryDecorator,
                   "a decorator that clips another geometry using a cubodial box")
-        ATTRIBUTE_TYPE_INSERT(BoxClipGeometryDecorator, "Dimension3")
+        ATTRIBUTE_TYPE_INSERT(BoxClipGeometryDecorator,
+                              "InMedia:MediaDimension3,Dimension3;SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(minX, "the start point of the box in the X direction")
         ATTRIBUTE_QUANTITY(minX, "length")

--- a/SKIRT/core/CenteredSource.hpp
+++ b/SKIRT/core/CenteredSource.hpp
@@ -26,17 +26,17 @@ class CenteredSource : public SpecialtySource
         PROPERTY_DOUBLE(centerX, "the center of the source, x component")
         ATTRIBUTE_QUANTITY(centerX, "length")
         ATTRIBUTE_DEFAULT_VALUE(centerX, "0")
-        ATTRIBUTE_INSERT(centerX, "centerX:Dimension3")
+        ATTRIBUTE_INSERT(centerX, "centerX:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(centerY, "the center of the source, y component")
         ATTRIBUTE_QUANTITY(centerY, "length")
         ATTRIBUTE_DEFAULT_VALUE(centerY, "0")
-        ATTRIBUTE_INSERT(centerY, "centerY:Dimension3")
+        ATTRIBUTE_INSERT(centerY, "centerY:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(centerZ, "the center of the source, z component")
         ATTRIBUTE_QUANTITY(centerZ, "length")
         ATTRIBUTE_DEFAULT_VALUE(centerZ, "0")
-        ATTRIBUTE_INSERT(centerZ, "centerZ:Dimension2")
+        ATTRIBUTE_INSERT(centerZ, "centerZ:SourceDimension2,Dimension2")
 
     ITEM_END()
 

--- a/SKIRT/core/Configuration.cpp
+++ b/SKIRT/core/Configuration.cpp
@@ -71,8 +71,10 @@ void Configuration::setupSelfBefore()
         if (is) _defaultWavelengthGrid = is->defaultWavelengthGrid();
     }
 
-    // determine model dimension based on sources only (we'll redo this later if there are media)
-    _modelDimension = ss->dimension();
+    // determine source and (provisional) model dimension based on sources only
+    // (we'll redo the model dimension later if there are media)
+    _sourceDimension = ss->dimension();
+    _modelDimension = _sourceDimension;
 
     // check for velocities in sources
     for (auto source : ss->sources())
@@ -279,8 +281,12 @@ void Configuration::setupSelfBefore()
     _numPropertySamples = ms->samplingOptions()->numPropertySamples();
 
     // retrieve symmetry dimensions
-    _modelDimension = max(ss->dimension(), ms->dimension());
+    _mediaDimension = ms->dimension();
     _gridDimension = ms->gridDimension();
+
+    // primary sources are not discretized onto the spatial grid, so the grid needs to support their
+    // symmetry only if the radiation field is being stored; otherwise the media symmetry suffices
+    _modelDimension = _hasRadiationField ? max(_sourceDimension, _mediaDimension) : _mediaDimension;
     if (_modelDimension > _gridDimension)
         throw FATALERROR("The grid symmetry (" + std::to_string(_gridDimension)
                          + "D) does not support the model symmetry (" + std::to_string(_modelDimension) + "D)");
@@ -437,22 +443,24 @@ void Configuration::setupSelfAfter()
 
     // --- log model symmetries ---
 
-    // if there are no media, simply log the source model symmetry
-    // if there are media, compare the model symmetry to the grid symmetry
-    // (the case where the grid has insufficient dimension causes a fatal error in setupSelfBefore)
-    if (!_hasMedium)
+    log->info("  Source symmetry: " + std::to_string(_sourceDimension) + "D");
+    if (_hasMedium)
     {
-        log->info("  Model symmetry: " + std::to_string(_modelDimension) + "D");
-    }
-    else if (_modelDimension == _gridDimension)
-    {
-        log->info("  Model and grid symmetry: " + std::to_string(_modelDimension) + "D");
-    }
-    else
-    {
-        log->info("  Model symmetry: " + std::to_string(_modelDimension)
-                  + "D; Spatial grid symmetry: " + std::to_string(_gridDimension) + "D");
-        log->warning("  Selecting a grid with the model symmetry might be more efficient");
+        log->info("  Medium symmetry: " + std::to_string(_mediaDimension) + "D");
+        log->info("  Grid   symmetry: " + std::to_string(_gridDimension) + "D");
+
+        // the model symmetry required of the grid depends on whether the radiation field is stored
+        // (the case where the grid has insufficient dimension causes a fatal error in setupSelfBefore)
+        if (_sourceDimension > _modelDimension)
+        {
+            log->info("  Because the radiation field is not stored,"
+                      " the grid does not need to support the source symmetry");
+        }
+        if (_gridDimension > _modelDimension)
+        {
+            log->warning("  Selecting a grid with " + std::to_string(_modelDimension)
+                         + "D symmetry might be more efficient");
+        }
     }
 
     // --- log (and possibly adjust) photon cycle options ---

--- a/SKIRT/core/Configuration.hpp
+++ b/SKIRT/core/Configuration.hpp
@@ -68,15 +68,33 @@ public:
 
     // ----> symmetry
 
-    /** Returns the symmetry dimension of the input model, including sources and media, if present.
-        A value of 1 means spherical symmetry, 2 means axial symmetry and 3 means none of these
+    /** Returns the symmetry dimension of the primary sources configured in the source system. A
+        value of 1 means spherical symmetry, 2 means axial symmetry and 3 means none of these
         symmetries. */
-    int modelDimension() const { return _modelDimension; }
+    int sourceDimension() const { return _sourceDimension; }
 
-    /** Returns the symmetry dimension of the spatial grid, if present, or 0 if there is no spatial
-        grid (which can only happen if the simulation does not include any media). A value of 1
-        means spherical symmetry, 2 means axial symmetry and 3 means none of these symmetries. */
+    /** Returns the symmetry dimension of the transfer media configured in the medium system, or 0
+        if the simulation does not include any media. A value of 1 means spherical symmetry, 2 means
+        axial symmetry and 3 means none of these symmetries. */
+    int mediaDimension() const { return _mediaDimension; }
+
+    /** Returns the symmetry dimension of the spatial grid, or 0 if there is no spatial grid (which
+        can only happen if the simulation does not include any media). A value of 1 means spherical
+        symmetry, 2 means axial symmetry and 3 means none of these symmetries. */
     int gridDimension() const { return _gridDimension; }
+
+    /** Returns the minimum symmetry dimension required of the spatial grid for the model to be
+        simulated correctly, or, if the simulation does not include any media (so that there is no
+        spatial grid), the symmetry dimension of the primary sources.
+
+        Because primary sources are not discretized onto the spatial grid, the grid needs to support
+        their symmetry only if the radiation field is being stored (see hasRadiationField()), for
+        example because the simulation iterates over primary emission or includes secondary
+        emission. In that case, this function returns the maximum of the source and media dimension.
+        Otherwise, the grid merely needs to support the symmetry of the media, and this function
+        returns the media dimension. A value of 1 means spherical symmetry, 2 means axial symmetry
+        and 3 means none of these symmetries. */
+    int modelDimension() const { return _modelDimension; }
 
     // ----> cosmology
 
@@ -448,8 +466,10 @@ private:
     bool _emulationMode{false};
 
     // symmetry
-    int _modelDimension{0};
+    int _sourceDimension{0};
+    int _mediaDimension{0};
     int _gridDimension{0};
+    int _modelDimension{0};
 
     // cosmology
     double _redshift{0.};

--- a/SKIRT/core/CubicalBackgroundSource.hpp
+++ b/SKIRT/core/CubicalBackgroundSource.hpp
@@ -19,7 +19,7 @@ class CubicalBackgroundSource : public CenteredSource
 {
     ITEM_CONCRETE(CubicalBackgroundSource, CenteredSource,
                   "a cubical background source with an anisotropic inward radiation field")
-        ATTRIBUTE_TYPE_INSERT(CubicalBackgroundSource, "Dimension3")
+        ATTRIBUTE_TYPE_INSERT(CubicalBackgroundSource, "SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(edgeLength, "the edge length of the background cube")
         ATTRIBUTE_QUANTITY(edgeLength, "length")

--- a/SKIRT/core/Cylinder2DSpatialGrid.hpp
+++ b/SKIRT/core/Cylinder2DSpatialGrid.hpp
@@ -28,7 +28,7 @@ class Cylinder2DSpatialGrid : public CylinderSpatialGrid
 {
     ITEM_CONCRETE(Cylinder2DSpatialGrid, CylinderSpatialGrid,
                   "a 2D axisymmetric spatial grid in cylindrical coordinates")
-        ATTRIBUTE_TYPE_ALLOWED_IF(Cylinder2DSpatialGrid, "!Dimension3")
+        ATTRIBUTE_TYPE_ALLOWED_IF(Cylinder2DSpatialGrid, "!RequiredDimension3")
 
         PROPERTY_ITEM(meshRadial, Mesh, "the bin distribution in the radial direction")
         ATTRIBUTE_DEFAULT_VALUE(meshRadial, "LinMesh")

--- a/SKIRT/core/CylindricalClipGeometryDecorator.hpp
+++ b/SKIRT/core/CylindricalClipGeometryDecorator.hpp
@@ -17,7 +17,8 @@ class CylindricalClipGeometryDecorator : public ClipGeometryDecorator
 {
     ITEM_CONCRETE(CylindricalClipGeometryDecorator, ClipGeometryDecorator,
                   "a decorator that clips another geometry using a cylinder")
-        ATTRIBUTE_TYPE_INSERT(CylindricalClipGeometryDecorator, "Dimension2")
+        ATTRIBUTE_TYPE_INSERT(CylindricalClipGeometryDecorator,
+                              "InMedia:MediaDimension2,Dimension2;SourceDimension2,Dimension2")
 
         PROPERTY_DOUBLE(clipRadius, "the radius of the clipping cylinder")
         ATTRIBUTE_QUANTITY(clipRadius, "length")

--- a/SKIRT/core/CylindricalVectorField.hpp
+++ b/SKIRT/core/CylindricalVectorField.hpp
@@ -44,7 +44,7 @@
 class CylindricalVectorField : public VectorField
 {
     ITEM_CONCRETE(CylindricalVectorField, VectorField, "a vector field rotating clockwise around the z-axis")
-        ATTRIBUTE_TYPE_INSERT(CylindricalVectorField, "Dimension3")
+        ATTRIBUTE_TYPE_INSERT(CylindricalVectorField, "InMedia:MediaDimension3,Dimension3;SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(unityRadius, "the radius where the magnitude of the vectors is unity")
         ATTRIBUTE_QUANTITY(unityRadius, "length")

--- a/SKIRT/core/FilePolarizedPointSource.hpp
+++ b/SKIRT/core/FilePolarizedPointSource.hpp
@@ -156,7 +156,7 @@ class FilePolarizedPointSource : public Source, public VelocityInterface
 {
     ITEM_CONCRETE(FilePolarizedPointSource, Source, "a primary point source with a polarized spectrum read from file")
         ATTRIBUTE_TYPE_DISPLAYED_IF(FilePolarizedPointSource, "Level2")
-        ATTRIBUTE_TYPE_INSERT(FilePolarizedPointSource, "Dimension2,ContSED")
+        ATTRIBUTE_TYPE_INSERT(FilePolarizedPointSource, "SourceDimension2,Dimension2,ContSED")
 
         PROPERTY_STRING(filename, "the name of the stored table file listing the Stokes vector components")
 
@@ -166,12 +166,12 @@ class FilePolarizedPointSource : public Source, public VelocityInterface
         PROPERTY_DOUBLE(positionX, "the position of the point source, x component")
         ATTRIBUTE_QUANTITY(positionX, "length")
         ATTRIBUTE_DEFAULT_VALUE(positionX, "0")
-        ATTRIBUTE_INSERT(positionX, "positionX:Dimension3")
+        ATTRIBUTE_INSERT(positionX, "positionX:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(positionY, "the position of the point source, y component")
         ATTRIBUTE_QUANTITY(positionY, "length")
         ATTRIBUTE_DEFAULT_VALUE(positionY, "0")
-        ATTRIBUTE_INSERT(positionY, "positionY:Dimension3")
+        ATTRIBUTE_INSERT(positionY, "positionY:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(positionZ, "the position of the point source, z component")
         ATTRIBUTE_QUANTITY(positionZ, "length")
@@ -180,12 +180,12 @@ class FilePolarizedPointSource : public Source, public VelocityInterface
         PROPERTY_DOUBLE(symmetryX, "the direction of the positive symmetry axis, x component")
         ATTRIBUTE_QUANTITY(symmetryX, "length")
         ATTRIBUTE_DEFAULT_VALUE(symmetryX, "0")
-        ATTRIBUTE_INSERT(symmetryX, "symmetryX:Dimension3")
+        ATTRIBUTE_INSERT(symmetryX, "symmetryX:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(symmetryY, "the direction of the positive symmetry axis, y component")
         ATTRIBUTE_QUANTITY(symmetryY, "length")
         ATTRIBUTE_DEFAULT_VALUE(symmetryY, "0")
-        ATTRIBUTE_INSERT(symmetryY, "symmetryY:Dimension3")
+        ATTRIBUTE_INSERT(symmetryY, "symmetryY:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(symmetryZ, "the direction of the positive symmetry axis, z component")
         ATTRIBUTE_QUANTITY(symmetryZ, "length")
@@ -197,7 +197,7 @@ class FilePolarizedPointSource : public Source, public VelocityInterface
         ATTRIBUTE_MAX_VALUE(velocityX, "100000 km/s]")
         ATTRIBUTE_DEFAULT_VALUE(velocityX, "0")
         ATTRIBUTE_RELEVANT_IF(velocityX, "Panchromatic")
-        ATTRIBUTE_INSERT(velocityX, "Panchromatic&velocityX:Dimension3")
+        ATTRIBUTE_INSERT(velocityX, "Panchromatic&velocityX:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(velocityY, "the bulk velocity of the point source, y component")
         ATTRIBUTE_QUANTITY(velocityY, "velocity")
@@ -205,7 +205,7 @@ class FilePolarizedPointSource : public Source, public VelocityInterface
         ATTRIBUTE_MAX_VALUE(velocityY, "100000 km/s]")
         ATTRIBUTE_DEFAULT_VALUE(velocityY, "0")
         ATTRIBUTE_RELEVANT_IF(velocityY, "Panchromatic")
-        ATTRIBUTE_INSERT(velocityY, "Panchromatic&velocityY:Dimension3")
+        ATTRIBUTE_INSERT(velocityY, "Panchromatic&velocityY:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(velocityZ, "the bulk velocity of the point source, z component")
         ATTRIBUTE_QUANTITY(velocityZ, "velocity")

--- a/SKIRT/core/GenGeometry.hpp
+++ b/SKIRT/core/GenGeometry.hpp
@@ -15,7 +15,7 @@
 class GenGeometry : public Geometry
 {
     ITEM_ABSTRACT(GenGeometry, Geometry, "a geometry without a specific symmetry")
-        ATTRIBUTE_TYPE_INSERT(GenGeometry, "Dimension3")
+        ATTRIBUTE_TYPE_INSERT(GenGeometry, "InMedia:MediaDimension3,Dimension3;SourceDimension3,Dimension3")
     ITEM_END()
 
     //======================== Other Functions =======================

--- a/SKIRT/core/HollowRadialVectorField.hpp
+++ b/SKIRT/core/HollowRadialVectorField.hpp
@@ -34,7 +34,7 @@ class HollowRadialVectorField : public VectorField
 {
     ITEM_CONCRETE(HollowRadialVectorField, VectorField,
                   "a vector field pointing away from the origin with a central cavity")
-        ATTRIBUTE_TYPE_INSERT(HollowRadialVectorField, "Dimension3")
+        ATTRIBUTE_TYPE_INSERT(HollowRadialVectorField, "InMedia:MediaDimension3,Dimension3;SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(zeroRadius, "the radius within which the magnitude of the vectors is zero")
         ATTRIBUTE_QUANTITY(zeroRadius, "length")

--- a/SKIRT/core/HubbleRadialVectorField.hpp
+++ b/SKIRT/core/HubbleRadialVectorField.hpp
@@ -26,7 +26,7 @@ class HubbleRadialVectorField : public VectorField
 {
     ITEM_CONCRETE(HubbleRadialVectorField, VectorField,
                   "a Hubble flow pointing away from the origin with a constant acceleration and decelaration")
-        ATTRIBUTE_TYPE_INSERT(HubbleRadialVectorField, "Dimension3")
+        ATTRIBUTE_TYPE_INSERT(HubbleRadialVectorField, "InMedia:MediaDimension3,Dimension3;SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(turnoverRadius, "the turnover radius marking the transition from acceleration to decelaration")
         ATTRIBUTE_QUANTITY(turnoverRadius, "length")

--- a/SKIRT/core/ImportedMedium.hpp
+++ b/SKIRT/core/ImportedMedium.hpp
@@ -22,7 +22,7 @@ class Snapshot;
 class ImportedMedium : public Medium, public SiteListInterface
 {
     ITEM_ABSTRACT(ImportedMedium, Medium, "a transfer medium imported from snapshot data")
-        ATTRIBUTE_TYPE_INSERT(ImportedMedium, "Dimension3,SiteListInterface")
+        ATTRIBUTE_TYPE_INSERT(ImportedMedium, "MediaDimension3,Dimension3,SiteListInterface")
 
         PROPERTY_STRING(filename, "the name of the file to be imported")
 

--- a/SKIRT/core/ImportedSource.hpp
+++ b/SKIRT/core/ImportedSource.hpp
@@ -70,7 +70,7 @@ class Snapshot;
 class ImportedSource : public Source
 {
     ITEM_ABSTRACT(ImportedSource, Source, "a primary source imported from snapshot data")
-        ATTRIBUTE_TYPE_INSERT(ImportedSource, "Dimension3")
+        ATTRIBUTE_TYPE_INSERT(ImportedSource, "SourceDimension3,Dimension3")
 
         PROPERTY_STRING(filename, "the name of the file to be imported")
 

--- a/SKIRT/core/MediumSystem.hpp
+++ b/SKIRT/core/MediumSystem.hpp
@@ -100,6 +100,7 @@ class MediumSystem : public SimulationItem
 {
     ITEM_CONCRETE(MediumSystem, SimulationItem, "a medium system")
         ATTRIBUTE_TYPE_ALLOWED_IF(MediumSystem, "!NoMedium")
+        ATTRIBUTE_TYPE_INSERT(MediumSystem, "InMedia")
 
         PROPERTY_ITEM(photonPacketOptions, PhotonPacketOptions, "the photon packet options")
         ATTRIBUTE_DEFAULT_VALUE(photonPacketOptions, "PhotonPacketOptions")
@@ -136,9 +137,27 @@ class MediumSystem : public SimulationItem
         PROPERTY_ITEM(samplingOptions, SamplingOptions, "the spatial grid sampling options")
         ATTRIBUTE_DEFAULT_VALUE(samplingOptions, "SamplingOptions")
 
+        // Primary sources are not discretized onto the spatial grid, so the grid is required to support
+        // their symmetry only if the radiation field is actually being stored (see RadiationFieldOptions
+        // and the "RadiationField" name inserted from simulationMode/iteratePrimaryEmission/
+        // storeRadiationField); otherwise the grid only needs to support the media symmetry. To express
+        // this, sources and media insert their "DimensionN" contributions as before (for consumers that
+        // care about the true combined model symmetry, e.g. instrument/cut-plane forms), but ALSO,
+        // depending on whether the current item is being configured before or after this MediumSystem
+        // has inserted "InMedia" (sources are always configured first; see MonteCarloSimulation), as
+        // either "SourceDimensionN" or "MediaDimensionN". By the time we get here, both are complete, so
+        // we can derive "RequiredDimensionN" -- the dimension actually required of the grid -- as the
+        // media dimension, or the combined dimension when the radiation field is stored. The spatial
+        // grid classes and this class' own "grid" default value below are keyed off "RequiredDimensionN"
+        // rather than "DimensionN" so that the schema mirrors the more liberal rule enforced at runtime
+        // by Configuration::setupSelfBefore().
+        ATTRIBUTE_INSERT(samplingOptions, "MediaDimension3|(RadiationField&SourceDimension3):RequiredDimension3;"
+                                          "MediaDimension2|(RadiationField&SourceDimension2):RequiredDimension2")
+
         PROPERTY_ITEM(grid, SpatialGrid, "the spatial grid")
-        ATTRIBUTE_DEFAULT_VALUE(grid,
-                                "Dimension3:PolicyTreeSpatialGrid;Dimension2:Cylinder2DSpatialGrid;Sphere1DSpatialGrid")
+        ATTRIBUTE_DEFAULT_VALUE(
+            grid,
+            "RequiredDimension3:PolicyTreeSpatialGrid;RequiredDimension2:Cylinder2DSpatialGrid;Sphere1DSpatialGrid")
 
     ITEM_END()
 

--- a/SKIRT/core/OffsetGeometryDecorator.hpp
+++ b/SKIRT/core/OffsetGeometryDecorator.hpp
@@ -29,17 +29,17 @@ class OffsetGeometryDecorator : public Geometry
         PROPERTY_DOUBLE(offsetX, "the offset in the x direction")
         ATTRIBUTE_QUANTITY(offsetX, "length")
         ATTRIBUTE_DEFAULT_VALUE(offsetX, "0")
-        ATTRIBUTE_INSERT(offsetX, "offsetX:Dimension3")
+        ATTRIBUTE_INSERT(offsetX, "InMedia&offsetX:MediaDimension3,Dimension3;offsetX:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(offsetY, "the offset in the y direction")
         ATTRIBUTE_QUANTITY(offsetY, "length")
         ATTRIBUTE_DEFAULT_VALUE(offsetY, "0")
-        ATTRIBUTE_INSERT(offsetY, "offsetY:Dimension3")
+        ATTRIBUTE_INSERT(offsetY, "InMedia&offsetY:MediaDimension3,Dimension3;offsetY:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(offsetZ, "the offset in the z direction")
         ATTRIBUTE_QUANTITY(offsetZ, "length")
         ATTRIBUTE_DEFAULT_VALUE(offsetZ, "0")
-        ATTRIBUTE_INSERT(offsetZ, "offsetZ:Dimension2")
+        ATTRIBUTE_INSERT(offsetZ, "InMedia&offsetZ:MediaDimension2,Dimension2;offsetZ:SourceDimension2,Dimension2")
 
     ITEM_END()
 

--- a/SKIRT/core/OffsetVectorFieldDecorator.hpp
+++ b/SKIRT/core/OffsetVectorFieldDecorator.hpp
@@ -29,17 +29,17 @@ class OffsetVectorFieldDecorator : public VectorField
         PROPERTY_DOUBLE(offsetX, "the offset in the x direction")
         ATTRIBUTE_QUANTITY(offsetX, "length")
         ATTRIBUTE_DEFAULT_VALUE(offsetX, "0")
-        ATTRIBUTE_INSERT(offsetX, "offsetX:Dimension3")
+        ATTRIBUTE_INSERT(offsetX, "InMedia&offsetX:MediaDimension3,Dimension3;offsetX:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(offsetY, "the offset in the y direction")
         ATTRIBUTE_QUANTITY(offsetY, "length")
         ATTRIBUTE_DEFAULT_VALUE(offsetY, "0")
-        ATTRIBUTE_INSERT(offsetY, "offsetY:Dimension3")
+        ATTRIBUTE_INSERT(offsetY, "InMedia&offsetY:MediaDimension3,Dimension3;offsetY:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(offsetZ, "the offset in the z direction")
         ATTRIBUTE_QUANTITY(offsetZ, "length")
         ATTRIBUTE_DEFAULT_VALUE(offsetZ, "0")
-        ATTRIBUTE_INSERT(offsetZ, "offsetZ:Dimension2")
+        ATTRIBUTE_INSERT(offsetZ, "InMedia&offsetZ:MediaDimension2,Dimension2;offsetZ:SourceDimension2,Dimension2")
 
     ITEM_END()
 

--- a/SKIRT/core/PointSource.hpp
+++ b/SKIRT/core/PointSource.hpp
@@ -24,17 +24,17 @@ class PointSource : public SpecialtySource
         PROPERTY_DOUBLE(positionX, "the position of the point source, x component")
         ATTRIBUTE_QUANTITY(positionX, "length")
         ATTRIBUTE_DEFAULT_VALUE(positionX, "0")
-        ATTRIBUTE_INSERT(positionX, "positionX:Dimension3")
+        ATTRIBUTE_INSERT(positionX, "positionX:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(positionY, "the position of the point source, y component")
         ATTRIBUTE_QUANTITY(positionY, "length")
         ATTRIBUTE_DEFAULT_VALUE(positionY, "0")
-        ATTRIBUTE_INSERT(positionY, "positionY:Dimension3")
+        ATTRIBUTE_INSERT(positionY, "positionY:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(positionZ, "the position of the point source, z component")
         ATTRIBUTE_QUANTITY(positionZ, "length")
         ATTRIBUTE_DEFAULT_VALUE(positionZ, "0")
-        ATTRIBUTE_INSERT(positionZ, "positionZ:Dimension2")
+        ATTRIBUTE_INSERT(positionZ, "positionZ:SourceDimension2,Dimension2")
 
         PROPERTY_ITEM(angularDistribution, AngularDistribution, "the angular luminosity distribution of the emission")
         ATTRIBUTE_DEFAULT_VALUE(angularDistribution, "IsotropicAngularDistribution")

--- a/SKIRT/core/RadialVectorField.hpp
+++ b/SKIRT/core/RadialVectorField.hpp
@@ -39,7 +39,7 @@
 class RadialVectorField : public VectorField
 {
     ITEM_CONCRETE(RadialVectorField, VectorField, "a vector field pointing away from the origin")
-        ATTRIBUTE_TYPE_INSERT(RadialVectorField, "Dimension3")
+        ATTRIBUTE_TYPE_INSERT(RadialVectorField, "InMedia:MediaDimension3,Dimension3;SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(unityRadius, "the radius where the magnitude of the vectors is unity")
         ATTRIBUTE_QUANTITY(unityRadius, "length")

--- a/SKIRT/core/RotateVectorFieldDecorator.hpp
+++ b/SKIRT/core/RotateVectorFieldDecorator.hpp
@@ -58,7 +58,8 @@
 class RotateVectorFieldDecorator : public VectorField
 {
     ITEM_CONCRETE(RotateVectorFieldDecorator, VectorField, "a decorator that adds a rotation to any vector field")
-        ATTRIBUTE_TYPE_INSERT(RotateVectorFieldDecorator, "Dimension3")
+        ATTRIBUTE_TYPE_INSERT(RotateVectorFieldDecorator,
+                              "InMedia:MediaDimension3,Dimension3;SourceDimension3,Dimension3")
 
         PROPERTY_ITEM(vectorField, VectorField, "the vector field to be rotated")
 

--- a/SKIRT/core/SineSquarePolarizationProfile.hpp
+++ b/SKIRT/core/SineSquarePolarizationProfile.hpp
@@ -36,17 +36,17 @@ class SineSquarePolarizationProfile : public PolarizationProfile
 {
     ITEM_CONCRETE(SineSquarePolarizationProfile, PolarizationProfile,
                   "an axysimmetric sine-square polarization emission profile")
-        ATTRIBUTE_TYPE_INSERT(SineSquarePolarizationProfile, "Dimension2")
+        ATTRIBUTE_TYPE_INSERT(SineSquarePolarizationProfile, "SourceDimension2,Dimension2")
 
         PROPERTY_DOUBLE(symmetryX, "the direction of the positive symmetry axis, x component")
         ATTRIBUTE_QUANTITY(symmetryX, "length")
         ATTRIBUTE_DEFAULT_VALUE(symmetryX, "0")
-        ATTRIBUTE_INSERT(symmetryX, "symmetryX:Dimension3")
+        ATTRIBUTE_INSERT(symmetryX, "symmetryX:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(symmetryY, "the direction of the positive symmetry axis, y component")
         ATTRIBUTE_QUANTITY(symmetryY, "length")
         ATTRIBUTE_DEFAULT_VALUE(symmetryY, "0")
-        ATTRIBUTE_INSERT(symmetryY, "symmetryY:Dimension3")
+        ATTRIBUTE_INSERT(symmetryY, "symmetryY:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(symmetryZ, "the direction of the positive symmetry axis, z component")
         ATTRIBUTE_QUANTITY(symmetryZ, "length")

--- a/SKIRT/core/SpecialtySource.hpp
+++ b/SKIRT/core/SpecialtySource.hpp
@@ -31,7 +31,7 @@ class SpecialtySource : public NormalizedSource, public VelocityInterface
         ATTRIBUTE_DEFAULT_VALUE(velocityX, "0")
         ATTRIBUTE_RELEVANT_IF(velocityX, "Panchromatic")
         ATTRIBUTE_DISPLAYED_IF(velocityX, "Level2")
-        ATTRIBUTE_INSERT(velocityX, "Panchromatic&velocityX:Dimension3")
+        ATTRIBUTE_INSERT(velocityX, "Panchromatic&velocityX:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(velocityY, "the bulk velocity of the source, y component")
         ATTRIBUTE_QUANTITY(velocityY, "velocity")
@@ -40,7 +40,7 @@ class SpecialtySource : public NormalizedSource, public VelocityInterface
         ATTRIBUTE_DEFAULT_VALUE(velocityY, "0")
         ATTRIBUTE_RELEVANT_IF(velocityY, "Panchromatic")
         ATTRIBUTE_DISPLAYED_IF(velocityY, "Level2")
-        ATTRIBUTE_INSERT(velocityY, "Panchromatic&velocityY:Dimension3")
+        ATTRIBUTE_INSERT(velocityY, "Panchromatic&velocityY:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(velocityZ, "the bulk velocity of the source, z component")
         ATTRIBUTE_QUANTITY(velocityZ, "velocity")
@@ -49,7 +49,7 @@ class SpecialtySource : public NormalizedSource, public VelocityInterface
         ATTRIBUTE_DEFAULT_VALUE(velocityZ, "0")
         ATTRIBUTE_RELEVANT_IF(velocityZ, "Panchromatic")
         ATTRIBUTE_DISPLAYED_IF(velocityZ, "Level2")
-        ATTRIBUTE_INSERT(velocityZ, "Panchromatic&velocityZ:Dimension2")
+        ATTRIBUTE_INSERT(velocityZ, "Panchromatic&velocityZ:SourceDimension2,Dimension2")
 
     ITEM_END()
 

--- a/SKIRT/core/Sphere1DSpatialGrid.hpp
+++ b/SKIRT/core/Sphere1DSpatialGrid.hpp
@@ -21,7 +21,7 @@ class Random;
 class Sphere1DSpatialGrid : public SphereSpatialGrid
 {
     ITEM_CONCRETE(Sphere1DSpatialGrid, SphereSpatialGrid, "a 1D spherically symmetric spatial grid")
-        ATTRIBUTE_TYPE_ALLOWED_IF(Sphere1DSpatialGrid, "!Dimension2&!Dimension3")
+        ATTRIBUTE_TYPE_ALLOWED_IF(Sphere1DSpatialGrid, "!RequiredDimension2&!RequiredDimension3")
 
         PROPERTY_ITEM(meshRadial, Mesh, "the bin distribution in the radial direction")
         ATTRIBUTE_DEFAULT_VALUE(meshRadial, "LinMesh")

--- a/SKIRT/core/Sphere2DSpatialGrid.hpp
+++ b/SKIRT/core/Sphere2DSpatialGrid.hpp
@@ -32,7 +32,7 @@ class Random;
 class Sphere2DSpatialGrid : public SphereSpatialGrid
 {
     ITEM_CONCRETE(Sphere2DSpatialGrid, SphereSpatialGrid, "a 2D axisymmetric spatial grid in spherical coordinates")
-        ATTRIBUTE_TYPE_ALLOWED_IF(Sphere2DSpatialGrid, "!Dimension3")
+        ATTRIBUTE_TYPE_ALLOWED_IF(Sphere2DSpatialGrid, "!RequiredDimension3")
         ATTRIBUTE_TYPE_DISPLAYED_IF(Sphere2DSpatialGrid, "Level2")
 
         PROPERTY_ITEM(meshRadial, Mesh, "the bin distribution in the radial direction")

--- a/SKIRT/core/SphericalClipGeometryDecorator.hpp
+++ b/SKIRT/core/SphericalClipGeometryDecorator.hpp
@@ -27,19 +27,19 @@ class SphericalClipGeometryDecorator : public ClipGeometryDecorator
         ATTRIBUTE_QUANTITY(centerX, "length")
         ATTRIBUTE_DEFAULT_VALUE(centerX, "0")
         ATTRIBUTE_DISPLAYED_IF(centerX, "Level2")
-        ATTRIBUTE_INSERT(centerX, "centerX:Dimension3")
+        ATTRIBUTE_INSERT(centerX, "InMedia&centerX:MediaDimension3,Dimension3;centerX:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(centerY, "the y coordinate of the sphere's center")
         ATTRIBUTE_QUANTITY(centerY, "length")
         ATTRIBUTE_DEFAULT_VALUE(centerY, "0")
         ATTRIBUTE_DISPLAYED_IF(centerY, "Level2")
-        ATTRIBUTE_INSERT(centerY, "centerY:Dimension3")
+        ATTRIBUTE_INSERT(centerY, "InMedia&centerY:MediaDimension3,Dimension3;centerY:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(centerZ, "the z coordinate of the sphere's center")
         ATTRIBUTE_QUANTITY(centerZ, "length")
         ATTRIBUTE_DEFAULT_VALUE(centerZ, "0")
         ATTRIBUTE_DISPLAYED_IF(centerZ, "Level2")
-        ATTRIBUTE_INSERT(centerZ, "centerZ:Dimension2")
+        ATTRIBUTE_INSERT(centerZ, "InMedia&centerZ:MediaDimension2,Dimension2;centerZ:SourceDimension2,Dimension2")
 
     ITEM_END()
 

--- a/SKIRT/core/UnidirectionalVectorField.hpp
+++ b/SKIRT/core/UnidirectionalVectorField.hpp
@@ -19,15 +19,15 @@ class UnidirectionalVectorField : public VectorField
 
         PROPERTY_DOUBLE(fieldX, "the field direction, x component")
         ATTRIBUTE_DEFAULT_VALUE(fieldX, "0")
-        ATTRIBUTE_INSERT(fieldX, "fieldX:Dimension3")
+        ATTRIBUTE_INSERT(fieldX, "InMedia&fieldX:MediaDimension3,Dimension3;fieldX:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(fieldY, "the field direction, y component")
         ATTRIBUTE_DEFAULT_VALUE(fieldY, "0")
-        ATTRIBUTE_INSERT(fieldY, "fieldY:Dimension3")
+        ATTRIBUTE_INSERT(fieldY, "InMedia&fieldY:MediaDimension3,Dimension3;fieldY:SourceDimension3,Dimension3")
 
         PROPERTY_DOUBLE(fieldZ, "the field direction, z component")
         ATTRIBUTE_DEFAULT_VALUE(fieldZ, "1")
-        ATTRIBUTE_INSERT(fieldZ, "fieldZ:Dimension2")
+        ATTRIBUTE_INSERT(fieldZ, "InMedia&fieldZ:MediaDimension2,Dimension2;fieldZ:SourceDimension2,Dimension2")
 
     ITEM_END()
 


### PR DESCRIPTION
**Description**

Primary sources are not discretized onto the spatial grid — only the media are. The spatial grid's dimension has always been required to support `max(source dimension, media dimension)`, but that's stricter than necessary: the source's symmetry only matters for the grid when the radiation field is actually being stored on it (e.g. because of primary/secondary iteration, secondary emission, or an explicit `storeRadiationField` request). This PR relaxes the requirement so the grid only needs to support the media's dimension in the common case where the radiation field isn't stored, letting users pair a more complex/asymmetric source with a lower-dimensional (more efficient) grid matched to a simpler medium.

Two layers needed the change:

1. **Runtime (`Configuration`)**: source dimension, medium dimension, and grid dimension are now logged individually, and model dimension is redefined as the dimension actually required of the grid — the medium dimension, or `max(source, media)` when the simulation stores the radiation field.

2. **SMILE schema layer**:  Sources and media now insert different `SourceDimensionN` or `MediaDimensionN` markers. Since `Geometry`/`VectorField` and their decorators are shared between sources and media, their dimension contribution marker is conditional on whether `MediumSystem` (which always follows `SourceSystem`) has already been parsed. The original `DimensionN` names are left untouched for the unrelated consumers (instruments and probes) that legitimately want the true combined source+media symmetry.

**Motivation**

Feature requested by @bertvdm

**Tests**

- Full local regression suite (`Functional9`) passes.
- Hand-built and actually ran four `.ski` files against the built `skirt` binary to exercise the new behavior end to end: a 3D source over a 1D medium/grid with no stored radiation field (now accepted, with the new log lines confirming the relaxed dimension in play), the same configuration but with the radiation field stored (still correctly rejected at parse time), a 3D medium with no stored field (still correctly rejected, confirming the relaxation is source-scoped only), and a 3D source over a 2D medium/grid (accepted).

**Guidelines**

Matches existing code style and doc-comment conventions.

**Context**

🤖 Generated with [Claude Code](https://claude.com/claude-code)