### PR TITLE
Two fixes: property-sample divide by zero, and transition-table selection

### DIFF
--- a/SKIRT/core/DiffuseIonizedGasMix.cpp
+++ b/SKIRT/core/DiffuseIonizedGasMix.cpp
@@ -178,8 +178,7 @@ void DiffuseIonizedGasMix::setupSelfBefore()
         _transitionTemperatureTable.open(this, "DiffuseIonizedGas5Bin_Transition_multiZ_Temperature",
                                          "Z(1),n_H(1/m3),logU(1),logR2(1),logR3(1),logR4(1),logR5(1)", "logT(K)", true);
 
-        // Cache the transition table's upper logU edge, where it meets the standard table,
-        // for the per-cell selectTable/getBlendingWeight hot path.
+        // Cache the transition table's upper logU edge, where it meets the standard table.
         Array logUAxis;
         _transitionTemperatureTable.axisArray<2>(logUAxis);
         _transitionLogUMax = logUAxis[logUAxis.size() - 1];

--- a/SKIRT/core/DiffuseIonizedGasMix.cpp
+++ b/SKIRT/core/DiffuseIonizedGasMix.cpp
@@ -178,10 +178,10 @@ void DiffuseIonizedGasMix::setupSelfBefore()
         _transitionTemperatureTable.open(this, "DiffuseIonizedGas5Bin_Transition_multiZ_Temperature",
                                          "Z(1),n_H(1/m3),logU(1),logR2(1),logR3(1),logR4(1),logR5(1)", "logT(K)", true);
 
-        // Cache the transition table's logU axis edges for the per-cell selectTable/getBlendingWeight hot path.
+        // Cache the transition table's upper logU edge, where it meets the standard table,
+        // for the per-cell selectTable/getBlendingWeight hot path.
         Array logUAxis;
         _transitionTemperatureTable.axisArray<2>(logUAxis);
-        _transitionLogUMin = logUAxis[0];
         _transitionLogUMax = logUAxis[logUAxis.size() - 1];
     }
 
@@ -1094,18 +1094,16 @@ DisjointWavelengthGrid* DiffuseIonizedGasMix::emissionWavelengthGrid() const
 
 DiffuseIonizedGasMix::TableSelection DiffuseIonizedGasMix::selectTable(double logU) const
 {
-    // Transition-table logU edges were cached in setupSelfBefore.
+    // The transition table's upper logU edge was cached in setupSelfBefore.
     const double blendWidth = transitionBlendWidth();
 
-    // Core transition region
-    if (logU >= _transitionLogUMin + blendWidth && logU <= _transitionLogUMax - blendWidth)
-        return TableSelection::Transition;
-
-    // Far from transition range - use standard
-    if (logU < _transitionLogUMin - blendWidth || logU > _transitionLogUMax + blendWidth)
-        return TableSelection::Standard;
-
-    // In blending region
+    // The tables share data only at their common edge, _transitionLogUMax, so blend
+    // there and nowhere else. Below it Transition applies and clamps at its own
+    // floor; Standard would clamp to the shared edge, handing near-neutral gas the
+    // opacity of gas at the ionised-neutral boundary. The opacity path is not gated
+    // by _minLogUEmit.
+    if (logU <= _transitionLogUMax - blendWidth) return TableSelection::Transition;
+    if (logU > _transitionLogUMax + blendWidth) return TableSelection::Standard;
     return TableSelection::Blend;
 }
 
@@ -1114,27 +1112,16 @@ DiffuseIonizedGasMix::TableSelection DiffuseIonizedGasMix::selectTable(double lo
 double DiffuseIonizedGasMix::getBlendingWeight(double logU) const
 {
     // Returns weight for transition table (0 = standard only, 1 = transition only).
-    // Transition-table logU edges were cached in setupSelfBefore.
+    // The transition table's upper logU edge was cached in setupSelfBefore.
     const double blendWidth = transitionBlendWidth();
 
-    // Lower blending region: transitioning into transition table
-    if (logU >= _transitionLogUMin - blendWidth && logU < _transitionLogUMin + blendWidth)
-    {
-        double weight = (logU - (_transitionLogUMin - blendWidth)) / (2.0 * blendWidth);
-        return std::max(0.0, std::min(1.0, weight));
-    }
-
-    // Upper blending region: transitioning back to standard
+    // Blend only at the tables' shared edge; see selectTable().
     if (logU > _transitionLogUMax - blendWidth && logU <= _transitionLogUMax + blendWidth)
     {
         double weight = ((_transitionLogUMax + blendWidth) - logU) / (2.0 * blendWidth);
         return std::max(0.0, std::min(1.0, weight));
     }
-
-    // Core transition region
-    if (logU >= _transitionLogUMin + blendWidth && logU <= _transitionLogUMax - blendWidth) return 1.0;
-
-    // Standard region
+    if (logU <= _transitionLogUMax - blendWidth) return 1.0;
     return 0.0;
 }
 

--- a/SKIRT/core/DiffuseIonizedGasMix.hpp
+++ b/SKIRT/core/DiffuseIonizedGasMix.hpp
@@ -509,8 +509,7 @@ private:
     double _maxNH_m3 = 0.;
 
     // Cached upper edge of the transition table's logU axis, where it meets the standard
-    // table, set in setupSelfBefore from _transitionTemperatureTable.axisArray<2>().
-    // Used in the per-cell table-selection and blending-weight hot path.
+    // table, set in setupSelfBefore. Used when selecting between the two tables.
     double _transitionLogUMax = 0.;
 
     // Custom state variable indices

--- a/SKIRT/core/DiffuseIonizedGasMix.hpp
+++ b/SKIRT/core/DiffuseIonizedGasMix.hpp
@@ -508,10 +508,9 @@ private:
     // Cached density ceiling in m^-3 (0 = disabled), set in setupSelfBefore from maxHydrogenDensity
     double _maxNH_m3 = 0.;
 
-    // Cached logU edges of the transition table's logU axis, set in setupSelfBefore
-    // from _transitionTemperatureTable.axisArray<2>(). Used in the per-cell table-selection
-    // and blending-weight hot path.
-    double _transitionLogUMin = 0.;
+    // Cached upper edge of the transition table's logU axis, where it meets the standard
+    // table, set in setupSelfBefore from _transitionTemperatureTable.axisArray<2>().
+    // Used in the per-cell table-selection and blending-weight hot path.
     double _transitionLogUMax = 0.;
 
     // Custom state variable indices

--- a/SKIRT/core/MediumSystem.cpp
+++ b/SKIRT/core/MediumSystem.cpp
@@ -174,7 +174,10 @@ namespace
                 _media[h]->parameters(_positions[n], sample);
                 params += _densities(h, n) * sample;
             }
-            params /= nsum;
+            if (nsum > 0.)
+                params /= nsum;
+            else
+                params = 0.;
             return;
         }
     };


### PR DESCRIPTION
Two small, independent fixes found while post-processing cosmological
simulations. They are in separate commits and can be taken separately.

**`MediumSystem`: divide by zero in the property sampler.** `params /= nsum`
runs even when `nsum == 0`, which happens when all `numPropertySamples`
positions of a cell fall in empty space. NaN then enters the medium state,
where it is stored and written out by state probes. The fix returns zeros,
which is what an empty cell carries anyway.

**`DiffuseIonizedGasMix`: table selection below the transition range.** The
standard and transition tables share data only at their upper common edge.
`selectTable()` treated the transition table's lower edge as a second decision
point and returned `Standard` below it; `StoredTable` then clamps to the shared
edge, so gas that is nearly neutral is given the opacity of gas at the
ionised-neutral boundary. Selecting on the shared edge alone lets the
transition table clamp at its own floor, which is what it is there for, and the
cached lower edge is no longer needed. Line emission is gated at
`logU = -6.5` and does not change; the opacity path has no such gate, so that
is where results move.

Builds clean against `master` (Release, AppleClang). `clang-format` reports no
changes on the three files. Doxygen warnings are unchanged, 17 before and
after, on identical inputs.
