### PR TITLE
TextOutFile: avoid std::endl

### DIFF
--- a/SKIRT/core/TextOutFile.cpp
+++ b/SKIRT/core/TextOutFile.cpp
@@ -72,7 +72,7 @@ void TextOutFile::writeLine(string line)
 {
     if (_out.is_open())
     {
-        _out << line << std::endl;
+        _out << line << "\n";
     }
 }
 


### PR DESCRIPTION
**Description**
This replaces use of `std::endl` with a simple newline character.
This will **not** change behavior on non-unix platforms that use different newlines (see comment below).

**Motivation**
endl triggers a flush of the ostream buffer, resulting in many small writes which is quite inefficient. We noticed people running this on our cluster doing a lot of IO and tracked it down to this one line.

**Tests**
I'm told by the people runinng it that this improved overall performance.

**Context**
iostreams and text output in general is quite inefficient for managing numeric data at scale, so we'd probably recommend avoiding this altogether and replacing it with some binary storage format. However that's obviously a larger endeavor, so as a short-term fix this should provide some benefit.